### PR TITLE
ci: fix auto-merge-deps reusable workflow reference

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,13 +1,13 @@
 name: Auto-merge dependency PRs
 
 on:
-  pull_request:
+  pull_request_target:
 
 permissions: {}
 
 jobs:
   auto-merge:
-    uses: netresearch/skill-repo-skill/.github/workflows/auto-merge-deps.yml@main
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

The caller pointed at \`netresearch/skill-repo-skill/.github/workflows/auto-merge-deps.yml\`, which does not exist. The real reusable workflow lives at \`netresearch/.github/.github/workflows/auto-merge-deps.yml\`. Every \`pull_request\` event in this repo therefore failed to resolve it (runs #32–#35 for \`feat/llm-security\`, \`feat/cloud-iac-references\`, \`feat/api-frontend-references\`).

## Changes

- \`uses:\` → correct org-level reusable workflow
- \`on: pull_request\` → \`on: pull_request_target\` (so Dependabot/Renovate PRs get write-scoped creds)

## Test plan

- [ ] \`auto-merge\` job resolves and runs (no "reusable workflow not found")
- [ ] Run shows \`skipped\` for non-bot PRs (the \`if:\` in the upstream workflow filters on \`dependabot[bot]\`/\`renovate[bot]\`)