### PR TITLE
feat(skill): surface cloud/IaC/API/frontend/LLM refs in SKILL.md index

### DIFF
--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-audit
-description: "Use when conducting security assessments, OWASP/CWE/LLM Top 10 audits, CVSS scoring, auditing code or infrastructure for vulnerabilities — PHP/TYPO3 projects, REST/GraphQL APIs, frontend (CSP/SRI/DOM-XSS), Terraform/Kubernetes/Docker/IaC, AWS/Azure/GCP cloud configuration, and AI agent setups (SKILL.md/AGENTS.md/CLAUDE.md/MCP/hooks for prompt injection and excessive agency). Also use when scanning dependencies or reviewing code for security concerns."
+description: "Use when conducting security assessments — OWASP Top 10, CWE Top 25, OWASP API Top 10, and OWASP Top 10 for LLM Applications audits, CVSS scoring, or reviewing code or infrastructure for vulnerabilities. Covers PHP/TYPO3 projects, REST and GraphQL APIs, frontend (CSP, SRI, DOM-XSS), Terraform, Kubernetes, Docker, and other IaC, AWS/Azure/GCP cloud configuration, and AI agent setups (SKILL.md, AGENTS.md, CLAUDE.md, mcp.json, and hooks.json for prompt injection and excessive agency). Also use when scanning dependencies or reviewing code for security concerns."
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires grep, jq, gh CLI."
 metadata:
@@ -12,18 +12,18 @@ allowed-tools: Bash(grep:*) Bash(jq:*) Bash(gh:*) Read Glob Grep
 
 # Security Audit Skill
 
-Security audit patterns (OWASP Top 10, OWASP LLM Top 10 2025, CWE Top 25 2025, CVSS v4.0), cloud & IaC misconfiguration checks, and GitHub project security checks. Deep PHP/TYPO3 code scanning with 80+ checkpoints and 26 reference guides.
+Security audit patterns (OWASP Top 10, OWASP Top 10 for LLM Applications 2025, CWE Top 25 2025, CVSS v4.0), cloud & IaC misconfiguration checks, and GitHub project security checks. Deep PHP/TYPO3 code scanning with 80+ checkpoints. See `references/` for the full set of reference guides.
 
 ## Expertise Areas
 
 - **Vulnerabilities**: XXE, SQLi, XSS, CSRF, command injection, path traversal, file upload, deserialization, SSRF, type juggling, SSTI, JWT flaws, insecure randomness
 - **Risk Scoring**: CVSS v3.1 and v4.0
 - **Secure Coding**: Input validation, output encoding, cryptography, session management, authentication, error sanitization
-- **Standards**: OWASP Top 10, OWASP API Top 10, OWASP LLM Top 10 (2025), CWE Top 25, OWASP ASVS, Proactive Controls
+- **Standards**: OWASP Top 10, OWASP API Top 10, OWASP Top 10 for LLM Applications (2025), CWE Top 25, OWASP ASVS, Proactive Controls
 - **Container/Docker**: Root user detection, file permissions, image pinning, non-root users
-- **Cloud & IaC**: AWS/Azure/GCP misconfigurations, Terraform/Kubernetes/Helm/Pulumi patterns
-- **API & Frontend**: REST/GraphQL authZ, rate limiting, mass assignment, CSP/SRI/Trusted Types, DOM-XSS
-- **AI Agent Security**: SKILL.md / AGENTS.md / CLAUDE.md / MCP / hooks.json audit, prompt injection, excessive agency
+- **Cloud & IaC**: AWS, Azure, and GCP misconfigurations; Terraform, Kubernetes, Helm, and Pulumi patterns
+- **API & Frontend**: REST and GraphQL authZ, rate limiting, mass assignment, CSP, SRI, Trusted Types, DOM-XSS
+- **AI Agent Security**: SKILL.md, AGENTS.md, CLAUDE.md, mcp.json, and hooks.json audit; prompt injection; excessive agency
 
 ## Reference Files
 
