### PR TITLE
feat(references): add cloud and IaC security references (AWS, Azure, GCP, IaC)

### DIFF
--- a/skills/security-audit/references/aws-security.md
+++ b/skills/security-audit/references/aws-security.md
@@ -1,0 +1,660 @@
+# AWS Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for Amazon Web Services infrastructure. Covers IAM, S3, Lambda, Security Groups, KMS, CloudTrail, Secrets Manager, and RDS across Terraform, CloudFormation, and raw JSON/YAML configurations.
+
+## IAM: Overly Permissive Policies
+
+### Wildcard Actions in IAM Policies
+
+```hcl
+// VULNERABLE: IAM policy allows all actions on all resources
+resource "aws_iam_policy" "admin" {
+  name   = "full-admin"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "*"
+      Resource = "*"
+    }]
+  })
+}
+
+// SECURE: Least-privilege policy scoped to specific actions and resources
+resource "aws_iam_policy" "s3_reader" {
+  name   = "s3-reader"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["s3:GetObject", "s3:ListBucket"]
+      Resource = [
+        "arn:aws:s3:::my-bucket",
+        "arn:aws:s3:::my-bucket/*"
+      ]
+    }]
+  })
+}
+```
+
+**Detection regex:** `"Action"\s*:\s*"\*"|"Action"\s*:\s*\[\s*"\*"\s*\]`
+**Severity:** error
+
+### Missing Conditions on IAM Policies
+
+```json
+// VULNERABLE: No conditions — any principal matching the trust can assume this role
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": "sts:AssumeRole",
+    "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+    "Resource": "*"
+  }]
+}
+
+// SECURE: Conditions restrict usage by source IP, MFA, or external ID
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": "sts:AssumeRole",
+    "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+    "Resource": "*",
+    "Condition": {
+      "Bool": {"aws:MultiFactorAuthPresent": "true"},
+      "IpAddress": {"aws:SourceIp": "203.0.113.0/24"}
+    }
+  }]
+}
+```
+
+**Detection regex:** `"Effect"\s*:\s*"Allow"[^}]*"Action"\s*:\s*"sts:AssumeRole"(?![^}]*"Condition")`
+**Severity:** warning
+
+### Overly Permissive Trust Policies
+
+```hcl
+// VULNERABLE: Trust policy allows any AWS account to assume the role
+resource "aws_iam_role" "cross_account" {
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = {"AWS": "*"}
+    }]
+  })
+}
+
+// SECURE: Trust restricted to specific account and role
+resource "aws_iam_role" "cross_account" {
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = {"AWS": "arn:aws:iam::987654321098:role/SpecificRole"}
+      Condition = {
+        StringEquals = {"sts:ExternalId" = "unique-external-id"}
+      }
+    }]
+  })
+}
+```
+
+**Detection regex:** `"Principal"\s*:\s*\{\s*"AWS"\s*:\s*"\*"\s*\}|"Principal"\s*:\s*"\*"`
+**Severity:** error
+
+### iam:PassRole Abuse
+
+```hcl
+// VULNERABLE: PassRole with wildcard resource — can escalate to any role
+resource "aws_iam_policy" "passrole_any" {
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "iam:PassRole"
+      Resource = "*"
+    }]
+  })
+}
+
+// SECURE: PassRole restricted to specific role ARN
+resource "aws_iam_policy" "passrole_scoped" {
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "iam:PassRole"
+      Resource = "arn:aws:iam::123456789012:role/LambdaExecutionRole"
+      Condition = {
+        StringEquals = {"iam:PassedToService" = "lambda.amazonaws.com"}
+      }
+    }]
+  })
+}
+```
+
+**Detection regex:** `"Action"\s*:\s*"iam:PassRole"[^}]*"Resource"\s*:\s*"\*"`
+**Severity:** error
+
+## S3: Public Access and Encryption
+
+### Public S3 Bucket via ACL
+
+```hcl
+// VULNERABLE: Public read ACL on S3 bucket
+resource "aws_s3_bucket_acl" "public" {
+  bucket = aws_s3_bucket.data.id
+  acl    = "public-read"
+}
+
+// SECURE: Private ACL (default)
+resource "aws_s3_bucket_acl" "private" {
+  bucket = aws_s3_bucket.data.id
+  acl    = "private"
+}
+```
+
+**Detection regex:** `acl\s*=\s*"public-read"|acl\s*=\s*"public-read-write"`
+**Severity:** error
+
+### Public S3 Bucket via Bucket Policy
+
+```json
+// VULNERABLE: Bucket policy grants access to anyone
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": "*",
+    "Action": "s3:GetObject",
+    "Resource": "arn:aws:s3:::my-bucket/*"
+  }]
+}
+
+// SECURE: Bucket policy restricted to CloudFront OAI
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "AWS": "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity E1234"
+    },
+    "Action": "s3:GetObject",
+    "Resource": "arn:aws:s3:::my-bucket/*"
+  }]
+}
+```
+
+**Detection regex:** `"Principal"\s*:\s*"\*"[^}]*s3:|s3[^}]*"Principal"\s*:\s*"\*"`
+**Severity:** error
+
+### Missing S3 Server-Side Encryption
+
+```hcl
+// VULNERABLE: No encryption configuration
+resource "aws_s3_bucket" "data" {
+  bucket = "sensitive-data-bucket"
+}
+
+// SECURE: Server-side encryption with KMS
+resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
+  bucket = aws_s3_bucket.data.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.s3.arn
+    }
+    bucket_key_enabled = true
+  }
+}
+```
+
+**Detection regex:** `resource\s+"aws_s3_bucket"\s+"[^"]+"\s*\{(?![^}]*server_side_encryption)`
+**Severity:** warning
+
+### S3 Public Access Block Not Enabled
+
+```hcl
+// VULNERABLE: No public access block — bucket may become public
+resource "aws_s3_bucket" "uploads" {
+  bucket = "user-uploads"
+}
+
+// SECURE: Block all public access
+resource "aws_s3_bucket_public_access_block" "uploads" {
+  bucket                  = aws_s3_bucket.uploads.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+```
+
+**Detection regex:** `block_public_acls\s*=\s*false|block_public_policy\s*=\s*false|ignore_public_acls\s*=\s*false|restrict_public_buckets\s*=\s*false`
+**Severity:** error
+
+## Lambda: Secrets and Permissions
+
+### Secrets in Lambda Environment Variables
+
+```hcl
+// VULNERABLE: Database password in plaintext environment variable
+resource "aws_lambda_function" "api" {
+  function_name = "api-handler"
+  environment {
+    variables = {
+      DB_PASSWORD = "super-secret-password-123"
+      API_KEY     = "AKIAIOSFODNN7EXAMPLE"
+    }
+  }
+}
+
+// SECURE: Reference secrets from Secrets Manager or SSM Parameter Store
+resource "aws_lambda_function" "api" {
+  function_name = "api-handler"
+  environment {
+    variables = {
+      DB_SECRET_ARN = aws_secretsmanager_secret.db.arn
+      API_KEY_PARAM = aws_ssm_parameter.api_key.name
+    }
+  }
+}
+```
+
+**Detection regex:** `environment\s*\{[^}]*variables\s*=\s*\{[^}]*(PASSWORD|SECRET|API_KEY|TOKEN|PRIVATE_KEY)\s*=\s*"[^"]+"`
+**Severity:** error
+
+### Overly Permissive Lambda Execution Role
+
+```hcl
+// VULNERABLE: Lambda with AdministratorAccess managed policy
+resource "aws_iam_role_policy_attachment" "lambda_admin" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+// SECURE: Lambda with specific permissions only
+resource "aws_iam_role_policy" "lambda_s3" {
+  role   = aws_iam_role.lambda.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["s3:GetObject"]
+      Resource = "arn:aws:s3:::data-bucket/*"
+    }]
+  })
+}
+```
+
+**Detection regex:** `policy_arn\s*=\s*"arn:aws:iam::aws:policy/AdministratorAccess"|policy_arn\s*=\s*"arn:aws:iam::aws:policy/PowerUserAccess"`
+**Severity:** error
+
+### Lambda Missing VPC Configuration
+
+```hcl
+// VULNERABLE: Lambda not in VPC — cannot access private resources, no network isolation
+resource "aws_lambda_function" "processor" {
+  function_name = "data-processor"
+  runtime       = "python3.11"
+  handler       = "index.handler"
+}
+
+// SECURE: Lambda deployed in VPC with specific subnets and security groups
+resource "aws_lambda_function" "processor" {
+  function_name = "data-processor"
+  runtime       = "python3.11"
+  handler       = "index.handler"
+
+  vpc_config {
+    subnet_ids         = var.private_subnet_ids
+    security_group_ids = [aws_security_group.lambda.id]
+  }
+}
+```
+
+**Detection regex:** `resource\s+"aws_lambda_function"\s+"[^"]+"\s*\{(?![^}]*vpc_config)`
+**Severity:** warning
+
+## Security Groups: Open Ingress
+
+### Unrestricted Ingress on Sensitive Ports
+
+```hcl
+// VULNERABLE: SSH open to the entire internet
+resource "aws_security_group_rule" "ssh_open" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.web.id
+}
+
+// SECURE: SSH restricted to bastion or VPN CIDR
+resource "aws_security_group_rule" "ssh_vpn" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["10.0.0.0/24"]
+  security_group_id = aws_security_group.web.id
+}
+```
+
+**Detection regex:** `cidr_blocks\s*=\s*\[\s*"0\.0\.0\.0/0"\s*\]|CidrIp:\s*["']?0\.0\.0\.0/0`
+**Severity:** error
+
+### Security Group Allowing All Traffic
+
+```hcl
+// VULNERABLE: All ports open to the internet
+resource "aws_security_group_rule" "all_open" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.default.id
+}
+
+// SECURE: Only specific ports open, restricted source
+resource "aws_security_group_rule" "https" {
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["10.0.0.0/8"]
+  security_group_id = aws_security_group.web.id
+}
+```
+
+**Detection regex:** `protocol\s*=\s*"-1"[^}]*cidr_blocks\s*=\s*\[\s*"0\.0\.0\.0/0"|from_port\s*=\s*0[^}]*to_port\s*=\s*65535[^}]*"0\.0\.0\.0/0"`
+**Severity:** error
+
+### CloudFormation: Open Security Group Ingress
+
+```yaml
+# VULNERABLE: SSH open to the world in CloudFormation
+Resources:
+  WebSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: 0.0.0.0/0
+
+# SECURE: SSH restricted to VPN range
+Resources:
+  WebSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: 10.0.0.0/24
+```
+
+**Detection regex:** `CidrIp:\s*["']?0\.0\.0\.0/0|CidrIpv6:\s*["']?::/0`
+**Severity:** error
+
+## KMS: Key Rotation
+
+### Missing KMS Key Rotation
+
+```hcl
+// VULNERABLE: KMS key without automatic rotation
+resource "aws_kms_key" "data" {
+  description = "Encryption key for data"
+  enable_key_rotation = false
+}
+
+// SECURE: KMS key with automatic rotation enabled
+resource "aws_kms_key" "data" {
+  description         = "Encryption key for data"
+  enable_key_rotation = true
+}
+```
+
+**Detection regex:** `enable_key_rotation\s*=\s*false`
+**Severity:** warning
+
+### KMS Key Missing Rotation Configuration
+
+```hcl
+// VULNERABLE: KMS key with no rotation setting at all (defaults to disabled)
+resource "aws_kms_key" "app" {
+  description = "Application encryption key"
+}
+
+// SECURE: Explicitly enable rotation
+resource "aws_kms_key" "app" {
+  description         = "Application encryption key"
+  enable_key_rotation = true
+}
+```
+
+**Detection regex:** `resource\s+"aws_kms_key"\s+"[^"]+"\s*\{(?![^}]*enable_key_rotation)`
+**Severity:** warning
+
+## CloudTrail: Logging and Monitoring
+
+### CloudTrail Disabled or Not Multi-Region
+
+```hcl
+// VULNERABLE: CloudTrail only in one region
+resource "aws_cloudtrail" "main" {
+  name                  = "main-trail"
+  s3_bucket_name        = aws_s3_bucket.trail.id
+  is_multi_region_trail = false
+}
+
+// SECURE: Multi-region trail with log validation
+resource "aws_cloudtrail" "main" {
+  name                          = "main-trail"
+  s3_bucket_name                = aws_s3_bucket.trail.id
+  is_multi_region_trail         = true
+  enable_log_file_validation    = true
+  include_global_service_events = true
+}
+```
+
+**Detection regex:** `is_multi_region_trail\s*=\s*false`
+**Severity:** error
+
+### CloudTrail Missing Log Validation
+
+```hcl
+// VULNERABLE: No log file validation — tampering undetectable
+resource "aws_cloudtrail" "audit" {
+  name                       = "audit-trail"
+  s3_bucket_name             = aws_s3_bucket.trail.id
+  enable_log_file_validation = false
+}
+
+// SECURE: Log file validation enabled
+resource "aws_cloudtrail" "audit" {
+  name                       = "audit-trail"
+  s3_bucket_name             = aws_s3_bucket.trail.id
+  enable_log_file_validation = true
+}
+```
+
+**Detection regex:** `enable_log_file_validation\s*=\s*false`
+**Severity:** warning
+
+## Secrets Manager: Hardcoded Secrets
+
+### Hardcoded Secrets Instead of Secrets Manager References
+
+```hcl
+// VULNERABLE: Hardcoded database credentials in Terraform
+resource "aws_db_instance" "main" {
+  engine   = "mysql"
+  username = "admin"
+  password = "MyS3cretP@ss!"
+}
+
+// SECURE: Password from Secrets Manager
+resource "aws_db_instance" "main" {
+  engine   = "mysql"
+  username = "admin"
+  password = data.aws_secretsmanager_secret_version.db.secret_string
+}
+
+data "aws_secretsmanager_secret_version" "db" {
+  secret_id = aws_secretsmanager_secret.db.id
+}
+```
+
+**Detection regex:** `password\s*=\s*"[^"]+"|master_password\s*=\s*"[^"]+"`
+**Severity:** error
+
+### Hardcoded Secrets in CloudFormation
+
+```yaml
+# VULNERABLE: Hardcoded secret in CloudFormation parameters default
+Parameters:
+  DBPassword:
+    Type: String
+    Default: "my-secret-password"
+
+# SECURE: Use AWS Secrets Manager dynamic reference
+Resources:
+  MyDB:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      MasterUserPassword: '{{resolve:secretsmanager:MySecret:SecretString:password}}'
+```
+
+**Detection regex:** `Default:\s*["'][^"']*(?:password|secret|key|token)[^"']*["']`
+**Severity:** error
+
+### Secrets in Terraform Variables Default Values
+
+```hcl
+// VULNERABLE: Secret with plaintext default value
+variable "db_password" {
+  type    = string
+  default = "admin123"
+}
+
+// SECURE: Sensitive variable with no default — must be provided at runtime
+variable "db_password" {
+  type      = string
+  sensitive = true
+}
+```
+
+**Detection regex:** `variable\s+"[^"]*(?:password|secret|key|token)[^"]*"\s*\{[^}]*default\s*=\s*"[^"]+"`
+**Severity:** error
+
+## RDS: Public Access and Encryption
+
+### RDS Instance Publicly Accessible
+
+```hcl
+// VULNERABLE: RDS instance publicly accessible
+resource "aws_db_instance" "main" {
+  engine               = "postgres"
+  instance_class       = "db.t3.micro"
+  publicly_accessible  = true
+}
+
+// SECURE: RDS not publicly accessible, in private subnets
+resource "aws_db_instance" "main" {
+  engine               = "postgres"
+  instance_class       = "db.t3.micro"
+  publicly_accessible  = false
+  db_subnet_group_name = aws_db_subnet_group.private.name
+}
+```
+
+**Detection regex:** `publicly_accessible\s*=\s*true`
+**Severity:** error
+
+### RDS Unencrypted Storage
+
+```hcl
+// VULNERABLE: RDS storage not encrypted
+resource "aws_db_instance" "main" {
+  engine         = "mysql"
+  instance_class = "db.t3.micro"
+  storage_encrypted = false
+}
+
+// SECURE: Encrypted storage with KMS key
+resource "aws_db_instance" "main" {
+  engine            = "mysql"
+  instance_class    = "db.t3.micro"
+  storage_encrypted = true
+  kms_key_id        = aws_kms_key.rds.arn
+}
+```
+
+**Detection regex:** `storage_encrypted\s*=\s*false`
+**Severity:** error
+
+### RDS Missing Deletion Protection
+
+```hcl
+// VULNERABLE: No deletion protection on production database
+resource "aws_db_instance" "prod" {
+  engine                  = "postgres"
+  instance_class          = "db.r5.large"
+  deletion_protection     = false
+}
+
+// SECURE: Deletion protection enabled
+resource "aws_db_instance" "prod" {
+  engine                  = "postgres"
+  instance_class          = "db.r5.large"
+  deletion_protection     = true
+  backup_retention_period = 7
+}
+```
+
+**Detection regex:** `deletion_protection\s*=\s*false`
+**Severity:** warning
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| IAM wildcard actions (SA-AWS-01) | Critical | Immediate | Medium |
+| Missing IAM conditions (SA-AWS-02) | High | 1 week | Low |
+| Overly permissive trust policies (SA-AWS-03) | Critical | Immediate | Medium |
+| iam:PassRole abuse (SA-AWS-04) | Critical | Immediate | Medium |
+| Public S3 bucket (SA-AWS-05) | Critical | Immediate | Low |
+| Missing S3 encryption (SA-AWS-06) | High | 1 week | Low |
+| Lambda env var secrets (SA-AWS-07) | Critical | Immediate | Medium |
+| Overly permissive Lambda role (SA-AWS-08) | High | 1 week | Medium |
+| Open security groups (SA-AWS-09) | Critical | Immediate | Low |
+| Missing KMS key rotation (SA-AWS-10) | Medium | 1 month | Low |
+| CloudTrail misconfiguration (SA-AWS-11) | High | 1 week | Low |
+| Hardcoded secrets (SA-AWS-12) | Critical | Immediate | Medium |
+| RDS publicly accessible (SA-AWS-13) | Critical | Immediate | Low |
+| RDS unencrypted storage (SA-AWS-14) | High | 1 week | Low |
+| RDS missing deletion protection (SA-AWS-15) | Medium | 1 month | Low |
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `iac-security.md` — Infrastructure-as-Code security patterns
+- `cryptography-guide.md` — Encryption and key management
+- `security-logging.md` — Logging and monitoring patterns
+- `api-key-encryption.md` — API key and secrets management
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Cloud security references |

