### PR TITLE
feat(security-audit): document opengrep as OSS Semgrep alternative

### DIFF
--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -69,7 +69,7 @@ $hash = password_hash($password, PASSWORD_ARGON2ID);
 $token = bin2hex(random_bytes(32));
 ```
 
-For scanning tools (semgrep, trivy, gitleaks), see `references/automated-scanning.md`.
+For scanning tools (semgrep/opengrep, trivy, gitleaks), see `references/automated-scanning.md`.
 
 ## Security Checklist
 

--- a/skills/security-audit/checkpoints.yaml
+++ b/skills/security-audit/checkpoints.yaml
@@ -479,13 +479,13 @@ mechanical:
     severity: warning
     desc: "Hardcoded relative path traversal patterns should be avoided in PHP source"
 
-  # === SEMGREP IN CI ===
+  # === SEMGREP / OPENGREP IN CI ===
   - id: SA-SAST-02
     type: regex
     target: .github/workflows/*.yml
-    pattern: "semgrep"
+    pattern: "semgrep|opengrep"
     severity: info
-    desc: "CI should include semgrep for SAST scanning"
+    desc: "CI should include semgrep or opengrep for SAST scanning"
 
   # === SECURITY POLICY ===
   - id: SA-SP-01

--- a/skills/security-audit/references/automated-scanning.md
+++ b/skills/security-audit/references/automated-scanning.md
@@ -1,12 +1,12 @@
 # Automated Scanning Tools Reference
 
-Configuration, custom rules, CI integration, and best practices for semgrep, trivy, and gitleaks.
+Configuration, custom rules, CI integration, and best practices for semgrep / opengrep, trivy, and gitleaks.
 
 ## Tool Comparison
 
 | Tool | Purpose | Scans | Best For |
 |------|---------|-------|----------|
-| **semgrep** | SAST (Static Application Security Testing) | Source code patterns | Injection, XSS, insecure crypto, code quality |
+| **semgrep** / **opengrep** | SAST (Static Application Security Testing) | Source code patterns | Injection, XSS, insecure crypto, code quality |
 | **trivy** | Vulnerability scanner | Dependencies, containers, IaC | Known CVEs, outdated packages, misconfigurations |
 | **gitleaks** | Secret detection | Git history, staged files | API keys, passwords, tokens, private keys |
 
@@ -14,7 +14,9 @@ Configuration, custom rules, CI integration, and best practices for semgrep, tri
 
 1. **gitleaks** -- fast, catches critical secrets immediately
 2. **trivy** -- scans dependencies and infrastructure
-3. **semgrep** -- deep code analysis, takes longest
+3. **semgrep** / **opengrep** -- deep code analysis, takes longest
+
+> **semgrep vs opengrep:** [Opengrep](https://github.com/opengrep/opengrep) is a fully open-source (LGPL-2.1) fork of Semgrep, created after Semgrep relicensed the community rule registry to CC-BY-NC-SA. The CLI is a drop-in replacement — rule syntax, `.semgrepignore`, `nosemgrep:` comments, and config files all work identically. See the [opengrep subsection](#opengrep--fully-oss-drop-in-replacement) below for when to prefer it.
 
 ---
 
@@ -102,6 +104,45 @@ node_modules/
   env:
     SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 ```
