### PR TITLE
chore(pr-quality): restore SECURITY note on pull_request_target caller

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,3 +1,9 @@
+# SECURITY: This caller runs on `pull_request_target`, so the job receives
+# base-branch permissions (including `pull-requests: write`). Do NOT add an
+# `actions/checkout` of the PR head or otherwise execute PR-controlled code
+# here — that would escalate untrusted code to write scope. All logic lives
+# in the reusable workflow; this file must stay a thin caller.
+
 name: PR Quality Gates
 
 on:


### PR DESCRIPTION
## Summary

Restores the SECURITY warning block on `.github/workflows/pr-quality.yml`. The block was dropped when migrating to the reusable workflow caller, but review feedback correctly pointed out that the caller file is where future editors are most likely to add steps — so the warning belongs there in addition to the reusable workflow.

No runtime behavior changes.

## Test plan

- [ ] Workflow still parses
- [ ] No change to auto-approve behavior