--- a/skills/security-audit/references/aws-security.md
+++ b/skills/security-audit/references/aws-security.md
@@ -44,13 +44,13 @@ resource "aws_iam_policy" "s3_reader" {
 
 ```json
 // VULNERABLE: No conditions — any principal matching the trust can assume this role
+// Note: trust (assume-role) policies do NOT use the Resource element — it's implied by the role.
 {
   "Version": "2012-10-17",
   "Statement": [{
     "Effect": "Allow",
     "Action": "sts:AssumeRole",
-    "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
-    "Resource": "*"
+    "Principal": {"AWS": "arn:aws:iam::123456789012:root"}
   }]
 }
 
@@ -61,7 +61,6 @@ resource "aws_iam_policy" "s3_reader" {
     "Effect": "Allow",
     "Action": "sts:AssumeRole",
     "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
-    "Resource": "*",
     "Condition": {
       "Bool": {"aws:MultiFactorAuthPresent": "true"},
       "IpAddress": {"aws:SourceIp": "203.0.113.0/24"}
@@ -214,7 +213,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
 }
 ```
 
-**Detection regex:** `resource\s+"aws_s3_bucket"\s+"[^"]+"\s*\{(?![^}]*server_side_encryption)`
+**Detection guidance:** flag `aws_s3_bucket` resources that do not have a matching `aws_s3_bucket_server_side_encryption_configuration` resource (or equivalent module). Matching `server_side_encryption` inside the bucket block produces false positives because the modern Terraform pattern uses a separate resource (as shown above).
 **Severity:** warning
 
 ### S3 Public Access Block Not Enabled

--- a/skills/security-audit/references/azure-security.md
+++ b/skills/security-audit/references/azure-security.md
@@ -1,0 +1,630 @@
+# Azure Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for Microsoft Azure infrastructure. Covers RBAC, Blob Storage, Azure Functions, NSGs, Key Vault, and Activity Log across Bicep, ARM templates, and Terraform configurations.
+
+## RBAC: Overly Permissive Role Assignments
+
+### Owner/Contributor at Subscription Scope
+
+```hcl
+// VULNERABLE: Owner role at subscription scope
+resource "azurerm_role_assignment" "owner" {
+  scope                = data.azurerm_subscription.primary.id
+  role_definition_name = "Owner"
+  principal_id         = var.user_object_id
+}
+
+// SECURE: Specific role at resource group scope
+resource "azurerm_role_assignment" "contributor" {
+  scope                = azurerm_resource_group.app.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = var.user_object_id
+}
+```
+
+**Detection regex:** `role_definition_name\s*=\s*"(Owner|Contributor)"[^}]*subscription|subscription[^}]*role_definition_name\s*=\s*"(Owner|Contributor)"`
+**Severity:** error
+
+### Bicep: Owner Role Assignment at Subscription
+
+```bicep
+// VULNERABLE: Owner at subscription scope
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, principalId, ownerRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
+    principalId: principalId
+  }
+}
+
+// SECURE: Scoped to resource group with specific role
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, principalId, readerRoleId)
+  scope: resourceGroup()
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
+    principalId: principalId
+    description: 'Reader access for monitoring'
+  }
+}
+```
+
+**Detection regex:** `8e3af657-a8ff-443c-a75c-2fe8c4bcb635|b24988ac-6180-42a0-ab88-20f7382dd24c`
+**Severity:** error
+
+### Missing Conditions on Role Assignments
+
+```hcl
+// VULNERABLE: Role assignment without conditions
+resource "azurerm_role_assignment" "storage" {
+  scope                = azurerm_storage_account.main.id
+  role_definition_name = "Storage Blob Data Owner"
+  principal_id         = var.app_principal_id
+}
+
+// SECURE: Role assignment with condition
+resource "azurerm_role_assignment" "storage" {
+  scope                = azurerm_storage_account.main.id
+  role_definition_name = "Storage Blob Data Owner"
+  principal_id         = var.app_principal_id
+  condition            = "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/delete'}))"
+  condition_version    = "2.0"
+}
+```
+
+**Detection regex:** `role_definition_name\s*=\s*"Storage Blob Data Owner"(?![^}]*condition\s*=)`
+**Severity:** warning
+
+## Blob Storage: Public Access and Encryption
+
+### Public Access Enabled on Storage Account
+
+```hcl
+// VULNERABLE: Public blob access enabled
+resource "azurerm_storage_account" "main" {
+  name                     = "storageaccount"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = "eastus"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  allow_nested_items_to_be_public = true
+}
+
+// SECURE: Public access disabled
+resource "azurerm_storage_account" "main" {
+  name                     = "storageaccount"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = "eastus"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  allow_nested_items_to_be_public = false
+  min_tls_version          = "TLS1_2"
+}
+```
+
+**Detection regex:** `allow_nested_items_to_be_public\s*=\s*true|allow_blob_public_access\s*=\s*true`
+**Severity:** error
+
+### Bicep: Public Blob Access
+
+```bicep
+// VULNERABLE: Public access allowed
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: 'mystorageaccount'
+  location: location
+  kind: 'StorageV2'
+  sku: { name: 'Standard_LRS' }
+  properties: {
+    allowBlobPublicAccess: true
+  }
+}
+
+// SECURE: Public access disabled with minimum TLS
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: 'mystorageaccount'
+  location: location
+  kind: 'StorageV2'
+  sku: { name: 'Standard_LRS' }
+  properties: {
+    allowBlobPublicAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+  }
+}
+```
+
+**Detection regex:** `allowBlobPublicAccess:\s*true|"allowBlobPublicAccess"\s*:\s*true`
+**Severity:** error
+
+### Anonymous Access on Blob Container
+
+```hcl
+// VULNERABLE: Container with anonymous blob access
+resource "azurerm_storage_container" "uploads" {
+  name                  = "uploads"
+  storage_account_name  = azurerm_storage_account.main.name
+  container_access_type = "blob"
+}
+
+// SECURE: Container with private access
+resource "azurerm_storage_container" "uploads" {
+  name                  = "uploads"
+  storage_account_name  = azurerm_storage_account.main.name
+  container_access_type = "private"
+}
+```
+
+**Detection regex:** `container_access_type\s*=\s*"(blob|container)"`
+**Severity:** error
+
+### Missing Customer-Managed Encryption
+
+```hcl
+// VULNERABLE: Using default Microsoft-managed keys
+resource "azurerm_storage_account" "data" {
+  name                     = "datastore"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = "eastus"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+// SECURE: Customer-managed encryption key
+resource "azurerm_storage_account" "data" {
+  name                     = "datastore"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = "eastus"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  customer_managed_key {
+    key_vault_key_id          = azurerm_key_vault_key.storage.id
+    user_assigned_identity_id = azurerm_user_assigned_identity.storage.id
+  }
+}
+```
+
+**Detection regex:** `resource\s+"azurerm_storage_account"\s+"[^"]+"\s*\{(?![^}]*customer_managed_key)`
+**Severity:** warning
+
+## Azure Functions: Authentication and Secrets
+
+### Anonymous Authentication Level
+
+```hcl
+// VULNERABLE: Function with anonymous auth level
+resource "azurerm_function_app_function" "api" {
+  name            = "api-handler"
+  function_app_id = azurerm_linux_function_app.main.id
+  config_json = jsonencode({
+    bindings = [{
+      authLevel = "anonymous"
+      type      = "httpTrigger"
+      direction = "in"
+      name      = "req"
+      methods   = ["get", "post"]
+    }]
+  })
+}
+
+// SECURE: Function-level key required
+resource "azurerm_function_app_function" "api" {
+  name            = "api-handler"
+  function_app_id = azurerm_linux_function_app.main.id
+  config_json = jsonencode({
+    bindings = [{
+      authLevel = "function"
+      type      = "httpTrigger"
+      direction = "in"
+      name      = "req"
+      methods   = ["get", "post"]
+    }]
+  })
+}
+```
+
+**Detection regex:** `authLevel["\s]*[:=]\s*["']?anonymous|"authLevel"\s*:\s*"anonymous"`
+**Severity:** error
+
+### Secrets in App Settings
+
+```hcl
+// VULNERABLE: Connection string hardcoded in app settings
+resource "azurerm_linux_function_app" "main" {
+  name                = "my-func-app"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = "eastus"
+  service_plan_id     = azurerm_service_plan.plan.id
+
+  app_settings = {
+    DB_CONNECTION = "Server=tcp:myserver.database.windows.net;Database=mydb;User ID=admin;Password=Secret123!"
+    API_SECRET    = "sk-live-abc123def456"
+  }
+}
+
+// SECURE: Reference Key Vault secrets
+resource "azurerm_linux_function_app" "main" {
+  name                = "my-func-app"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = "eastus"
+  service_plan_id     = azurerm_service_plan.plan.id
+
+  app_settings = {
+    DB_CONNECTION = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.db_conn.id})"
+    API_SECRET    = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.api.id})"
+  }
+}
+```
+
+**Detection regex:** `app_settings\s*=\s*\{[^}]*(PASSWORD|SECRET|KEY|TOKEN|CONNECTION)\s*=\s*"(?!@Microsoft\.KeyVault)[^"]+"`
+**Severity:** error
+
+## NSGs: Open Inbound Rules
+
+### Unrestricted Inbound on Sensitive Ports
+
+```hcl
+// VULNERABLE: SSH open to the entire internet
+resource "azurerm_network_security_rule" "ssh_open" {
+  name                        = "allow-ssh"
+  priority                    = 100
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  destination_port_range      = "22"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.rg.name
+  network_security_group_name = azurerm_network_security_group.nsg.name
+}
+
+// SECURE: SSH restricted to VPN CIDR
+resource "azurerm_network_security_rule" "ssh_vpn" {
+  name                        = "allow-ssh-vpn"
+  priority                    = 100
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  destination_port_range      = "22"
+  source_address_prefix       = "10.0.0.0/24"
+  destination_address_prefix  = "10.0.1.0/24"
+  resource_group_name         = azurerm_resource_group.rg.name
+  network_security_group_name = azurerm_network_security_group.nsg.name
+}
+```
+
+**Detection regex:** `source_address_prefix\s*=\s*"\*"[^}]*direction\s*=\s*"Inbound"|direction\s*=\s*"Inbound"[^}]*source_address_prefix\s*=\s*"\*"`
+**Severity:** error
+
+### Bicep: Open NSG Inbound Rule
+
+```bicep
+// VULNERABLE: RDP open to internet
+resource nsg 'Microsoft.Network/networkSecurityGroups@2023-05-01' = {
+  name: 'web-nsg'
+  location: location
+  properties: {
+    securityRules: [
+      {
+        name: 'allow-rdp'
+        properties: {
+          priority: 100
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          destinationPortRange: '3389'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: '*'
+        }
+      }
+    ]
+  }
+}
+
+// SECURE: RDP restricted to Azure Bastion subnet
+resource nsg 'Microsoft.Network/networkSecurityGroups@2023-05-01' = {
+  name: 'web-nsg'
+  location: location
+  properties: {
+    securityRules: [
+      {
+        name: 'allow-rdp-bastion'
+        properties: {
+          priority: 100
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          destinationPortRange: '3389'
+          sourceAddressPrefix: 'AzureBastionSubnet'
+          destinationAddressPrefix: 'VirtualNetwork'
+        }
+      }
+    ]
+  }
+}
+```
+
+**Detection regex:** `sourceAddressPrefix['"]*\s*[:=]\s*['"]\*['"]|"sourceAddressPrefix"\s*:\s*"\*"`
+**Severity:** error
+
+## Key Vault: Soft Delete and Access
+
+### Missing Soft Delete on Key Vault
+
+```hcl
+// VULNERABLE: Soft delete not explicitly enabled (older API versions)
+resource "azurerm_key_vault" "main" {
+  name                = "my-key-vault"
+  location            = "eastus"
+  resource_group_name = azurerm_resource_group.rg.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = false
+}
+
+// SECURE: Soft delete with purge protection
+resource "azurerm_key_vault" "main" {
+  name                = "my-key-vault"
+  location            = "eastus"
+  resource_group_name = azurerm_resource_group.rg.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+  soft_delete_retention_days = 90
+  purge_protection_enabled   = true
+}
+```
+
+**Detection regex:** `purge_protection_enabled\s*=\s*false`
+**Severity:** error
+
+### Key Vault Using Access Policies Instead of RBAC
+
+```hcl
+// VULNERABLE: Access policies (legacy, harder to audit)
+resource "azurerm_key_vault" "main" {
+  name                = "my-key-vault"
+  location            = "eastus"
+  resource_group_name = azurerm_resource_group.rg.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = var.user_object_id
+    secret_permissions = ["Get", "List", "Set", "Delete"]
+    key_permissions    = ["Get", "List", "Create", "Delete"]
+  }
+}
+
+// SECURE: RBAC-based access control
+resource "azurerm_key_vault" "main" {
+  name                       = "my-key-vault"
+  location                   = "eastus"
+  resource_group_name        = azurerm_resource_group.rg.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  enable_rbac_authorization  = true
+  purge_protection_enabled   = true
+  soft_delete_retention_days = 90
+}
+```
+
+**Detection regex:** `enable_rbac_authorization\s*=\s*false|access_policy\s*\{`
+**Severity:** warning
+
+### Bicep: Key Vault Without Purge Protection
+
+```bicep
+// VULNERABLE: No purge protection
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: 'my-key-vault'
+  location: location
+  properties: {
+    tenantId: tenant().tenantId
+    sku: { family: 'A', name: 'standard' }
+    enablePurgeProtection: false
+  }
+}
+
+// SECURE: Purge protection and RBAC enabled
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: 'my-key-vault'
+  location: location
+  properties: {
+    tenantId: tenant().tenantId
+    sku: { family: 'A', name: 'standard' }
+    enablePurgeProtection: true
+    enableRbacAuthorization: true
+    enableSoftDelete: true
+    softDeleteRetentionInDays: 90
+  }
+}
+```
+
+**Detection regex:** `enablePurgeProtection:\s*false|"enablePurgeProtection"\s*:\s*false`
+**Severity:** error
+
+## Activity Log: Diagnostic Settings
+
+### Missing Diagnostic Settings
+
+```hcl
+// VULNERABLE: No diagnostic settings for activity log
+// (absence of azurerm_monitor_diagnostic_setting)
+
+// SECURE: Activity log forwarded to Log Analytics
+resource "azurerm_monitor_diagnostic_setting" "activity_log" {
+  name                       = "activity-log-analytics"
+  target_resource_id         = data.azurerm_subscription.primary.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log {
+    category = "Administrative"
+  }
+  enabled_log {
+    category = "Security"
+  }
+  enabled_log {
+    category = "Alert"
+  }
+  enabled_log {
+    category = "Policy"
+  }
+}
+```
+
+**Detection regex:** `azurerm_monitor_diagnostic_setting`
+**Severity:** warning
+
+### Bicep: Missing Diagnostic Settings
+
+```bicep
+// VULNERABLE: No diagnostic settings configured
+
+// SECURE: Activity log diagnostic setting
+resource diagnosticSetting 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'activity-log-analytics'
+  properties: {
+    workspaceId: logAnalyticsWorkspace.id
+    logs: [
+      { category: 'Administrative', enabled: true }
+      { category: 'Security', enabled: true }
+      { category: 'Alert', enabled: true }
+    ]
+  }
+}
+```
+
+**Detection regex:** `Microsoft\.Insights/diagnosticSettings`
+**Severity:** warning
+
+## Azure SQL: Public Access
+
+### Azure SQL Public Network Access
+
+```hcl
+// VULNERABLE: Public network access enabled
+resource "azurerm_mssql_server" "main" {
+  name                         = "sql-server"
+  resource_group_name          = azurerm_resource_group.rg.name
+  location                     = "eastus"
+  version                      = "12.0"
+  public_network_access_enabled = true
+}
+
+// SECURE: Public access disabled, private endpoint
+resource "azurerm_mssql_server" "main" {
+  name                         = "sql-server"
+  resource_group_name          = azurerm_resource_group.rg.name
+  location                     = "eastus"
+  version                      = "12.0"
+  public_network_access_enabled = false
+}
+```
+
+**Detection regex:** `public_network_access_enabled\s*=\s*true`
+**Severity:** error
+
+### Azure SQL Firewall Allow All Azure IPs
+
+```hcl
+// VULNERABLE: Allow all Azure services (0.0.0.0 rule)
+resource "azurerm_mssql_firewall_rule" "allow_azure" {
+  name             = "AllowAllAzureIps"
+  server_id        = azurerm_mssql_server.main.id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "0.0.0.0"
+}
+
+// SECURE: Use private endpoints instead of firewall rules
+resource "azurerm_private_endpoint" "sql" {
+  name                = "sql-private-endpoint"
+  location            = "eastus"
+  resource_group_name = azurerm_resource_group.rg.name
+  subnet_id           = azurerm_subnet.private.id
+
+  private_service_connection {
+    name                           = "sql-connection"
+    private_connection_resource_id = azurerm_mssql_server.main.id
+    subresource_names              = ["sqlServer"]
+    is_manual_connection           = false
+  }
+}
+```
+
+**Detection regex:** `start_ip_address\s*=\s*"0\.0\.0\.0"[^}]*end_ip_address\s*=\s*"0\.0\.0\.0"`
+**Severity:** warning
+
+### Missing TDE on Azure SQL
+
+```hcl
+// VULNERABLE: Transparent Data Encryption not configured with CMK
+resource "azurerm_mssql_database" "main" {
+  name      = "my-database"
+  server_id = azurerm_mssql_server.main.id
+}
+
+// SECURE: TDE with customer-managed key
+resource "azurerm_mssql_server_transparent_data_encryption" "main" {
+  server_id        = azurerm_mssql_server.main.id
+  key_vault_key_id = azurerm_key_vault_key.sql_tde.id
+}
+```
+
+**Detection regex:** `resource\s+"azurerm_mssql_server"\s+"[^"]+"\s*\{(?![^}]*transparent_data_encryption)`
+**Severity:** warning
+
+### Azure SQL Auditing Not Enabled
+
+```hcl
+// VULNERABLE: No auditing configured
+resource "azurerm_mssql_server" "main" {
+  name                = "sql-server"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = "eastus"
+  version             = "12.0"
+}
+
+// SECURE: Extended auditing enabled
+resource "azurerm_mssql_server_extended_auditing_policy" "main" {
+  server_id              = azurerm_mssql_server.main.id
+  storage_endpoint       = azurerm_storage_account.audit.primary_blob_endpoint
+  retention_in_days      = 90
+  log_monitoring_enabled = true
+}
+```
+
+**Detection regex:** `azurerm_mssql_server_extended_auditing_policy`
+**Severity:** warning
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| Owner/Contributor at subscription (SA-AZURE-01) | Critical | Immediate | Medium |
+| Missing RBAC conditions (SA-AZURE-02) | High | 1 week | Low |
+| Public blob access (SA-AZURE-03) | Critical | Immediate | Low |
+| Missing CMK encryption (SA-AZURE-04) | Medium | 1 month | Medium |
+| Anonymous function auth (SA-AZURE-05) | Critical | Immediate | Low |
+| Open NSG inbound rules (SA-AZURE-06) | Critical | Immediate | Low |
+| Missing purge protection (SA-AZURE-07) | High | 1 week | Low |
+| Key Vault access policies (SA-AZURE-08) | Medium | 1 month | Medium |
+| Missing diagnostic settings (SA-AZURE-09) | High | 1 week | Low |
+| SQL public network access (SA-AZURE-10) | Critical | Immediate | Medium |
+| SQL missing TDE (SA-AZURE-11) | Medium | 1 month | Medium |
+| SQL auditing not enabled (SA-AZURE-12) | High | 1 week | Low |
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `iac-security.md` — Infrastructure-as-Code security patterns
+- `cryptography-guide.md` — Encryption and key management
+- `security-logging.md` — Logging and monitoring patterns
+- `api-key-encryption.md` — API key and secrets management
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Cloud security references |

--- a/skills/security-audit/references/azure-security.md
+++ b/skills/security-audit/references/azure-security.md
@@ -474,7 +474,7 @@ resource "azurerm_monitor_diagnostic_setting" "activity_log" {
 }
 ```
 
-**Detection regex:** `azurerm_monitor_diagnostic_setting`
+**Detection guidance:** flag activity-log-capable resources that lack a companion `azurerm_monitor_diagnostic_setting`. Matching `azurerm_monitor_diagnostic_setting` directly would flag the secure pattern shown above — use absence-of-resource checks (e.g., Checkov, tfsec, or a module inventory) instead of a simple regex.
 **Severity:** warning
 
 ### Bicep: Missing Diagnostic Settings
@@ -496,7 +496,7 @@ resource diagnosticSetting 'Microsoft.Insights/diagnosticSettings@2021-05-01-pre
 }
 ```
 
-**Detection regex:** `Microsoft\.Insights/diagnosticSettings`
+**Detection guidance:** flag Bicep/ARM deployments without a `Microsoft.Insights/diagnosticSettings` resource covering the target scope. Matching the resource type directly flags the secure pattern — prefer an absence-of-resource check.
 **Severity:** warning
 
 ## Azure SQL: Public Access
@@ -572,7 +572,7 @@ resource "azurerm_mssql_server_transparent_data_encryption" "main" {
 }
 ```
 
-**Detection regex:** `resource\s+"azurerm_mssql_server"\s+"[^"]+"\s*\{(?![^}]*transparent_data_encryption)`
+**Detection guidance:** flag `azurerm_mssql_server` resources that lack a matching `azurerm_mssql_server_transparent_data_encryption`. A nested-block regex produces false positives because TDE lives in a separate resource in modern Terraform.
 **Severity:** warning
 
 ### Azure SQL Auditing Not Enabled