+
+### opengrep — fully-OSS drop-in replacement
+
+[Opengrep](https://github.com/opengrep/opengrep) is an LGPL-2.1 fork of Semgrep maintained by a coalition of security vendors. Reasons to prefer it:
+
+- **No license friction.** Semgrep's Community rule registry is CC-BY-NC-SA (non-commercial). Opengrep rules are freely usable in any setting, including commercial audits and derived rulesets.
+- **Fully open engine.** Semgrep's Pro engine (interfile / taint tracking beyond the OSS baseline) is proprietary. Opengrep keeps the complete analysis engine open.
+- **CLI-compatible.** Same rule syntax, same config files (`.semgrep.yml`, `.semgrepignore`), same `nosemgrep:` ignore comments. Existing rules and CI pipelines port over by swapping the binary.
+
+Install via `coding_agent_cli_toolset`:
+
+```bash
+make install-opengrep   # downloads statically-linked binary to ~/.local/bin
+```
+
+Usage — identical to semgrep:
+
+```bash
+opengrep scan --config auto --error .                 # community rules
+opengrep scan --config p/owasp-top-ten --sarif -o out.sarif .
+opengrep scan --config .semgrep.yml .                 # custom rules (same format)
+```
+
+CI integration (no official action yet — invoke the binary directly):
+
+```yaml
+- name: Opengrep SAST
+  run: |
+    curl -fsSL -o /usr/local/bin/opengrep \
+      https://github.com/opengrep/opengrep/releases/latest/download/opengrep_manylinux_x86
+    chmod +x /usr/local/bin/opengrep
+    opengrep scan --config auto --sarif --output opengrep.sarif --error .
+- name: Upload SARIF
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: opengrep.sarif
+```
+
+**When to stay on semgrep:** Semgrep Pro/AppSec Platform features (interfile taint tracking, managed registry, SCM integrations). **When to switch:** rule-authoring freedom, offline/air-gapped scanning, avoiding the Semgrep account requirement for `--config auto` against the Pro registry.
 
 ---
 

--- a/skills/security-audit/references/automated-scanning.md
+++ b/skills/security-audit/references/automated-scanning.md
@@ -122,19 +122,26 @@ make install-opengrep   # downloads statically-linked binary to ~/.local/bin
 Usage — identical to semgrep:
 
 ```bash
-opengrep scan --config auto --error .                 # community rules
-opengrep scan --config p/owasp-top-ten --sarif -o out.sarif .
-opengrep scan --config .semgrep.yml .                 # custom rules (same format)
+opengrep scan --config auto --error .                           # community rules
+opengrep scan --config p/owasp-top-ten --sarif --output out.sarif .
+opengrep scan --config .semgrep.yml .                           # custom rules (same format)
 ```
 
-CI integration (no official action yet — invoke the binary directly):
+CI integration (no official action yet — invoke the binary directly). Pin the version and verify the SHA256 to keep the pipeline reproducible and supply-chain safe:
 
 ```yaml
 - name: Opengrep SAST
+  env:
+    OPENGREP_VERSION: v1.19.0
+    # SHA256 of opengrep_manylinux_x86 at OPENGREP_VERSION
+    OPENGREP_SHA256: 1d69a41beb88e8e7917f26cc6a16c1edf298f31402807e6d1afbb5d8684c3590
   run: |
-    curl -fsSL -o /usr/local/bin/opengrep \
-      https://github.com/opengrep/opengrep/releases/latest/download/opengrep_manylinux_x86
-    chmod +x /usr/local/bin/opengrep
+    mkdir -p "$HOME/.local/bin"
+    curl -fsSL -o "$HOME/.local/bin/opengrep" \
+      "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86"
+    echo "${OPENGREP_SHA256}  $HOME/.local/bin/opengrep" | sha256sum -c -
+    chmod +x "$HOME/.local/bin/opengrep"
+    echo "$HOME/.local/bin" >> "$GITHUB_PATH"
     opengrep scan --config auto --sarif --output opengrep.sarif --error .
 - name: Upload SARIF
   uses: github/codeql-action/upload-sarif@v3

--- a/skills/security-audit/references/automated-scanning.md
+++ b/skills/security-audit/references/automated-scanning.md
@@ -16,7 +16,7 @@ Configuration, custom rules, CI integration, and best practices for semgrep / op
 2. **trivy** -- scans dependencies and infrastructure
 3. **semgrep** / **opengrep** -- deep code analysis, takes longest
 
-> **semgrep vs opengrep:** [Opengrep](https://github.com/opengrep/opengrep) is a fully open-source (LGPL-2.1) fork of Semgrep, created after Semgrep relicensed the community rule registry to CC-BY-NC-SA. The CLI is a drop-in replacement — rule syntax, `.semgrepignore`, `nosemgrep:` comments, and config files all work identically. See the [opengrep subsection](#opengrep--fully-oss-drop-in-replacement) below for when to prefer it.
+> **semgrep vs opengrep:** [Opengrep](https://github.com/opengrep/opengrep) is a fully open-source (LGPL-2.1) fork of Semgrep, created after Semgrep relicensed the community rule registry to CC-BY-NC-SA. The CLI is a drop-in replacement — rule syntax, `.semgrepignore`, `nosemgrep:` comments, and config files all work identically. See the [opengrep subsection](#opengrep-fully-oss-drop-in-replacement) below for when to prefer it.
 
 ---
 
@@ -105,7 +105,7 @@ node_modules/
     SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 ```
 
-### opengrep — fully-OSS drop-in replacement
+### opengrep: fully-OSS drop-in replacement
 
 [Opengrep](https://github.com/opengrep/opengrep) is an LGPL-2.1 fork of Semgrep maintained by a coalition of security vendors. Reasons to prefer it:
 


### PR DESCRIPTION
## Summary
Adds [opengrep](https://github.com/opengrep/opengrep) (LGPL-2.1 fork of Semgrep) as a documented drop-in SAST alternative alongside existing Semgrep guidance.

- [`SKILL.md`](./skills/security-audit/SKILL.md): one-line pointer in the automated-scanning summary and the Security Checklist line (stays under 500 words: 481)
- [`references/automated-scanning.md`](./skills/security-audit/references/automated-scanning.md): new **"opengrep — fully-OSS drop-in replacement"** subsection covering install, usage, CI snippet, and when-to-prefer guidance
- [`checkpoints.yaml`](./skills/security-audit/checkpoints.yaml): SA-SAST-02 regex now matches `semgrep|opengrep` in `.github/workflows/*.yml`
- [`evals/evals.json`](./skills/security-audit/evals/evals.json): adds `opengrep` to the SAST tool-use pattern for the php_security_audit eval

Rule syntax, `.semgrepignore`, `nosemgrep:` comments — all identical. Teams can migrate to avoid CC-BY-NC-SA registry rules and the proprietary Pro engine.

**Companion PR:** [`coding_agent_cli_toolset#feat/opengrep-catalog`](https://github.com/netresearch/coding_agent_cli_toolset/pull/new/feat/opengrep-catalog) — adds the `make install-opengrep` target referenced here.

## Test plan
- [x] `python3 scripts/validate_checkpoints.py` → 63 mechanical + 23 LLM review checkpoints valid
- [x] `python3 -c "import json; json.load(open('skills/security-audit/evals/evals.json'))"` → JSON valid
- [x] `wc -w skills/security-audit/SKILL.md` → 481 (under 500-word limit)