### PR TITLE
chore(workflows): use reusable pr-quality workflow

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,47 +1,13 @@
-# .github/workflows/pr-quality.yml
-# Solo-maintainer auto-approve: approves PRs from repo collaborators
-# so that required_approving_review_count >= 1 is satisfied without
-# manual review for trusted authors.
-#
-# SECURITY: This workflow uses pull_request_target which runs with base branch
-# permissions. NEVER add an actions/checkout step here -- that would allow code
-# from the PR to execute with write access to the repository.
-#
-# Bootstrap: The PR that introduces this workflow must be approved manually
-# (the workflow isn't on the base branch yet). All subsequent PRs auto-approve.
-
 name: PR Quality Gates
 
 on:
-    pull_request_target:
-        types: [opened, synchronize, reopened]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
 
 jobs:
-    auto-approve:
-        name: Auto-approve (collaborators)
-        runs-on: ubuntu-latest
-        permissions:
-            pull-requests: write
-
-        steps:
-            - name: Harden Runner
-              uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
-              with:
-                  egress-policy: audit
-
-            - name: Check author permission
-              id: check-permission
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-                  REPO: ${{ github.repository }}
-              run: |
-                  PERMISSION=$(gh api "repos/$REPO/collaborators/$PR_AUTHOR/permission" --jq '.permission' 2>/dev/null || echo "none")
-                  echo "permission=$PERMISSION" >> "$GITHUB_OUTPUT"
-
-            - name: Auto-approve PR
-              if: steps.check-permission.outputs.permission == 'admin' || steps.check-permission.outputs.permission == 'write'
-              env:
-                  PR_URL: ${{ github.event.pull_request.html_url }}
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: gh pr review --approve "$PR_URL"
+  pr-quality:
+    uses: netresearch/skill-repo-skill/.github/workflows/pr-quality.yml@main
+    permissions:
+      pull-requests: write


### PR DESCRIPTION
## Summary

- Replaces the local `.github/workflows/pr-quality.yml` (which directly pinned `step-security/harden-runner`) with a thin caller for the reusable workflow in [netresearch/skill-repo-skill](https://github.com/netresearch/skill-repo-skill/pull/56).
- Same runtime behavior: `pull_request_target` triggers auto-approve for collaborator PRs.

## Why

All skill repos should delegate CI to reusable workflows so action version bumps happen in one place. Previously each skill repo maintained its own copy and Dependabot created a separate PR per repo for every `harden-runner` bump.

## Test plan

- [ ] Workflow parses on GitHub (will show in checks)
- [ ] This PR itself must be approved manually (bootstrap — the new workflow is not yet on `main`)
- [ ] A subsequent PR from a collaborator should get auto-approved via the reusable workflow