@@ -595,7 +595,7 @@ resource "azurerm_mssql_server_extended_auditing_policy" "main" {
 }
 ```
 
-**Detection regex:** `azurerm_mssql_server_extended_auditing_policy`
+**Detection guidance:** flag `azurerm_mssql_server` resources without a matching `azurerm_mssql_server_extended_auditing_policy`. Matching the auditing-policy resource type directly flags the secure pattern.
 **Severity:** warning
 
 ## Remediation Priority

--- a/skills/security-audit/references/gcp-security.md
+++ b/skills/security-audit/references/gcp-security.md
@@ -481,7 +481,7 @@ resource "google_project_iam_audit_config" "all_services" {
 }
 ```
 
-**Detection regex:** `google_project_iam_audit_config`
+**Detection guidance:** flag GCP projects that lack a `google_project_iam_audit_config` covering `allServices`/`DATA_READ`/`DATA_WRITE`. Matching the resource type directly flags the secure pattern — prefer an absence-of-resource check.
 **Severity:** warning
 
 ### Audit Log Exemptions for Users

--- a/skills/security-audit/references/gcp-security.md
+++ b/skills/security-audit/references/gcp-security.md
@@ -1,0 +1,640 @@
+# GCP Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for Google Cloud Platform infrastructure. Covers IAM, Cloud Storage, Cloud Functions, VPC Firewall, KMS, and Audit Logs across Terraform, JSON, and YAML configurations.
+
+## IAM: Primitive Roles and Service Accounts
+
+### Primitive Roles on Projects (Owner/Editor)
+
+```hcl
+// VULNERABLE: Granting Owner role at project level
+resource "google_project_iam_member" "admin" {
+  project = "my-project"
+  role    = "roles/owner"
+  member  = "user:admin@example.com"
+}
+
+// SECURE: Granular predefined role scoped to specific service
+resource "google_project_iam_member" "storage_admin" {
+  project = "my-project"
+  role    = "roles/storage.admin"
+  member  = "user:admin@example.com"
+}
+```
+
+**Detection regex:** `role\s*=\s*"roles/(owner|editor)"|"roles/(owner|editor)"`
+**Severity:** error
+
+### Service Account Key Files
+
+```hcl
+// VULNERABLE: Creating downloadable service account keys
+resource "google_service_account_key" "sa_key" {
+  service_account_id = google_service_account.mysa.name
+}
+
+// SECURE: Use Workload Identity Federation instead of key files
+resource "google_iam_workload_identity_pool" "pool" {
+  workload_identity_pool_id = "github-pool"
+  display_name              = "GitHub Actions Pool"
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.pool.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github-provider"
+  attribute_mapping = {
+    "google.subject" = "assertion.sub"
+  }
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+```
+
+**Detection regex:** `resource\s+"google_service_account_key"|google_service_account_key\s*\{`
+**Severity:** error
+
+### allUsers / allAuthenticatedUsers Bindings
+
+```hcl
+// VULNERABLE: IAM binding grants access to all internet users
+resource "google_project_iam_binding" "public" {
+  project = "my-project"
+  role    = "roles/viewer"
+  members = ["allUsers"]
+}
+
+// SECURE: Binding restricted to specific group
+resource "google_project_iam_binding" "team" {
+  project = "my-project"
+  role    = "roles/viewer"
+  members = ["group:team@example.com"]
+}
+```
+
+**Detection regex:** `"allUsers"|"allAuthenticatedUsers"|member\s*=\s*"allUsers"|member\s*=\s*"allAuthenticatedUsers"`
+**Severity:** error
+
+### Overly Broad Service Account Impersonation
+
+```hcl
+// VULNERABLE: Any user can impersonate any service account
+resource "google_project_iam_member" "sa_token_creator" {
+  project = "my-project"
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "user:developer@example.com"
+}
+
+// SECURE: Impersonation scoped to specific service account
+resource "google_service_account_iam_member" "sa_token_creator" {
+  service_account_id = google_service_account.deploy.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:ci@my-project.iam.gserviceaccount.com"
+}
+```
+
+**Detection regex:** `role\s*=\s*"roles/iam\.serviceAccountTokenCreator"[^}]*google_project_iam|google_project_iam[^}]*serviceAccountTokenCreator`
+**Severity:** warning
+
+## Cloud Storage: Public Access and Encryption
+
+### Public Storage Bucket ACL
+
+```hcl
+// VULNERABLE: Cloud Storage bucket accessible to allUsers
+resource "google_storage_bucket_iam_member" "public" {
+  bucket = google_storage_bucket.data.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
+// SECURE: Access restricted to specific service account
+resource "google_storage_bucket_iam_member" "app" {
+  bucket = google_storage_bucket.data.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:app@my-project.iam.gserviceaccount.com"
+}
+```
+
+**Detection regex:** `google_storage_bucket_iam[^}]*(allUsers|allAuthenticatedUsers)`
+**Severity:** error
+
+### Missing Customer-Managed Encryption Key (CMEK)
+
+```hcl
+// VULNERABLE: Bucket using default Google-managed encryption
+resource "google_storage_bucket" "sensitive" {
+  name     = "sensitive-data"
+  location = "US"
+}
+
+// SECURE: Bucket using customer-managed encryption key
+resource "google_storage_bucket" "sensitive" {
+  name     = "sensitive-data"
+  location = "US"
+  encryption {
+    default_kms_key_name = google_kms_crypto_key.storage.id
+  }
+}
+```
+
+**Detection regex:** `resource\s+"google_storage_bucket"\s+"[^"]+"\s*\{(?![^}]*encryption\s*\{)`
+**Severity:** warning
+
+### Uniform Bucket-Level Access Not Enabled
+
+```hcl
+// VULNERABLE: Object-level ACLs allowed — inconsistent access control
+resource "google_storage_bucket" "data" {
+  name                        = "my-data"
+  location                    = "US"
+  uniform_bucket_level_access = false
+}
+
+// SECURE: Uniform bucket-level access enforced
+resource "google_storage_bucket" "data" {
+  name                        = "my-data"
+  location                    = "US"
+  uniform_bucket_level_access = true
+}
+```
+
+**Detection regex:** `uniform_bucket_level_access\s*=\s*false`
+**Severity:** warning
+
+### Public Bucket in YAML/JSON Configuration
+
+```yaml
+# VULNERABLE: Public predefinedAcl in deployment config
+resources:
+  - name: data-bucket
+    type: storage.v1.bucket
+    properties:
+      predefinedAcl: publicRead
+      location: US
+
+# SECURE: Private access
+resources:
+  - name: data-bucket
+    type: storage.v1.bucket
+    properties:
+      predefinedAcl: private
+      location: US
+      iamConfiguration:
+        uniformBucketLevelAccess:
+          enabled: true
+```
+
+**Detection regex:** `predefinedAcl:\s*public|predefinedAcl:\s*["']public`
+**Severity:** error
+
+## Cloud Functions: Secrets and Access
+
+### Secrets in Cloud Functions Environment Variables
+
+```hcl
+// VULNERABLE: Secret in plaintext environment variable
+resource "google_cloudfunctions_function" "api" {
+  name    = "api-handler"
+  runtime = "nodejs18"
+  environment_variables = {
+    DB_PASSWORD = "s3cret-pass!"
+    API_KEY     = "AIzaSyB_example_key"
+  }
+}
+
+// SECURE: Reference secrets from Secret Manager
+resource "google_cloudfunctions_function" "api" {
+  name    = "api-handler"
+  runtime = "nodejs18"
+  secret_environment_variables {
+    key        = "DB_PASSWORD"
+    project_id = "my-project"
+    secret     = google_secret_manager_secret.db_pass.secret_id
+    version    = "latest"
+  }
+}
+```
+
+**Detection regex:** `environment_variables\s*=\s*\{[^}]*(PASSWORD|SECRET|API_KEY|TOKEN|PRIVATE_KEY)\s*=\s*"[^"]+"`
+**Severity:** error
+
+### allUsers Cloud Functions Invoker
+
+```hcl
+// VULNERABLE: Function invocable by anyone on the internet
+resource "google_cloudfunctions_function_iam_member" "public" {
+  cloud_function = google_cloudfunctions_function.api.name
+  role           = "roles/cloudfunctions.invoker"
+  member         = "allUsers"
+}
+
+// SECURE: Function invocable only by specific service account
+resource "google_cloudfunctions_function_iam_member" "invoker" {
+  cloud_function = google_cloudfunctions_function.api.name
+  role           = "roles/cloudfunctions.invoker"
+  member         = "serviceAccount:scheduler@my-project.iam.gserviceaccount.com"
+}
+```
+
+**Detection regex:** `cloudfunctions\.invoker[^}]*allUsers|allUsers[^}]*cloudfunctions\.invoker`
+**Severity:** error
+
+### Cloud Functions Missing VPC Connector
+
+```hcl
+// VULNERABLE: Function without VPC connector — no private network access
+resource "google_cloudfunctions_function" "processor" {
+  name    = "data-processor"
+  runtime = "python311"
+}
+
+// SECURE: Function with VPC connector for private network access
+resource "google_cloudfunctions_function" "processor" {
+  name                  = "data-processor"
+  runtime               = "python311"
+  vpc_connector         = google_vpc_access_connector.connector.id
+  vpc_connector_egress_settings = "ALL_TRAFFIC"
+}
+```
+
+**Detection regex:** `resource\s+"google_cloudfunctions_function"\s+"[^"]+"\s*\{(?![^}]*vpc_connector)`
+**Severity:** warning
+
+## VPC Firewall: Open Ingress
+
+### Unrestricted Ingress Rules
+
+```hcl
+// VULNERABLE: Firewall rule allows SSH from anywhere
+resource "google_compute_firewall" "ssh_open" {
+  name    = "allow-ssh"
+  network = google_compute_network.vpc.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+// SECURE: SSH restricted to IAP tunnel range
+resource "google_compute_firewall" "ssh_iap" {
+  name    = "allow-ssh-iap"
+  network = google_compute_network.vpc.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["35.235.240.0/20"]
+}
+```
+
+**Detection regex:** `source_ranges\s*=\s*\[\s*"0\.0\.0\.0/0"\s*\]`
+**Severity:** error
+
+### Firewall Rule Allowing All Protocols
+
+```hcl
+// VULNERABLE: All traffic from any source
+resource "google_compute_firewall" "allow_all" {
+  name    = "allow-all"
+  network = google_compute_network.vpc.name
+
+  allow {
+    protocol = "all"
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+// SECURE: Only specific protocols and ports
+resource "google_compute_firewall" "web" {
+  name    = "allow-web"
+  network = google_compute_network.vpc.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["443"]
+  }
+
+  source_ranges = ["10.0.0.0/8"]
+}
+```
+
+**Detection regex:** `protocol\s*=\s*"all"[^}]*source_ranges\s*=\s*\[\s*"0\.0\.0\.0/0"`
+**Severity:** error
+
+### YAML Firewall Configuration Open to Internet
+
+```yaml
+# VULNERABLE: Deployment Manager firewall rule open to all
+resources:
+  - name: allow-ssh
+    type: compute.v1.firewall
+    properties:
+      network: global/networks/default
+      sourceRanges:
+        - "0.0.0.0/0"
+      allowed:
+        - IPProtocol: tcp
+          ports:
+            - "22"
+
+# SECURE: Restricted source range
+resources:
+  - name: allow-ssh-internal
+    type: compute.v1.firewall
+    properties:
+      network: global/networks/default
+      sourceRanges:
+        - "10.128.0.0/9"
+      allowed:
+        - IPProtocol: tcp
+          ports:
+            - "22"
+```
+
+**Detection regex:** `sourceRanges:[^}]*0\.0\.0\.0/0`
+**Severity:** error
+
+## KMS: Key Rotation and Access
+
+### Missing KMS Key Rotation
+
+```hcl
+// VULNERABLE: Crypto key without rotation period
+resource "google_kms_crypto_key" "data" {
+  name     = "data-key"
+  key_ring = google_kms_key_ring.ring.id
+}
+
+// SECURE: Crypto key with 90-day rotation
+resource "google_kms_crypto_key" "data" {
+  name            = "data-key"
+  key_ring        = google_kms_key_ring.ring.id
+  rotation_period = "7776000s"
+}
+```
+
+**Detection regex:** `resource\s+"google_kms_crypto_key"\s+"[^"]+"\s*\{(?![^}]*rotation_period)`
+**Severity:** warning
+
+### Overly Permissive IAM on KMS Keys
+
+```hcl
+// VULNERABLE: allUsers can decrypt with this key
+resource "google_kms_crypto_key_iam_member" "public_decrypt" {
+  crypto_key_id = google_kms_crypto_key.data.id
+  role          = "roles/cloudkms.cryptoKeyDecrypter"
+  member        = "allUsers"
+}
+
+// SECURE: Only specific service account can decrypt
+resource "google_kms_crypto_key_iam_member" "decrypt" {
+  crypto_key_id = google_kms_crypto_key.data.id
+  role          = "roles/cloudkms.cryptoKeyDecrypter"
+  member        = "serviceAccount:app@my-project.iam.gserviceaccount.com"
+}
+```
+
+**Detection regex:** `google_kms_crypto_key_iam[^}]*(allUsers|allAuthenticatedUsers)`
+**Severity:** error
+
+### KMS Key Destroy Scheduled Duration Too Short
+
+```hcl
+// VULNERABLE: Key can be destroyed with only 1 day wait
+resource "google_kms_crypto_key" "data" {
+  name                       = "data-key"
+  key_ring                   = google_kms_key_ring.ring.id
+  destroy_scheduled_duration = "86400s"
+}
+
+// SECURE: 30-day scheduled destruction duration
+resource "google_kms_crypto_key" "data" {
+  name                       = "data-key"
+  key_ring                   = google_kms_key_ring.ring.id
+  destroy_scheduled_duration = "2592000s"
+  rotation_period            = "7776000s"
+}
+```
+
+**Detection regex:** `destroy_scheduled_duration\s*=\s*"86400s"`
+**Severity:** warning
+
+## Audit Logs: Data Access Logging
+
+### Data Access Logging Disabled
+
+```hcl
+// VULNERABLE: Data access audit logging not configured
+resource "google_project_iam_audit_config" "minimal" {
+  project = "my-project"
+  service = "allServices"
+  audit_log_config {
+    log_type = "ADMIN_READ"
+  }
+}
+
+// SECURE: Full data access audit logging enabled
+resource "google_project_iam_audit_config" "full" {
+  project = "my-project"
+  service = "allServices"
+  audit_log_config {
+    log_type = "ADMIN_READ"
+  }
+  audit_log_config {
+    log_type = "DATA_READ"
+  }
+  audit_log_config {
+    log_type = "DATA_WRITE"
+  }
+}
+```
+
+**Detection regex:** `google_project_iam_audit_config[^}]*ADMIN_READ(?![^}]*(DATA_READ|DATA_WRITE))`
+**Severity:** warning
+
+### Missing Audit Config for Critical Services
+
+```hcl
+// VULNERABLE: No audit logging configured at all
+// (absence of google_project_iam_audit_config resource)
+
+// SECURE: Audit logging for all services
+resource "google_project_iam_audit_config" "all_services" {
+  project = "my-project"
+  service = "allServices"
+  audit_log_config {
+    log_type = "ADMIN_READ"
+  }
+  audit_log_config {
+    log_type = "DATA_READ"
+  }
+  audit_log_config {
+    log_type = "DATA_WRITE"
+  }
+}
+```
+
+**Detection regex:** `google_project_iam_audit_config`
+**Severity:** warning
+
+### Audit Log Exemptions for Users
+
+```hcl
+// VULNERABLE: Exempting users from audit logging
+resource "google_project_iam_audit_config" "exempted" {
+  project = "my-project"
+  service = "allServices"
+  audit_log_config {
+    log_type = "DATA_READ"
+    exempted_members = [
+      "user:admin@example.com",
+    ]
+  }
+}
+
+// SECURE: No exemptions — all access is logged
+resource "google_project_iam_audit_config" "full" {
+  project = "my-project"
+  service = "allServices"
+  audit_log_config {
+    log_type = "DATA_READ"
+  }
+}
+```
+
+**Detection regex:** `exempted_members\s*=\s*\[`
+**Severity:** warning
+
+## Cloud SQL: Public Access
+
+### Cloud SQL Public IP
+
+```hcl
+// VULNERABLE: Cloud SQL with public IP enabled
+resource "google_sql_database_instance" "main" {
+  name             = "main-db"
+  database_version = "POSTGRES_15"
+  settings {
+    tier = "db-f1-micro"
+    ip_configuration {
+      ipv4_enabled = true
+      authorized_networks {
+        value = "0.0.0.0/0"
+        name  = "all"
+      }
+    }
+  }
+}
+
+// SECURE: Private IP only, accessed via Cloud SQL Proxy
+resource "google_sql_database_instance" "main" {
+  name             = "main-db"
+  database_version = "POSTGRES_15"
+  settings {
+    tier = "db-f1-micro"
+    ip_configuration {
+      ipv4_enabled    = false
+      private_network = google_compute_network.vpc.id
+    }
+  }
+}
+```
+
+**Detection regex:** `authorized_networks[^}]*0\.0\.0\.0/0|ipv4_enabled\s*=\s*true`
+**Severity:** error
+
+### Cloud SQL Missing Encryption
+
+```hcl
+// VULNERABLE: Database without CMEK encryption
+resource "google_sql_database_instance" "main" {
+  name             = "main-db"
+  database_version = "MYSQL_8_0"
+  settings {
+    tier = "db-f1-micro"
+  }
+}
+
+// SECURE: Database with CMEK
+resource "google_sql_database_instance" "main" {
+  name               = "main-db"
+  database_version   = "MYSQL_8_0"
+  encryption_key_name = google_kms_crypto_key.sql.id
+  settings {
+    tier = "db-f1-micro"
+  }
+}
+```
+
+**Detection regex:** `resource\s+"google_sql_database_instance"\s+"[^"]+"\s*\{(?![^}]*encryption_key_name)`
+**Severity:** warning
+
+### Cloud SQL Backup Not Enabled
+
+```hcl
+// VULNERABLE: Backups not enabled
+resource "google_sql_database_instance" "main" {
+  name             = "main-db"
+  database_version = "POSTGRES_15"
+  settings {
+    tier = "db-f1-micro"
+    backup_configuration {
+      enabled = false
+    }
+  }
+}
+
+// SECURE: Automated backups with PITR
+resource "google_sql_database_instance" "main" {
+  name             = "main-db"
+  database_version = "POSTGRES_15"
+  settings {
+    tier = "db-f1-micro"
+    backup_configuration {
+      enabled                        = true
+      point_in_time_recovery_enabled = true
+    }
+  }
+}
+```
+
+**Detection regex:** `backup_configuration\s*\{[^}]*enabled\s*=\s*false`
+**Severity:** warning
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| Primitive roles on projects (SA-GCP-01) | Critical | Immediate | Medium |
+| Service account key files (SA-GCP-02) | High | 1 week | High |
+| allUsers/allAuthenticatedUsers (SA-GCP-03) | Critical | Immediate | Low |
+| Public storage bucket (SA-GCP-04) | Critical | Immediate | Low |
+| Missing CMEK on storage (SA-GCP-05) | Medium | 1 month | Medium |
+| Cloud Functions env secrets (SA-GCP-06) | Critical | Immediate | Medium |
+| Public Cloud Functions invoker (SA-GCP-07) | Critical | Immediate | Low |
+| Open VPC firewall rules (SA-GCP-08) | Critical | Immediate | Low |
+| Missing KMS key rotation (SA-GCP-09) | Medium | 1 month | Low |
+| Audit logging gaps (SA-GCP-10) | High | 1 week | Low |
+| Cloud SQL public access (SA-GCP-11) | Critical | Immediate | Medium |
+| Cloud SQL backup disabled (SA-GCP-12) | High | 1 week | Low |
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `iac-security.md` — Infrastructure-as-Code security patterns
+- `cryptography-guide.md` — Encryption and key management
+- `security-logging.md` — Logging and monitoring patterns
+- `api-key-encryption.md` — API key and secrets management
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Cloud security references |