@@ -34,7 +34,7 @@ Security audit patterns (OWASP Top 10, OWASP LLM Top 10 2025, CWE Top 25 2025, C
 - **Framework Security**: `framework-security.md` (TYPO3, Symfony, Laravel — code-level patterns)
 - **API & Frontend**: `api-security.md` (REST/GraphQL, JWT, batching, field-suggestion leaks), `frontend-security.md` (CSP, SRI, Trusted Types, DOM-XSS detection)
 - **Cloud & IaC**: `aws-security.md`, `azure-security.md`, `gcp-security.md`, `iac-security.md` (Terraform/Kubernetes/Docker/Helm/Pulumi misconfigurations)
-- **AI Agent Security**: `llm-security.md` (OWASP LLM Top 10 2025 — SKILL.md/AGENTS.md/CLAUDE.md/mcp.json/hooks.json auditing)
+- **AI Agent Security**: `llm-security.md` (OWASP Top 10 for LLM Applications 2025 — SKILL.md, AGENTS.md, CLAUDE.md, mcp.json, and hooks.json auditing)
 - **Modern Threats**: `modern-attacks.md`, `cve-patterns.md`, `php-security-features.md`
 - **DevSecOps**: `ci-security-pipeline.md`, `supply-chain-security.md`, `automated-scanning.md`, `gha-security.md`
 - **Incident Response**: `supply-chain-incident-response.md`

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-audit
-description: "Use when conducting security assessments — OWASP Top 10, CWE Top 25, OWASP API Top 10, and OWASP Top 10 for LLM Applications audits, CVSS scoring, or reviewing code or infrastructure for vulnerabilities. Covers PHP/TYPO3 projects, REST and GraphQL APIs, frontend (CSP, SRI, DOM-XSS), Terraform, Kubernetes, Docker, and other IaC, AWS/Azure/GCP cloud configuration, and AI agent setups (SKILL.md, AGENTS.md, CLAUDE.md, mcp.json, and hooks.json for prompt injection and excessive agency). Also use when scanning dependencies or reviewing code for security concerns."
+description: "Use when conducting security assessments, OWASP/CWE/API/LLM Top 10 audits, CVSS scoring, auditing PHP/TYPO3 code, REST/GraphQL APIs, frontend, Terraform/Kubernetes/Docker IaC, AWS/Azure/GCP cloud, or AI agent configs (SKILL.md/AGENTS.md/CLAUDE.md/mcp.json/hooks.json) for vulnerabilities, scanning dependencies, or reviewing code for security concerns."
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires grep, jq, gh CLI."
 metadata:
@@ -12,34 +12,31 @@ allowed-tools: Bash(grep:*) Bash(jq:*) Bash(gh:*) Read Glob Grep
 
 # Security Audit Skill
 
-Security audit patterns (OWASP Top 10, OWASP Top 10 for LLM Applications 2025, CWE Top 25 2025, CVSS v4.0), cloud & IaC misconfiguration checks, and GitHub project security checks. Deep PHP/TYPO3 code scanning with 80+ checkpoints. See `references/` for the full set of reference guides.
+Security audit patterns (OWASP Top 10, LLM Top 10 2025, CWE Top 25 2025, CVSS v4.0), cloud & IaC checks, GitHub project security. 80+ PHP/TYPO3 checkpoints. See `references/`.
 
 ## Expertise Areas
 
-- **Vulnerabilities**: XXE, SQLi, XSS, CSRF, command injection, path traversal, file upload, deserialization, SSRF, type juggling, SSTI, JWT flaws, insecure randomness
-- **Risk Scoring**: CVSS v3.1 and v4.0
-- **Secure Coding**: Input validation, output encoding, cryptography, session management, authentication, error sanitization
-- **Standards**: OWASP Top 10, OWASP API Top 10, OWASP Top 10 for LLM Applications (2025), CWE Top 25, OWASP ASVS, Proactive Controls
-- **Container/Docker**: Root user detection, file permissions, image pinning, non-root users
-- **Cloud & IaC**: AWS, Azure, and GCP misconfigurations; Terraform, Kubernetes, Helm, and Pulumi patterns
-- **API & Frontend**: REST and GraphQL authZ, rate limiting, mass assignment, CSP, SRI, Trusted Types, DOM-XSS
-- **AI Agent Security**: SKILL.md, AGENTS.md, CLAUDE.md, mcp.json, and hooks.json audit; prompt injection; excessive agency
+- **Vulnerabilities**: XXE, SQLi, XSS, CSRF, command injection, path traversal, file upload, deserialization, SSRF, type juggling, SSTI, JWT
+- **Secure Coding**: input validation, output encoding, cryptography, authentication, error sanitization
+- **Standards**: OWASP Top 10 / API / LLM (2025), CWE Top 25, CVSS v3.1/v4.0, OWASP ASVS
+- **Cloud & IaC**: AWS, Azure, GCP; Terraform, Kubernetes, Docker, Helm, Pulumi
+- **API & Frontend**: REST/GraphQL authZ, rate limits, mass assignment, CSP, SRI, DOM-XSS
+- **AI Agents**: SKILL.md/AGENTS.md/CLAUDE.md/mcp.json/hooks.json audit; prompt injection; excessive agency
 
 ## Reference Files
 
+All in `references/`.
+
 - **Core**: `owasp-top10.md`, `cwe-top25.md`, `xxe-prevention.md`, `cvss-scoring.md`, `api-key-encryption.md`
-- **Vulnerability Prevention**: `deserialization-prevention.md`, `path-traversal-prevention.md`, `file-upload-security.md`, `input-validation.md`
-- **Error Handling**: `error-message-sanitization.md` (API key redaction, exception hierarchy)
+- **Prevention**: `deserialization-prevention.md`, `path-traversal-prevention.md`, `file-upload-security.md`, `input-validation.md`, `error-message-sanitization.md`
 - **Architecture**: `authentication-patterns.md`, `security-headers.md`, `security-logging.md`, `cryptography-guide.md`
-- **Framework Security**: `framework-security.md` (TYPO3, Symfony, Laravel — code-level patterns)
-- **API & Frontend**: `api-security.md` (REST/GraphQL, JWT, batching, field-suggestion leaks), `frontend-security.md` (CSP, SRI, Trusted Types, DOM-XSS detection)
-- **Cloud & IaC**: `aws-security.md`, `azure-security.md`, `gcp-security.md`, `iac-security.md` (Terraform/Kubernetes/Docker/Helm/Pulumi misconfigurations)
-- **AI Agent Security**: `llm-security.md` (OWASP Top 10 for LLM Applications 2025 — SKILL.md, AGENTS.md, CLAUDE.md, mcp.json, and hooks.json auditing)
+- **Framework**: `framework-security.md` (TYPO3, Symfony, Laravel)
+- **API & Frontend**: `api-security.md`, `frontend-security.md`
+- **Cloud & IaC**: `aws-security.md`, `azure-security.md`, `gcp-security.md`, `iac-security.md`
+- **AI Agent**: `llm-security.md`
 - **Modern Threats**: `modern-attacks.md`, `cve-patterns.md`, `php-security-features.md`
 - **DevSecOps**: `ci-security-pipeline.md`, `supply-chain-security.md`, `automated-scanning.md`, `gha-security.md`
-- **Incident Response**: `supply-chain-incident-response.md`
-
-All files located in `references/`.
+- **Incident**: `supply-chain-incident-response.md`
 
 ## Quick Patterns
 
@@ -70,44 +67,40 @@ $encrypted = 'enc:' . base64_encode($nonce . sodium_crypto_secretbox($apiKey, $n
 $hash = password_hash($password, PASSWORD_ARGON2ID);
 ```
 
-**Secure randomness (NOT mt_rand/rand):**
+**Secure randomness:**
 ```php
 $token = bin2hex(random_bytes(32));
 ```
 
-For scanning tools (semgrep/opengrep, trivy, gitleaks), see `references/automated-scanning.md`.
+Scanners (semgrep, trivy, gitleaks): see `references/automated-scanning.md`.
 
 ## Security Checklist
 
 - [ ] `semgrep --config auto` — no high-severity findings
 - [ ] `trivy fs --severity HIGH,CRITICAL` — no unpatched CVEs
 - [ ] `gitleaks detect` — no leaked secrets
-- [ ] bcrypt/Argon2 for passwords, CSRF tokens on state changes
-- [ ] All input validated server-side, parameterized SQL
+- [ ] bcrypt/Argon2 passwords, CSRF tokens on state changes
+- [ ] Input validated server-side, parameterized SQL
 - [ ] XML external entities disabled (LIBXML_NONET only)
-- [ ] Context-appropriate output encoding, CSP configured
+- [ ] Output encoding, CSP configured
 - [ ] API keys encrypted at rest (sodium_crypto_secretbox)
-- [ ] Exception messages sanitized (no API keys, paths, or SQL in responses)
+- [ ] Exception messages sanitized
 - [ ] TLS 1.2+, secrets not in VCS, audit logging
-- [ ] No unserialize() with user input, use json_decode()
-- [ ] File uploads validated, renamed, stored outside web root
-- [ ] Security headers: HSTS, X-Content-Type-Options set
-- [ ] Dependencies scanned (composer audit), Dependabot enabled
+- [ ] No unserialize() with user input
+- [ ] File uploads validated, renamed, outside web root
+- [ ] Headers: HSTS, X-Content-Type-Options; dependencies scanned
 
 ## GitHub Actions Security
 
-- **NEVER** interpolate `${{ inputs.* }}` or `${{ github.event.* }}` in `run:` blocks — use `env:` instead
+- **NEVER** interpolate `${{ inputs.* }}` or `${{ github.event.* }}` in `run:` — use `env:`
 - Dependency triage: upgrade > override > dismiss with rationale
-- See `references/gha-security.md` for patterns and examples
+- See `references/gha-security.md`
 
 ## Verification
 
 ```bash
-# PHP project security audit
-./scripts/security-audit.sh /path/to/project
-
-# GitHub repository security audit
-./scripts/github-security-audit.sh owner/repo
+./scripts/security-audit.sh /path/to/project       # PHP project
+./scripts/github-security-audit.sh owner/repo      # GitHub repo
 ```
 
 ---

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-audit
-description: "Use when conducting security assessments, OWASP/CWE audits, CVSS scoring, auditing PHP/TYPO3 projects for vulnerabilities, scanning dependencies, or reviewing code for security concerns."
+description: "Use when conducting security assessments, OWASP/CWE/LLM Top 10 audits, CVSS scoring, auditing code or infrastructure for vulnerabilities — PHP/TYPO3 projects, REST/GraphQL APIs, frontend (CSP/SRI/DOM-XSS), Terraform/Kubernetes/Docker/IaC, AWS/Azure/GCP cloud configuration, and AI agent setups (SKILL.md/AGENTS.md/CLAUDE.md/MCP/hooks for prompt injection and excessive agency). Also use when scanning dependencies or reviewing code for security concerns."
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires grep, jq, gh CLI."
 metadata:
@@ -12,15 +12,18 @@ allowed-tools: Bash(grep:*) Bash(jq:*) Bash(gh:*) Read Glob Grep
 
 # Security Audit Skill
 
-Security audit patterns (OWASP Top 10, CWE Top 25 2025, CVSS v4.0) and GitHub project security checks. Deep PHP/TYPO3 code scanning with 80+ checkpoints and 19 reference guides.
+Security audit patterns (OWASP Top 10, OWASP LLM Top 10 2025, CWE Top 25 2025, CVSS v4.0), cloud & IaC misconfiguration checks, and GitHub project security checks. Deep PHP/TYPO3 code scanning with 80+ checkpoints and 26 reference guides.
 
 ## Expertise Areas
 
 - **Vulnerabilities**: XXE, SQLi, XSS, CSRF, command injection, path traversal, file upload, deserialization, SSRF, type juggling, SSTI, JWT flaws, insecure randomness
 - **Risk Scoring**: CVSS v3.1 and v4.0
 - **Secure Coding**: Input validation, output encoding, cryptography, session management, authentication, error sanitization
-- **Standards**: OWASP Top 10, CWE Top 25, OWASP ASVS, Proactive Controls
+- **Standards**: OWASP Top 10, OWASP API Top 10, OWASP LLM Top 10 (2025), CWE Top 25, OWASP ASVS, Proactive Controls
 - **Container/Docker**: Root user detection, file permissions, image pinning, non-root users
+- **Cloud & IaC**: AWS/Azure/GCP misconfigurations, Terraform/Kubernetes/Helm/Pulumi patterns
+- **API & Frontend**: REST/GraphQL authZ, rate limiting, mass assignment, CSP/SRI/Trusted Types, DOM-XSS
+- **AI Agent Security**: SKILL.md / AGENTS.md / CLAUDE.md / MCP / hooks.json audit, prompt injection, excessive agency
 
 ## Reference Files
 
@@ -28,7 +31,10 @@ Security audit patterns (OWASP Top 10, CWE Top 25 2025, CVSS v4.0) and GitHub pr
 - **Vulnerability Prevention**: `deserialization-prevention.md`, `path-traversal-prevention.md`, `file-upload-security.md`, `input-validation.md`
 - **Error Handling**: `error-message-sanitization.md` (API key redaction, exception hierarchy)
 - **Architecture**: `authentication-patterns.md`, `security-headers.md`, `security-logging.md`, `cryptography-guide.md`
-- **Framework Security**: `framework-security.md` (TYPO3, Symfony, Laravel)
+- **Framework Security**: `framework-security.md` (TYPO3, Symfony, Laravel — code-level patterns)
+- **API & Frontend**: `api-security.md` (REST/GraphQL, JWT, batching, field-suggestion leaks), `frontend-security.md` (CSP, SRI, Trusted Types, DOM-XSS detection)
+- **Cloud & IaC**: `aws-security.md`, `azure-security.md`, `gcp-security.md`, `iac-security.md` (Terraform/Kubernetes/Docker/Helm/Pulumi misconfigurations)
+- **AI Agent Security**: `llm-security.md` (OWASP LLM Top 10 2025 — SKILL.md/AGENTS.md/CLAUDE.md/mcp.json/hooks.json auditing)
 - **Modern Threats**: `modern-attacks.md`, `cve-patterns.md`, `php-security-features.md`
 - **DevSecOps**: `ci-security-pipeline.md`, `supply-chain-security.md`, `automated-scanning.md`, `gha-security.md`
 - **Incident Response**: `supply-chain-incident-response.md`


### PR DESCRIPTION
## Summary

Follow-up to #43 / #44 / #45. Those PRs added seven new reference guides (LLM, AWS, Azure, GCP, IaC, API, Frontend) into `skills/security-audit/references/`, but didn't update the SKILL.md index that tells Claude those references exist — so the files shipped but weren't reachable in practice.

This PR fixes progressive disclosure:

1. **Broaden the `description` frontmatter.** Previously triggered only on PHP/TYPO3 phrasing, so "audit my Terraform for AWS IAM misconfigs" or "review my MCP server config for prompt injection" wouldn't reach the skill at all. Now explicitly covers cloud/IaC, APIs, frontend, and AI-agent-config audits.
2. **Add three new categories** to both the Expertise Areas and Reference Files blocks: Cloud & IaC, API & Frontend, AI Agent Security.
3. **Mention OWASP API Top 10 and OWASP LLM Top 10 (2025)** in the Standards list.
4. **Note in the Framework Security entry** that it's for *code-level* patterns — to discourage future contributors from mixing cloud config into `framework-security.md`.

Lead paragraph reference count updated 19 → 26 to reflect the new guides from #43/#44/#45.

The `version:` field is intentionally left untouched — per project convention, bumps happen at release time, not per-PR.

## Rationale

A skill-creator review of #43/#44/#45 flagged this as the single remaining merge-gate: great content, but it's loaded by Claude based on what SKILL.md surfaces. If Claude never sees `llm-security.md` in the index, it never reads it, even when the user asks for exactly what's in it.

## Test plan

- [ ] CI green
- [ ] SKILL.md renders cleanly on GitHub
- [ ] Spot-check that new description still reads naturally (not keyword-stuffed)