--- a/skills/security-audit/references/iac-security.md
+++ b/skills/security-audit/references/iac-security.md
@@ -50,16 +50,31 @@ CMD ["python", "app.py"]
 
 ### Detection Patterns
 
-```
-# Dockerfiles missing USER directive (any Dockerfile without USER before CMD/ENTRYPOINT)
-# Regex: Dockerfile without any USER line
-^FROM\s.*(?!.*USER\s)
+A pure line-based regex cannot reliably detect "no USER directive anywhere in the file" because that is a whole-file property. Prefer whole-file checks:
+
+```bash
+# Dockerfiles missing USER directive — flag any Dockerfile that never declares USER.
+# Run per file; exit status 1 (no match) means USER is missing.
+for f in $(find . -name 'Dockerfile*' -type f); do
+  grep -qE '^\s*USER\b' "$f" || echo "MISSING USER: $f"
+done
 
 # Explicit root user
-USER\s+root
+grep -rnE '^\s*USER[[:space:]]+root\b' --include='Dockerfile*' .
 
-# USER directive appearing only after CMD/ENTRYPOINT (too late)
-(CMD|ENTRYPOINT)\s.*\nUSER\s
+# USER appearing after the last CMD/ENTRYPOINT (too late to apply).
+# Use awk so we can reason line-by-line across the whole file.
+awk '
+  /^[[:space:]]*(CMD|ENTRYPOINT)\b/ { last_exec = NR }
+  /^[[:space:]]*USER\b/              { last_user = NR }
+  END { if (last_exec && last_user && last_user > last_exec) print FILENAME": USER after CMD/ENTRYPOINT" }
+' Dockerfile*
+```
+
+If you use a PCRE-capable scanner (`grep -P`, ripgrep, Semgrep), an equivalent whole-file negative-lookahead is:
+
+```
+(?ms)\A(?!.*^\s*USER\b).*^\s*FROM\b.*\z
 ```
 
 ### Secrets in Image Layers
@@ -194,10 +209,10 @@ COPY app/ /app/
 ```
 
 ```dockerfile
-# SECURE: If you need to download a remote file, use RUN with checksum verification
+# SECURE: If you need to download a remote file, use RUN with checksum verification (SHA-256)
 FROM alpine:3.19
 RUN wget -O /tmp/app.tar.gz https://example.com/app.tar.gz && \
-    echo "e3b0c44298fc1c149afbf4c8996fb924  /tmp/app.tar.gz" | md5sum -c - && \
+    echo "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  /tmp/app.tar.gz" | sha256sum -c - && \
     tar -xzf /tmp/app.tar.gz -C /app/ && \
     rm /tmp/app.tar.gz
 ```
@@ -1219,15 +1234,18 @@ resource "aws_cloudwatch_log_group" "vpc_flow" {
 
 ### Detection Patterns
 
-```
-# VPC without flow logs (presence of aws_vpc without corresponding aws_flow_log)
-resource\s+"aws_vpc"
+```bash
+# VPC without flow logs — inventory aws_vpc and aws_flow_log, flag any VPC without
+# a matching aws_flow_log pointing at it. A simple resource-name regex cannot
+# decide this on its own, because flow logs live in a separate resource.
+# Use a policy tool (Checkov CKV_AWS_11, tfsec aws-vpc-no-public-egress-sgr,
+# Terrascan AC_AWS_0059) or a module inventory instead.
 
 # CloudTrail missing log file validation
-enable_log_file_validation\s*=\s*false
+grep -rnE 'enable_log_file_validation[[:space:]]*=[[:space:]]*false' --include='*.tf' .
 
 # CloudTrail not multi-region
-is_multi_region_trail\s*=\s*false
+grep -rnE 'is_multi_region_trail[[:space:]]*=[[:space:]]*false' --include='*.tf' .
 ```
 
 ### Hardcoded Credentials in .tf Files

--- a/skills/security-audit/references/iac-security.md
+++ b/skills/security-audit/references/iac-security.md
@@ -1,0 +1,1395 @@
+# Infrastructure-as-Code Security
+
+Infrastructure-as-Code (IaC) defines cloud and container infrastructure in version-controlled configuration files. Security misconfigurations in these files are deployed automatically and at scale, making IaC a critical audit surface. This reference covers Dockerfiles, Docker Compose, Kubernetes manifests, and Terraform configurations.
+
+---
+
+## Dockerfile Security
+
+### Running as Root
+
+By default, Docker containers run as `root` (UID 0). If an attacker escapes the application but remains inside the container, they have full root privileges, making further exploitation and container escape significantly easier.
+
+```dockerfile
+# VULNERABLE: No USER directive — container runs as root
+FROM python:3.12-slim
+WORKDIR /app
+COPY . .
+RUN pip install --no-cache-dir -r requirements.txt
+EXPOSE 8000
+CMD ["python", "app.py"]
+```
+
+```dockerfile
+# VULNERABLE: Explicit USER root
+FROM python:3.12-slim
+WORKDIR /app
+COPY . .
+RUN pip install --no-cache-dir -r requirements.txt
+USER root
+EXPOSE 8000
+CMD ["python", "app.py"]
+```
+
+```dockerfile
+# SECURE: Create a non-root user and switch to it
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Create non-root user with specific UID/GID
+RUN groupadd --gid 1001 appgroup && \
+    useradd --uid 1001 --gid appgroup --shell /bin/false --create-home appuser
+
+COPY --chown=appuser:appgroup . .
+USER appuser
+EXPOSE 8000
+CMD ["python", "app.py"]
+```
+
+### Detection Patterns
+
+```
+# Dockerfiles missing USER directive (any Dockerfile without USER before CMD/ENTRYPOINT)
+# Regex: Dockerfile without any USER line
+^FROM\s.*(?!.*USER\s)
+
+# Explicit root user
+USER\s+root
+
+# USER directive appearing only after CMD/ENTRYPOINT (too late)
+(CMD|ENTRYPOINT)\s.*\nUSER\s
+```
+
+### Secrets in Image Layers
+
+Every `COPY`, `ADD`, `RUN`, and `ARG` instruction creates a layer that persists in the image history. Secrets placed into layers can be extracted even if a later layer deletes them.
+
+```dockerfile
+# VULNERABLE: Copying .env file into the image
+FROM node:20-alpine
+WORKDIR /app
+COPY . .
+# .env with DB_PASSWORD, API_KEY, etc. is now baked into a layer
+RUN npm install
+CMD ["node", "server.js"]
+```
+
+```dockerfile
+# VULNERABLE: Build argument containing a secret
+FROM node:20-alpine
+ARG DATABASE_PASSWORD
+# ARG values are visible in `docker history`
+ENV DB_PASS=${DATABASE_PASSWORD}
+WORKDIR /app
+COPY . .
+RUN npm install
+CMD ["node", "server.js"]
+```
+
+```dockerfile
+# VULNERABLE: Secret in RUN command
+FROM alpine:3.19
+RUN curl -H "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.secret-token" \
+    https://api.example.com/config > /app/config.json
+```
+
+```dockerfile
+# SECURE: Use BuildKit secret mounts (secrets never persist in layers)
+# syntax=docker/dockerfile:1
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --production
+COPY . .
+
+# Mount secret at build time — it is available only during this RUN step
+# and is never written to any image layer
+RUN --mount=type=secret,id=db_password \
+    DB_PASS=$(cat /run/secrets/db_password) && \
+    node setup-db.js
+
+CMD ["node", "server.js"]
+# Build with: docker buildx build --secret id=db_password,src=./db_password.txt .
+```
+
+```dockerfile
+# SECURE: Use .dockerignore to prevent secrets from entering the build context
+# .dockerignore
+.env
+.env.*
+*.pem
+*.key
+credentials.json
+secrets/
+```
+
+### Detection Patterns
+
+```
+# .env file copied into image
+COPY\s+.*\.env
+ADD\s+.*\.env
+
+# Secrets in ARG instructions
+ARG\s+(PASSWORD|SECRET|TOKEN|API_KEY|PRIVATE_KEY|CREDENTIALS)
+
+# Secrets in RUN commands
+RUN\s.*curl\s.*(-H\s+["']Authorization:|--header\s.*Bearer)
+RUN\s.*(PASSWORD|SECRET|TOKEN|API_KEY)=
+```
+
+### Unsigned and Unversioned Base Images
+
+Using a bare image name without a tag or digest means Docker pulls `latest`, which is mutable. An attacker who compromises the registry can push a malicious `latest` tag, or a legitimate update may introduce breaking changes or new vulnerabilities.
+
+```dockerfile
+# VULNERABLE: No tag — implicitly pulls :latest, which is mutable
+FROM ubuntu
+FROM python
+FROM node
+```
+
+```dockerfile
+# BETTER: Pinned to a specific version tag
+FROM ubuntu:24.04
+FROM python:3.12-slim
+FROM node:20-alpine
+```
+
+```dockerfile
+# SECURE: Pinned to an immutable content-addressable digest
+FROM python:3.12-slim@sha256:1a2b3c4d5e6f7890abcdef1234567890abcdef1234567890abcdef1234567890
+```
+
+### Detection Patterns
+
+```
+# Base image without tag or digest
+^FROM\s+[a-z][a-z0-9._-]+(/[a-z][a-z0-9._-]+)?\s*$
+
+# Base image using :latest explicitly
+^FROM\s+\S+:latest
+```
+
+### ADD vs COPY Security Implications
+
+`ADD` has two capabilities beyond `COPY`: it can fetch remote URLs and auto-extract compressed archives (tar, gzip, bzip2, xz). These features expand the attack surface.
+
+- **Remote URL fetching**: `ADD` downloads files without checksum verification, enabling man-in-the-middle attacks.
+- **Auto-extraction**: Maliciously crafted tar archives can exploit path traversal (e.g., `../../etc/passwd`) or zip bombs.
+
+```dockerfile
+# VULNERABLE: ADD fetches a remote URL with no integrity verification
+FROM alpine:3.19
+ADD https://example.com/app.tar.gz /app/
+RUN cd /app && tar -xzf app.tar.gz
+```
+
+```dockerfile
+# SECURE: Use COPY for local files (no auto-extraction, no remote fetch)
+FROM alpine:3.19
+COPY app/ /app/
+```
+
+```dockerfile
+# SECURE: If you need to download a remote file, use RUN with checksum verification
+FROM alpine:3.19
+RUN wget -O /tmp/app.tar.gz https://example.com/app.tar.gz && \
+    echo "e3b0c44298fc1c149afbf4c8996fb924  /tmp/app.tar.gz" | md5sum -c - && \
+    tar -xzf /tmp/app.tar.gz -C /app/ && \
+    rm /tmp/app.tar.gz
+```
+
+### Detection Patterns
+
+```
+# ADD instruction (flag for review, prefer COPY)
+^ADD\s
+
+# ADD fetching remote URL
+^ADD\s+https?://
+```
+
+### Multi-Stage Build Best Practices
+
+Multi-stage builds allow you to use full build toolchains in earlier stages, then copy only the compiled artifacts into a minimal final image. This reduces the attack surface by excluding compilers, package managers, source code, and build-time secrets from the production image.
+
+```dockerfile
+# VULNERABLE: Single-stage build includes build tools, source, and dev dependencies
+FROM node:20
+WORKDIR /app
+COPY . .
+RUN npm install
+RUN npm run build
+EXPOSE 3000
+CMD ["node", "dist/server.js"]
+# Final image contains: npm, node_modules (dev+prod), source code, build tools
+```
+
+```dockerfile
+# SECURE: Multi-stage build — final image contains only production artifacts
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS production
+WORKDIR /app
+# Copy only production dependencies and compiled output
+COPY --from=builder /app/package*.json ./
+RUN npm ci --production && npm cache clean --force
+COPY --from=builder /app/dist ./dist
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+USER appuser
+EXPOSE 3000
+CMD ["node", "dist/server.js"]
+# Final image contains: node runtime, production node_modules, compiled dist/ only
+```
+
+---
+
+## Docker Compose Security
+
+### Privileged Containers
+
+The `privileged: true` flag disables almost all container isolation. A privileged container has full access to the host's devices, can load kernel modules, and can trivially escape to the host.
+
+```yaml
+# VULNERABLE: privileged grants near-full host access
+version: "3.9"
+services:
+  app:
+    image: myapp:latest
+    privileged: true
+    ports:
+      - "8080:8080"
+```
+
+```yaml
+# SECURE: Drop all capabilities and add back only what is needed
+version: "3.9"
+services:
+  app:
+    image: myapp:latest
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE  # Only if binding to ports < 1024
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    ports:
+      - "8080:8080"
+```
+
+### Detection Patterns
+
+```
+# Privileged flag
+privileged:\s*true
+
+# Dangerous capabilities
+cap_add:.*SYS_ADMIN
+cap_add:.*SYS_PTRACE
+cap_add:.*ALL
+```
+
+### Sensitive Host Mounts
+
+Mounting the Docker socket or sensitive host directories into a container allows full host compromise from within the container.
+
+```yaml
+# VULNERABLE: Docker socket mount — container can control the Docker daemon
+version: "3.9"
+services:
+  monitoring:
+    image: monitoring-tool:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  # VULNERABLE: Host root filesystem mounted
+  backup:
+    image: backup-tool:latest
+    volumes:
+      - /:/host-root
+
+  # VULNERABLE: Host /etc mounted — container can modify host config
+  config-editor:
+    image: config-tool:latest
+    volumes:
+      - /etc:/host-etc
+```
+
+```yaml
+# SECURE: Mount only the specific directories needed, read-only where possible
+version: "3.9"
+services:
+  app:
+    image: myapp:latest
+    volumes:
+      - app-data:/app/data              # Named volume (managed by Docker)
+      - ./config/app.conf:/app/app.conf:ro  # Single config file, read-only
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /var/run
+
+volumes:
+  app-data:
+```
+
+### Detection Patterns
+
+```
+# Docker socket mount
+/var/run/docker\.sock
+
+# Root filesystem mount
+volumes:.*[:-]\s*/:/
+
+# Sensitive directory mounts
+volumes:.*[:-]\s*/etc[:/]
+volumes:.*[:-]\s*/proc[:/]
+volumes:.*[:-]\s*/sys[:/]
+volumes:.*[:-]\s*/dev[:/]
+```
+
+### Unnecessary Port Exposure
+
+`ports:` publishes a port on the host interface, making it reachable from the network. `expose:` only makes a port available to linked services within the Docker network.
+
+```yaml
+# VULNERABLE: Database port published to host — accessible from network
+version: "3.9"
+services:
+  app:
+    image: myapp:latest
+    ports:
+      - "8080:8080"  # Intended: public-facing app
+
+  db:
+    image: postgres:16
+    ports:
+      - "5432:5432"  # VULNERABLE: Database directly reachable from network
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"  # VULNERABLE: Cache reachable from network (no auth by default)
+```
+
+```yaml
+# SECURE: Only expose what must be publicly reachable
+version: "3.9"
+services:
+  app:
+    image: myapp:latest
+    ports:
+      - "127.0.0.1:8080:8080"  # Bind to localhost only if behind reverse proxy
+    networks:
+      - frontend
+      - backend
+
+  db:
+    image: postgres:16
+    expose:
+      - "5432"  # Only reachable within Docker network
+    networks:
+      - backend
+
+  redis:
+    image: redis:7
+    expose:
+      - "6379"  # Only reachable within Docker network
+    networks:
+      - backend
+
+networks:
+  frontend:
+  backend:
+    internal: true  # No external access at all
+```
+
+### Detection Patterns
+
+```
+# Database ports published to host
+ports:.*5432
+ports:.*3306
+ports:.*27017
+ports:.*6379
+
+# Port bound to all interfaces (0.0.0.0, or missing host binding)
+ports:\s*-\s*"?\d+:\d+"?
+# vs safe: ports: - "127.0.0.1:8080:8080"
+```
+
+### Missing Resource Limits
+
+Without resource limits, a compromised or misbehaving container can consume all host CPU and memory, causing denial of service to other containers and the host itself.
+
+```yaml
+# VULNERABLE: No resource limits
+version: "3.9"
+services:
+  app:
+    image: myapp:latest
+```
+
+```yaml
+# SECURE: Resource limits configured
+version: "3.9"
+services:
+  app:
+    image: myapp:latest
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 512M
+        reservations:
+          cpus: "0.25"
+          memory: 128M
+    # For docker-compose v2 compatibility:
+    mem_limit: 512m
+    cpus: 1.0
+```
+
+### Environment Variable Secrets in Plaintext
+
+Secrets defined directly in `docker-compose.yml` or `.env` files checked into version control are visible to anyone with repository access.
+
+```yaml
+# VULNERABLE: Plaintext secrets in compose file
+version: "3.9"
+services:
+  app:
+    image: myapp:latest
+    environment:
+      - DATABASE_PASSWORD=SuperSecret123!
+      - API_KEY=sk-live-abc123def456
+      - JWT_SECRET=my-jwt-signing-key
+```
+
+```yaml
+# SECURE: Use Docker secrets (Swarm mode) or external secret management
+version: "3.9"
+services:
+  app:
+    image: myapp:latest
+    environment:
+      - DATABASE_HOST=db
+      - DATABASE_NAME=myapp
+    secrets:
+      - db_password
+      - api_key
+
+secrets:
+  db_password:
+    external: true   # Managed outside of compose, e.g., via `docker secret create`
+  api_key:
+    external: true
+```
+
+### Detection Patterns
+
+```
+# Plaintext secrets in environment
+environment:.*PASSWORD=
+environment:.*SECRET=
+environment:.*API_KEY=
+environment:.*TOKEN=
+environment:.*PRIVATE_KEY=
+
+# Inline secret values
+environment:\s*-\s*(PASSWORD|SECRET|API_KEY|TOKEN)\s*=\s*\S+
+```
+
+---
+
+## Kubernetes Security
+
+### Overly Permissive RBAC
+
+Kubernetes Role-Based Access Control (RBAC) restricts what users and service accounts can do. Overly broad roles, especially `cluster-admin` bindings and wildcard permissions, allow any compromised workload to take over the entire cluster.
+
+```yaml
+# VULNERABLE: Binding a service account to cluster-admin
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: app-admin-binding
+subjects:
+  - kind: ServiceAccount
+    name: app-sa
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin    # Full unrestricted cluster access
+  apiGroup: rbac.authorization.k8s.io
+```
+
+```yaml
+# VULNERABLE: Wildcard verbs and resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: overly-permissive
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]         # Can do anything to any resource in any API group
+```
+
+```yaml
+# SECURE: Least-privilege Role scoped to a specific namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: app-role
+  namespace: myapp
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list"]
+    resourceNames: ["app-config"]   # Restrict to specific named resources
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: app-rolebinding
+  namespace: myapp
+subjects:
+  - kind: ServiceAccount
+    name: app-sa
+    namespace: myapp
+roleRef:
+  kind: Role
+  name: app-role
+  apiGroup: rbac.authorization.k8s.io
+```
+
+### Detection Patterns
+
+```
+# ClusterRoleBinding to cluster-admin
+kind:\s*ClusterRoleBinding[\s\S]*?name:\s*cluster-admin
+
+# Wildcard permissions
+verbs:\s*\[?"?\*"?\]?
+resources:\s*\[?"?\*"?\]?
+apiGroups:\s*\[?"?\*"?\]?
+```
+
+### Missing NetworkPolicy
+
+By default, all pods in a Kubernetes cluster can communicate with all other pods across all namespaces. Without NetworkPolicy, a compromised pod can probe, attack, and pivot to any other workload in the cluster.
+
+```yaml
+# VULNERABLE (by omission): No NetworkPolicy exists
+# All pods can reach all other pods on all ports across all namespaces
+# — there is no manifest to show; the absence IS the vulnerability
+```
+
+```yaml
+# SECURE: Default-deny ingress policy — pods must be explicitly allowed
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: myapp
+spec:
+  podSelector: {}   # Applies to all pods in the namespace
+  policyTypes:
+    - Ingress
+    # No ingress rules = deny all inbound traffic
+---
+# SECURE: Allow only specific traffic
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-frontend-to-backend
+  namespace: myapp
+spec:
+  podSelector:
+    matchLabels:
+      app: backend
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: frontend
+      ports:
+        - protocol: TCP
+          port: 8080
+---
+# SECURE: Default-deny egress — prevent data exfiltration
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+  namespace: myapp
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+    # No egress rules = deny all outbound traffic
+```
+
+### Pod Security
+
+Pods should run as non-root, with a read-only root filesystem, and with explicit security contexts. Missing security contexts leave containers with default (often overly permissive) settings.
+
+```yaml
+# VULNERABLE: Running as root with no security context
+apiVersion: v1
+kind: Pod
+metadata:
+  name: insecure-pod
+spec:
+  containers:
+    - name: app
+      image: myapp:latest
+# No securityContext at all — container runs as root by default
+```
+
+```yaml
+# VULNERABLE: Explicitly running as root with dangerous settings
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dangerous-pod
+spec:
+  containers:
+    - name: app
+      image: myapp:latest
+      securityContext:
+        runAsUser: 0                    # Root
+        privileged: true                # Full host access
+        allowPrivilegeEscalation: true  # Can gain additional privileges
+```
+
+```yaml
+# SECURE: Hardened pod security context
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secure-pod
+spec:
+  securityContext:
+    runAsNonRoot: true          # Fail if image tries to run as UID 0
+    runAsUser: 1001
+    runAsGroup: 1001
+    fsGroup: 1001
+    seccompProfile:
+      type: RuntimeDefault      # Apply default seccomp filtering
+  containers:
+    - name: app
+      image: myapp:latest
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true   # Prevent writes to container filesystem
+        capabilities:
+          drop:
+            - ALL                       # Drop all Linux capabilities
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: cache
+          mountPath: /app/cache
+  volumes:
+    - name: tmp
+      emptyDir: {}
+    - name: cache
+      emptyDir: {}
+```
+
+### Detection Patterns
+
+```
+# Running as root
+runAsUser:\s*0
+
+# Missing runAsNonRoot
+# (Absence of runAsNonRoot in a pod spec is the vulnerability)
+
+# Privileged container
+privileged:\s*true
+
+# Privilege escalation allowed
+allowPrivilegeEscalation:\s*true
+```
+
+### Host Namespace Sharing
+
+`hostNetwork`, `hostPID`, and `hostIPC` break container isolation by sharing the host's network stack, process tree, or inter-process communication namespace with the container.
+
+```yaml
+# VULNERABLE: Host namespace sharing
+apiVersion: v1
+kind: Pod
+metadata:
+  name: host-namespace-pod
+spec:
+  hostNetwork: true   # Pod shares the host's network — can bind to host ports,
+                       # see all host network traffic, access localhost services
+  hostPID: true        # Pod can see all host processes — enables ptrace attacks,
+                       # signals to host processes, /proc filesystem access
+  hostIPC: true        # Pod shares host IPC namespace — can access host shared memory
+  containers:
+    - name: app
+      image: myapp:latest
+```
+
+```yaml
+# SECURE: No host namespace sharing (these are the defaults, shown for clarity)
+apiVersion: v1
+kind: Pod
+metadata:
+  name: isolated-pod
+spec:
+  hostNetwork: false
+  hostPID: false
+  hostIPC: false
+  containers:
+    - name: app
+      image: myapp:latest
+      securityContext:
+        runAsNonRoot: true
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+```
+
+### Detection Patterns
+
+```
+# Host namespace sharing
+hostNetwork:\s*true
+hostPID:\s*true
+hostIPC:\s*true
+```
+
+### Missing Resource Requests and Limits
+
+Without resource requests and limits, a single pod can consume all available node resources, starving other workloads (noisy neighbor problem) or enabling denial-of-service attacks.
+
+```yaml
+# VULNERABLE: No resource constraints
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      labels:
+        app: myapp
+    spec:
+      containers:
+        - name: app
+          image: myapp:latest
+          # No resources block — unbounded CPU and memory usage
+```
+
+```yaml
+# SECURE: Resource requests and limits defined
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      labels:
+        app: myapp
+    spec:
+      containers:
+        - name: app
+          image: myapp:latest
+          resources:
+            requests:
+              cpu: "100m"       # Guaranteed minimum
+              memory: "128Mi"
+            limits:
+              cpu: "500m"       # Hard ceiling
+              memory: "256Mi"   # OOMKilled if exceeded
+```
+
+### Secrets in Plaintext
+
+Kubernetes Secrets are base64-encoded, not encrypted. Anyone with access to the etcd datastore or the API server can read them. Use external secret management or sealed-secrets for production.
+
+```yaml
+# VULNERABLE: Secret with base64-encoded values (trivially decodable)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secrets
+type: Opaque
+data:
+  db-password: c3VwZXJTZWNyZXQxMjM=    # echo -n 'superSecret123' | base64
+  api-key: c2stbGl2ZS1hYmMxMjM=         # echo -n 'sk-live-abc123' | base64
+```
+
+```yaml
+# VULNERABLE: Secret values hardcoded in pod spec
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app
+spec:
+  containers:
+    - name: app
+      image: myapp:latest
+      env:
+        - name: DB_PASSWORD
+          value: "superSecret123"   # Plaintext in the manifest
+```
+
+```yaml
+# SECURE: Use external-secrets-operator to sync from a vault
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: app-secrets
+  namespace: myapp
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: app-secrets
+  data:
+    - secretKey: db-password
+      remoteRef:
+        key: myapp/production/db-password
+    - secretKey: api-key
+      remoteRef:
+        key: myapp/production/api-key
+```
+
+```yaml
+# SECURE: Use sealed-secrets (encrypted, safe to store in Git)
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: app-secrets
+  namespace: myapp
+spec:
+  encryptedData:
+    db-password: AgBy8hCi...encrypted...==
+    api-key: AgCtr4Qp...encrypted...==
+```
+
+### Detection Patterns
+
+```
+# Hardcoded secret values in pod specs
+env:[\s\S]*?name:\s*(PASSWORD|SECRET|API_KEY|TOKEN)[\s\S]*?value:\s*"[^"]+
+
+# Base64-encoded secrets in Secret manifests (all k8s Secrets use this, flag for review)
+kind:\s*Secret[\s\S]*?data:[\s\S]*?:\s*[A-Za-z0-9+/]+=*
+
+# Secrets not using external-secrets or sealed-secrets
+kind:\s*Secret[\s\S]*?type:\s*Opaque
+```
+
+---
+
+## Terraform Security
+
+### Public S3 Buckets
+
+S3 buckets with public ACLs or policies expose data to the internet. This is one of the most common causes of large-scale data breaches in cloud environments.
+
+```hcl
+# VULNERABLE: Public ACL on S3 bucket
+resource "aws_s3_bucket" "data" {
+  bucket = "my-company-data"
+}
+
+resource "aws_s3_bucket_acl" "data" {
+  bucket = aws_s3_bucket.data.id
+  acl    = "public-read"    # Anyone on the internet can read bucket contents
+}
+```
+
+```hcl
+# VULNERABLE: Bucket policy allowing public access
+resource "aws_s3_bucket_policy" "public" {
+  bucket = aws_s3_bucket.data.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "PublicRead"
+        Effect    = "Allow"
+        Principal = "*"          # Any AWS principal, including anonymous
+        Action    = "s3:GetObject"
+        Resource  = "${aws_s3_bucket.data.arn}/*"
+      }
+    ]
+  })
+}
+```
+
+```hcl
+# SECURE: Private bucket with public access block
+resource "aws_s3_bucket" "data" {
+  bucket = "my-company-data"
+}
+
+resource "aws_s3_bucket_public_access_block" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.s3.arn
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "data" {
+  bucket = aws_s3_bucket.data.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+```
+
+### Detection Patterns
+
+```
+# Public S3 ACLs
+acl\s*=\s*"public-read"
+acl\s*=\s*"public-read-write"
+
+# Wildcard principal in bucket policies
+Principal\s*=\s*"\*"
+"Principal":\s*"\*"
+
+# Missing public access block (absence of aws_s3_bucket_public_access_block for each bucket)
+```
+
+### Security Groups with Open Ingress
+
+Security groups with `0.0.0.0/0` (all IPv4) or `::/0` (all IPv6) ingress rules expose services to the entire internet. This is especially dangerous for management ports like SSH (22), RDP (3389), and databases.
+
+```hcl
+# VULNERABLE: SSH open to the world
+resource "aws_security_group" "app" {
+  name        = "app-sg"
+  description = "Application security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]    # Any IP can SSH in
+  }
+
+  ingress {
+    description = "All traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]    # All ports open to all IPs
+  }
+}
+```
+
+```hcl
+# SECURE: Restrict ingress to known CIDR ranges and specific ports
+resource "aws_security_group" "app" {
+  name        = "app-sg"
+  description = "Application security group"
+  vpc_id      = aws_vpc.main.id
+
+  # No inline rules — use separate aws_security_group_rule resources
+  # for better modularity and audit trail
+}
+
+resource "aws_security_group_rule" "app_https" {
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.app.id
+  source_security_group_id = aws_security_group.alb.id  # Only from the load balancer
+}
+
+resource "aws_security_group_rule" "ssh_bastion" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  security_group_id = aws_security_group.app.id
+  cidr_blocks       = ["10.0.0.0/24"]   # Only from bastion subnet
+}
+```
+
+### Detection Patterns
+
+```
+# Open ingress to all IPs
+cidr_blocks\s*=\s*\[?"0\.0\.0\.0/0"
+ipv6_cidr_blocks\s*=\s*\[?"::/0"
+
+# All ports open
+from_port\s*=\s*0[\s\S]*?to_port\s*=\s*0[\s\S]*?protocol\s*=\s*"-1"
+
+# Sensitive ports open (SSH, RDP, databases)
+(from_port\s*=\s*(22|3389|3306|5432|27017|6379))[\s\S]*?cidr_blocks\s*=\s*\[?"0\.0\.0\.0/0"
+```
+
+### Unencrypted Storage and Databases
+
+Data at rest should always be encrypted. Unencrypted EBS volumes, RDS instances, and S3 buckets leave data exposed if storage media is compromised or improperly decommissioned.
+
+```hcl
+# VULNERABLE: Unencrypted RDS instance
+resource "aws_db_instance" "main" {
+  identifier     = "production-db"
+  engine         = "postgres"
+  engine_version = "16.1"
+  instance_class = "db.r6g.large"
+  allocated_storage = 100
+  # storage_encrypted not set — defaults to false
+  # no kms_key_id specified
+
+  username = "admin"
+  password = "hardcoded-password-123"   # Also a hardcoded credential
+}
+```
+
+```hcl
+# VULNERABLE: Unencrypted EBS volume
+resource "aws_ebs_volume" "data" {
+  availability_zone = "us-east-1a"
+  size              = 100
+  # encrypted not set — defaults to false
+}
+```
+
+```hcl
+# SECURE: Encrypted RDS with KMS
+resource "aws_db_instance" "main" {
+  identifier     = "production-db"
+  engine         = "postgres"
+  engine_version = "16.1"
+  instance_class = "db.r6g.large"
+  allocated_storage = 100
+
+  storage_encrypted = true
+  kms_key_id        = aws_kms_key.rds.arn
+
+  # Password from Secrets Manager, not hardcoded
+  username                    = "admin"
+  manage_master_user_password = true   # AWS manages the password in Secrets Manager
+
+  # Additional hardening
+  deletion_protection   = true
+  skip_final_snapshot   = false
+  multi_az              = true
+  backup_retention_period = 30
+  iam_database_authentication_enabled = true
+}
+
+# SECURE: Encrypted EBS with KMS
+resource "aws_ebs_volume" "data" {
+  availability_zone = "us-east-1a"
+  size              = 100
+  encrypted         = true
+  kms_key_id        = aws_kms_key.ebs.arn
+
+  tags = {
+    Name = "encrypted-data-volume"
+  }
+}
+```
+
+### Detection Patterns
+
+```
+# Unencrypted RDS
+resource\s+"aws_db_instance"(?![\s\S]*?storage_encrypted\s*=\s*true)
+
+# Unencrypted EBS
+resource\s+"aws_ebs_volume"(?![\s\S]*?encrypted\s*=\s*true)
+
+# Unencrypted S3
+# (Absence of aws_s3_bucket_server_side_encryption_configuration for each bucket)
+
+# Hardcoded passwords in Terraform
+password\s*=\s*"[^"]*"
+secret\s*=\s*"[^"]*"
+```
+
+### Missing Logging and Monitoring
+
+Without CloudTrail, VPC Flow Logs, and other monitoring, you have no visibility into who is accessing your infrastructure, making breach detection and forensic analysis impossible.
+
+```hcl
+# VULNERABLE: No CloudTrail configured
+# (Absence of aws_cloudtrail resource means no API audit logging)
+
+# VULNERABLE: VPC without flow logs
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+  # No flow logs — no visibility into network traffic
+}
+```
+
+```hcl
+# SECURE: CloudTrail with S3 logging and log file validation
+resource "aws_cloudtrail" "main" {
+  name                          = "main-trail"
+  s3_bucket_name                = aws_s3_bucket.cloudtrail.id
+  include_global_service_events = true
+  is_multi_region_trail         = true
+  enable_log_file_validation    = true    # Detect tampering with log files
+  kms_key_id                    = aws_kms_key.cloudtrail.arn
+
+  cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.cloudtrail.arn}:*"
+  cloud_watch_logs_role_arn  = aws_iam_role.cloudtrail_cw.arn
+
+  event_selector {
+    read_write_type           = "All"
+    include_management_events = true
+
+    data_resource {
+      type   = "AWS::S3::Object"
+      values = ["arn:aws:s3"]    # Log all S3 data events
+    }
+  }
+}
+
+# SECURE: VPC Flow Logs
+resource "aws_flow_log" "main" {
+  iam_role_arn    = aws_iam_role.flow_log.arn
+  log_destination = aws_cloudwatch_log_group.vpc_flow.arn
+  traffic_type    = "ALL"      # Log accepted AND rejected traffic
+  vpc_id          = aws_vpc.main.id
+
+  tags = {
+    Name = "vpc-flow-log"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "vpc_flow" {
+  name              = "/aws/vpc/flow-logs"
+  retention_in_days = 365    # Retain for compliance
+  kms_key_id        = aws_kms_key.logs.arn
+}
+```
+
+### Detection Patterns
+
+```
+# VPC without flow logs (presence of aws_vpc without corresponding aws_flow_log)
+resource\s+"aws_vpc"
+
+# CloudTrail missing log file validation
+enable_log_file_validation\s*=\s*false
+
+# CloudTrail not multi-region
+is_multi_region_trail\s*=\s*false
+```
+
+### Hardcoded Credentials in .tf Files
+
+Credentials hardcoded in Terraform files end up in state files, version control, and CI/CD logs. Terraform state often contains the plaintext values of all resources, including secrets.
+
+```hcl
+# VULNERABLE: Hardcoded AWS credentials
+provider "aws" {
+  region     = "us-east-1"
+  access_key = "AKIAIOSFODNN7EXAMPLE"
+  secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+}
+
+# VULNERABLE: Hardcoded database password
+resource "aws_db_instance" "main" {
+  username = "admin"
+  password = "ProductionP@ssw0rd!"
+}
+
+# VULNERABLE: Hardcoded API token in user_data
+resource "aws_instance" "web" {
+  ami           = "ami-0abcdef1234567890"
+  instance_type = "t3.micro"
+  user_data = <<-EOF
+    #!/bin/bash
+    export API_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    export DD_API_KEY="abcdef1234567890abcdef1234567890"
+  EOF
+}
+```
+
+```hcl
+# SECURE: Use environment variables or IAM roles for provider auth
+provider "aws" {
+  region = "us-east-1"
+  # Credentials from environment variables, instance profile, or SSO
+  # AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY set in CI/CD environment
+  # Or use assume_role for cross-account access
+  assume_role {
+    role_arn = "arn:aws:iam::123456789012:role/TerraformDeployRole"
+  }
+}
+
+# SECURE: Use variables with sensitive flag (never in .tf files directly)
+variable "db_password" {
+  type      = string
+  sensitive = true   # Prevents display in plan/apply output
+  # Value provided via TF_VAR_db_password env var or .tfvars (not in VCS)
+}
+
+resource "aws_db_instance" "main" {
+  username = "admin"
+  password = var.db_password
+}
+
+# SECURE: Use AWS Secrets Manager data source
+data "aws_secretsmanager_secret_version" "api_token" {
+  secret_id = "myapp/api-token"
+}
+
+resource "aws_instance" "web" {
+  ami           = "ami-0abcdef1234567890"
+  instance_type = "t3.micro"
+  user_data = templatefile("${path.module}/user_data.sh.tpl", {
+    api_token = data.aws_secretsmanager_secret_version.api_token.secret_string
+  })
+}
+```
+
+### Detection Patterns
+
+```
+# AWS access keys hardcoded
+access_key\s*=\s*"AKIA[A-Z0-9]{16}"
+secret_key\s*=\s*"[A-Za-z0-9/+=]{40}"
+
+# Generic hardcoded credentials
+password\s*=\s*"[^"]{4,}"
+secret\s*=\s*"[^"]{4,}"
+api_key\s*=\s*"[^"]{4,}"
+token\s*=\s*"[^"]{4,}"
+
+# GitHub tokens
+ghp_[A-Za-z0-9]{36}
+github_pat_[A-Za-z0-9]{22}_[A-Za-z0-9]{59}
+
+# Sensitive data in user_data
+user_data\s*=.*<<[\s\S]*?(PASSWORD|SECRET|TOKEN|API_KEY)
+```
+
+---
+
+## Prevention Checklist
+
+### Dockerfile
+
+- [ ] All images use a non-root `USER` directive before `CMD`/`ENTRYPOINT`
+- [ ] `.dockerignore` excludes `.env`, `*.pem`, `*.key`, credentials, and secrets
+- [ ] No `ARG` instructions contain secrets (use BuildKit `--mount=type=secret` instead)
+- [ ] No `RUN` commands embed tokens, passwords, or API keys
+- [ ] Base images are pinned to a specific version tag or SHA256 digest
+- [ ] `COPY` is used instead of `ADD` unless archive extraction is explicitly needed
+- [ ] Multi-stage builds are used to exclude build tools and source from the final image
+- [ ] Images are scanned with Trivy, Grype, or Snyk before deployment
+- [ ] `HEALTHCHECK` directive is present for orchestration readiness
+
+### Docker Compose
+
+- [ ] No service uses `privileged: true`
+- [ ] `cap_drop: [ALL]` is set with only necessary capabilities added back
+- [ ] No volumes mount `/var/run/docker.sock`, `/`, `/etc`, `/proc`, `/sys`, or `/dev`
+- [ ] Volumes are mounted read-only (`:ro`) where possible
+- [ ] Internal services use `expose:` instead of `ports:`
+- [ ] Published ports bind to `127.0.0.1` when behind a reverse proxy
+- [ ] Resource limits (`mem_limit`, `cpus` or `deploy.resources.limits`) are set for all services
+- [ ] Secrets use Docker secrets or external secret management, not plaintext `environment:` values
+- [ ] Networks are segmented with `internal: true` for backend services
+- [ ] `security_opt: [no-new-privileges:true]` is set on all services
+- [ ] `read_only: true` is set with explicit `tmpfs` mounts for writable directories
+
+### Kubernetes
+
+- [ ] No pod runs as `runAsUser: 0` — `runAsNonRoot: true` is set at the pod level
+- [ ] `readOnlyRootFilesystem: true` is set on all containers
+- [ ] `allowPrivilegeEscalation: false` is set on all containers
+- [ ] `capabilities.drop: [ALL]` is set; only required capabilities are added back
+- [ ] `seccompProfile.type: RuntimeDefault` (or `Localhost`) is set
+- [ ] `hostNetwork`, `hostPID`, and `hostIPC` are not set to `true`
+- [ ] `privileged: true` is not used
+- [ ] Resource `requests` and `limits` are set for both CPU and memory on all containers
+- [ ] RBAC uses namespace-scoped `Role`/`RoleBinding` instead of `ClusterRole`/`ClusterRoleBinding` where possible
+- [ ] No RBAC rules use wildcard (`*`) for verbs, resources, or apiGroups
+- [ ] `cluster-admin` is not bound to application service accounts
+- [ ] `NetworkPolicy` exists with default-deny ingress and egress per namespace
+- [ ] Secrets use `external-secrets`, `sealed-secrets`, or a CSI secret store driver, not plaintext `Secret` resources
+- [ ] Pod Security Admission (or Pod Security Standards) is enforced at the namespace level
+- [ ] Service accounts have `automountServiceAccountToken: false` unless API access is needed
+
+### Terraform
+
+- [ ] No hardcoded credentials (`access_key`, `secret_key`, `password`, `token`) in `.tf` files
+- [ ] Sensitive variables use `sensitive = true` flag
+- [ ] Credentials are provided via environment variables, IAM roles, or external secret managers
+- [ ] S3 buckets have `aws_s3_bucket_public_access_block` with all four blocks enabled
+- [ ] S3 buckets have server-side encryption enabled (SSE-KMS preferred)
+- [ ] S3 buckets have versioning enabled
+- [ ] Security groups do not use `0.0.0.0/0` or `::/0` for ingress (especially on ports 22, 3389, 3306, 5432)
+- [ ] RDS instances have `storage_encrypted = true` with a KMS key
+- [ ] EBS volumes have `encrypted = true`
+- [ ] CloudTrail is enabled with `is_multi_region_trail = true` and `enable_log_file_validation = true`
+- [ ] VPC Flow Logs are enabled for all VPCs
+- [ ] Terraform state is stored in an encrypted remote backend (S3 + DynamoDB with SSE-KMS)
+- [ ] Terraform state bucket has versioning, logging, and access controls
+- [ ] `user_data` scripts do not contain inline secrets (use IAM roles or Secrets Manager)
+- [ ] `deletion_protection` is enabled on production databases and critical resources
+
+### General IaC Practices
+
+- [ ] All IaC files are scanned in CI/CD with tools like Checkov, tfsec, Trivy, or KICS
+- [ ] Policy-as-code (OPA/Rego, Sentinel) enforces security guardrails before deployment
+- [ ] IaC changes go through pull request review with security-focused reviewers
+- [ ] Drift detection runs regularly to catch manual changes that bypass IaC
+- [ ] Secrets scanning (Gitleaks, TruffleHog) runs on every commit to prevent credential leaks
+- [ ] Infrastructure changes are applied through CI/CD pipelines, not from developer machines


### PR DESCRIPTION
## Summary

Adds four new standalone reference guides covering cloud and infrastructure-as-code security — a scope our skill currently lacks:

- **`aws-security.md`** (~684 lines): IAM policies, S3, Lambda, Security Groups, KMS, CloudTrail, Secrets Manager, RDS. Terraform / CloudFormation / raw JSON examples.
- **`azure-security.md`** (~650 lines): RBAC, Blob storage, NSG, Key Vault, Storage Account, Azure SQL. Terraform / ARM.
- **`gcp-security.md`** (~663 lines): IAM, GCS, Cloud SQL, VPC firewall, Secret Manager, Cloud Functions. Terraform / raw config.
- **`iac-security.md`** (~1395 lines): Terraform, Kubernetes, Docker Compose, Helm, Pulumi misconfigurations — cross-cutting IaC patterns.

Each guide includes vulnerable vs secure code examples plus detection-regex patterns usable by static analysis tooling.

## Provenance

Imported from [evandervecht/security-audit-skill](https://github.com/evandervecht/security-audit-skill) — a dual-licensed (MIT + CC-BY-SA-4.0) fork by [E van der Vecht](mailto:evandervecht@schubergphilis.com).

## Modification note

Fork-specific checkpoint IDs (`**Checkpoint:** SA-AWS-*`, `SA-AZURE-*`, `SA-GCP-*`) were stripped because the matching entries in `checkpoints.yaml` have not been imported yet. The underlying `**Detection regex:**` / `**Severity:**` metadata lines are retained since they stand on their own as scanner hints.

## Test plan

- [ ] CI green (lint, shellcheck)
- [ ] References render correctly in GitHub preview
- [ ] No broken internal links
- [ ] Confirm scope fit — this extends the skill from PHP/TYPO3-centric to cross-stack; OK?

## Notes for reviewers

- Part of a 3-PR series cherry-picking standalone references from Ellert's fork. See also:
  - #43 LLM security reference
  - (pending) API + Frontend references
- Follow-up candidate: importing the matching `SA-AWS-*` / `SA-AZURE-*` / `SA-GCP-*` checkpoints into `checkpoints.yaml` so the detection regexes become enforceable automatically. Would land as a separate PR.