### PR TITLE
feat(references): add Python ecosystem security guides

### DIFF
--- a/skills/security-audit/references/django-security.md
+++ b/skills/security-audit/references/django-security.md
@@ -66,6 +66,7 @@ def raw_query_safe(request):
 When user-supplied input is used as field names in `filter()`, `exclude()`, `values()`, `order_by()`, or `annotate()`, attackers can traverse relationships or extract data from related models.
 
 ```python
+from django.http import HttpResponseBadRequest, JsonResponse
 from myapp.models import User
 
 # VULNERABLE: User-controlled field in filter()
@@ -226,6 +227,7 @@ def transfer_funds_safe(request):
 # SECURE: For APIs, use token authentication instead
 from rest_framework.decorators import api_view, authentication_classes
 from rest_framework.authentication import TokenAuthentication
+from rest_framework.response import Response
 
 @api_view(["POST"])
 @authentication_classes([TokenAuthentication])

--- a/skills/security-audit/references/django-security.md
+++ b/skills/security-audit/references/django-security.md
@@ -1,0 +1,490 @@
+# Django Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for Django applications. Covers ORM injection, CSRF misconfiguration, XSS via mark_safe, session backend risks, debug settings, secret key exposure, file uploads, admin exposure, and QuerySet injection.
+
+## Injection
+
+### SA-DJANGO-01: ORM Injection via raw() and extra()
+
+Django's ORM is safe by default when using QuerySet methods with parameterized values. However, `raw()`, `extra()`, and `RawSQL()` bypass these protections when user input is interpolated directly into query strings.
+
+```python
+from django.db import connection
+from myapp.models import User
+
+# VULNERABLE: String interpolation in raw()
+def search_users(request):
+    query = request.GET.get("q")
+    users = User.objects.raw(f"SELECT * FROM myapp_user WHERE name = '{query}'")
+    return render(request, "users.html", {"users": users})
+
+# VULNERABLE: f-string in extra()
+def filter_users(request):
+    order = request.GET.get("order", "id")
+    users = User.objects.extra(order_by=[order])  # attacker controls ORDER BY
+    return render(request, "users.html", {"users": users})
+
+# VULNERABLE: Direct cursor execution with string formatting
+def raw_query(request):
+    user_id = request.GET.get("id")
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT * FROM myapp_user WHERE id = %s" % user_id)
+        rows = cursor.fetchall()
+    return render(request, "users.html", {"rows": rows})
+
+# SECURE: Parameterized raw()
+def search_users_safe(request):
+    query = request.GET.get("q")
+    users = User.objects.raw(
+        "SELECT * FROM myapp_user WHERE name = %s", [query]
+    )
+    return render(request, "users.html", {"users": users})
+
+# SECURE: Use ORM filtering instead of extra()
+def filter_users_safe(request):
+    allowed_orders = {"id", "name", "date_joined"}
+    order = request.GET.get("order", "id")
+    if order not in allowed_orders:
+        order = "id"
+    users = User.objects.order_by(order)
+    return render(request, "users.html", {"users": users})
+
+# SECURE: Parameterized cursor execution
+def raw_query_safe(request):
+    user_id = request.GET.get("id")
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT * FROM myapp_user WHERE id = %s", [user_id])
+        rows = cursor.fetchall()
+    return render(request, "users.html", {"rows": rows})
+```
+
+**Detection regex:** `\.raw\s*\(\s*f["\']|\.raw\s*\(\s*["\'].*%s.*["\']\s*%|\.extra\s*\(|cursor\.execute\s*\(\s*f["\']|cursor\.execute\s*\(\s*["\'].*%s.*["\']\s*%`
+**Severity:** error
+
+### SA-DJANGO-09: QuerySet Injection via Untrusted Field Names
+
+When user-supplied input is used as field names in `filter()`, `exclude()`, `values()`, `order_by()`, or `annotate()`, attackers can traverse relationships or extract data from related models.
+
+```python
+from myapp.models import User
+
+# VULNERABLE: User-controlled field in filter()
+def search(request):
+    field = request.GET.get("field", "username")
+    value = request.GET.get("value")
+    results = User.objects.filter(**{field: value})
+    # Attacker can use: ?field=password&value=admin123
+    # Or traverse: ?field=profile__ssn&value=123-45-6789
+    return render(request, "results.html", {"results": results})
+
+# VULNERABLE: User-controlled field in values()
+def export(request):
+    fields = request.GET.getlist("fields")
+    data = User.objects.values(*fields)
+    # Attacker: ?fields=password&fields=email
+    return JsonResponse(list(data), safe=False)
+
+# VULNERABLE: User-controlled ordering
+def list_users(request):
+    sort = request.GET.get("sort", "id")
+    users = User.objects.order_by(sort)
+    return render(request, "users.html", {"users": users})
+
+# SECURE: Allowlist field names
+ALLOWED_SEARCH_FIELDS = {"username", "email", "first_name", "last_name"}
+ALLOWED_SORT_FIELDS = {"id", "username", "date_joined", "-id", "-username", "-date_joined"}
+
+def search_safe(request):
+    field = request.GET.get("field", "username")
+    value = request.GET.get("value")
+    if field not in ALLOWED_SEARCH_FIELDS:
+        return HttpResponseBadRequest("Invalid field")
+    results = User.objects.filter(**{field: value})
+    return render(request, "results.html", {"results": results})
+
+def list_users_safe(request):
+    sort = request.GET.get("sort", "id")
+    if sort not in ALLOWED_SORT_FIELDS:
+        sort = "id"
+    users = User.objects.order_by(sort)
+    return render(request, "users.html", {"users": users})
+```
+
+**Detection regex:** `\.filter\s*\(\s*\*\*\s*\{.*request\.|\.values\s*\(\s*\*.*request\.|\.order_by\s*\(.*request\.`
+**Severity:** warning
+
+## Cross-Site Scripting (XSS)
+
+### SA-DJANGO-04: XSS via mark_safe() and |safe Filter
+
+Django auto-escapes template variables by default. The `mark_safe()` function and `|safe` template filter bypass this protection. When combined with user input, they create XSS vulnerabilities.
+
+```python
+from django.utils.safestring import mark_safe
+from django.utils.html import format_html
+
+# VULNERABLE: mark_safe with user input
+def user_profile(request, user_id):
+    user = User.objects.get(id=user_id)
+    bio_html = mark_safe(user.bio)  # user.bio could contain <script>
+    return render(request, "profile.html", {"bio": bio_html})
+
+# VULNERABLE: mark_safe with string formatting
+def greeting(request):
+    name = request.GET.get("name", "World")
+    message = mark_safe(f"<h1>Hello, {name}!</h1>")
+    return render(request, "greeting.html", {"message": message})
+
+# VULNERABLE: |safe filter in template
+# In template: {{ user.bio|safe }}
+# This bypasses Django's auto-escaping
+
+# SECURE: Use format_html() for safe HTML construction
+def greeting_safe(request):
+    name = request.GET.get("name", "World")
+    message = format_html("<h1>Hello, {}!</h1>", name)
+    return render(request, "greeting.html", {"message": message})
+
+# SECURE: Use bleach or similar library for user HTML
+import bleach
+
+ALLOWED_TAGS = ["b", "i", "u", "a", "p", "br", "ul", "ol", "li"]
+ALLOWED_ATTRS = {"a": ["href", "title"]}
+
+def user_profile_safe(request, user_id):
+    user = User.objects.get(id=user_id)
+    bio_html = bleach.clean(user.bio, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRS)
+    return render(request, "profile.html", {"bio": mark_safe(bio_html)})
+```
+
+**Detection regex:** `mark_safe\s*\(|\.safestring\s+import|safestring\.mark_safe`
+**Severity:** error
+
+### SA-DJANGO-10: Template |safe Filter Usage
+
+The `|safe` filter in Django templates is equivalent to `mark_safe()` in Python code. It disables auto-escaping for a variable and should only be used with trusted, pre-sanitized content.
+
+```html
+<!-- VULNERABLE: |safe on user-controlled data -->
+<div class="bio">{{ user.bio|safe }}</div>
+<div class="comment">{{ comment.body|safe }}</div>
+
+<!-- VULNERABLE: |safe on data from external API -->
+<div>{{ api_response.html|safe }}</div>
+
+<!-- SECURE: Let Django auto-escape (default behavior) -->
+<div class="bio">{{ user.bio }}</div>
+
+<!-- SECURE: Use |escape explicitly for clarity -->
+<div class="comment">{{ comment.body|escape }}</div>
+
+<!-- SECURE: Use |safe only on pre-sanitized content -->
+<!-- In view: sanitized = bleach.clean(user.bio, ...) -->
+<div class="bio">{{ sanitized_bio|safe }}</div>
+```
+
+**Detection regex:** `\|\s*safe\b`
+**Severity:** warning
+
+## CSRF Protection
+
+### SA-DJANGO-02: CSRF Misconfiguration via @csrf_exempt
+
+Django provides automatic CSRF protection via middleware. The `@csrf_exempt` decorator disables this for individual views. State-changing endpoints without CSRF protection are vulnerable to cross-site request forgery.
+
+```python
+from django.views.decorators.csrf import csrf_exempt
+from django.http import JsonResponse
+
+# VULNERABLE: csrf_exempt on state-changing endpoint
+@csrf_exempt
+def transfer_funds(request):
+    if request.method == "POST":
+        amount = request.POST.get("amount")
+        recipient = request.POST.get("recipient")
+        # Process transfer without CSRF protection
+        return JsonResponse({"status": "ok"})
+
+# VULNERABLE: csrf_exempt on class-based view
+from django.utils.decorators import method_decorator
+from django.views import View
+
+@method_decorator(csrf_exempt, name="dispatch")
+class UpdateProfileView(View):
+    def post(self, request):
+        # State-changing operation without CSRF
+        request.user.profile.update(name=request.POST.get("name"))
+        return JsonResponse({"status": "updated"})
+
+# SECURE: Use CSRF protection (default)
+def transfer_funds_safe(request):
+    if request.method == "POST":
+        amount = request.POST.get("amount")
+        recipient = request.POST.get("recipient")
+        return JsonResponse({"status": "ok"})
+
+# SECURE: For APIs, use token authentication instead
+from rest_framework.decorators import api_view, authentication_classes
+from rest_framework.authentication import TokenAuthentication
+
+@api_view(["POST"])
+@authentication_classes([TokenAuthentication])
+def api_transfer(request):
+    amount = request.data.get("amount")
+    recipient = request.data.get("recipient")
+    return Response({"status": "ok"})
+```
+
+**Detection regex:** `@csrf_exempt|csrf_exempt\s*\(|decorators\.csrf\s+import\s+csrf_exempt`
+**Severity:** error
+
+## Authentication & Authorization
+
+### SA-DJANGO-07: Admin Site Exposure
+
+Django's admin site (`/admin/`) is a powerful interface that should be protected beyond default authentication. Exposing it on public URLs without additional protections creates an attack surface.
+
+```python
+# VULNERABLE: Default admin URL with no extra protection
+# urls.py
+from django.contrib import admin
+from django.urls import path
+
+urlpatterns = [
+    path("admin/", admin.site.urls),  # predictable URL
+]
+
+# VULNERABLE: Admin with DEBUG=True exposes detailed errors
+# settings.py
+DEBUG = True
+ALLOWED_HOSTS = ["*"]
+
+# SECURE: Change admin URL to non-predictable path
+urlpatterns = [
+    path("manage-8f3k2j/", admin.site.urls),  # obscure URL
+]
+
+# SECURE: Add IP restriction middleware or decorator
+from django.http import HttpResponseForbidden
+
+class AdminIPRestrictionMiddleware:
+    ALLOWED_IPS = {"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.path.startswith("/admin/"):
+            ip = request.META.get("REMOTE_ADDR")
+            if not self._is_allowed(ip):
+                return HttpResponseForbidden("Forbidden")
+        return self.get_response(request)
+
+    def _is_allowed(self, ip):
+        import ipaddress
+        client = ipaddress.ip_address(ip)
+        return any(
+            client in ipaddress.ip_network(net) for net in self.ALLOWED_IPS
+        )
+
+# SECURE: Enforce 2FA for admin (django-otp or django-two-factor-auth)
+# SECURE: Rate-limit admin login (django-axes)
+```
+
+**Detection regex:** `path\s*\(\s*["\']admin/["\']|url\s*\(\s*r?\s*["\'].*admin/`
+**Severity:** warning
+
+## Security Misconfiguration
+
+### SA-DJANGO-03: DEBUG=True in Production
+
+Django's `DEBUG = True` setting exposes detailed error pages, SQL queries, installed apps, settings, and full tracebacks. This information is invaluable to attackers.
+
+```python
+# VULNERABLE: DEBUG=True in settings.py
+# settings.py
+DEBUG = True
+ALLOWED_HOSTS = ["*"]  # Often accompanies DEBUG=True
+
+# VULNERABLE: Conditional debug that defaults to True
+import os
+DEBUG = os.environ.get("DEBUG", True)  # Default is True if env var missing
+
+# SECURE: DEBUG=False with explicit ALLOWED_HOSTS
+DEBUG = False
+ALLOWED_HOSTS = ["example.com", "www.example.com"]
+
+# SECURE: Use environment variable with safe default
+import os
+DEBUG = os.environ.get("DJANGO_DEBUG", "False").lower() == "true"
+
+# SECURE: Split settings files
+# settings/base.py — shared settings
+# settings/development.py — DEBUG = True (never deployed)
+# settings/production.py — DEBUG = False, strict ALLOWED_HOSTS
+```
+
+**Detection regex:** `DEBUG\s*=\s*True`
+**Severity:** error
+
+### SA-DJANGO-05: SECRET_KEY Exposure
+
+Django's `SECRET_KEY` is used for cryptographic signing (sessions, CSRF tokens, password reset tokens). Hardcoding it in source code or committing it to version control allows attackers to forge sessions and tokens.
+
+```python
+# VULNERABLE: Hardcoded SECRET_KEY in settings.py
+SECRET_KEY = "django-insecure-abc123def456ghi789jkl012mno345"
+
+# VULNERABLE: SECRET_KEY in committed file
+SECRET_KEY = "my-super-secret-key-that-should-not-be-here"
+
+# VULNERABLE: Weak or default SECRET_KEY
+SECRET_KEY = "change-me"
+SECRET_KEY = "django-insecure-"
+
+# SECURE: Load from environment variable
+import os
+SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]  # Fails loudly if missing
+
+# SECURE: Load from a secrets file not in VCS
+from pathlib import Path
+SECRET_KEY = Path("/run/secrets/django_secret_key").read_text().strip()
+
+# SECURE: Use django-environ
+import environ
+env = environ.Env()
+SECRET_KEY = env("DJANGO_SECRET_KEY")
+```
+
+**Detection regex:** `SECRET_KEY\s*=\s*["\'][^"\']{8,}["\']`
+**Severity:** error
+
+### SA-DJANGO-06: Insecure Session Backend (Pickle)
+
+Django supports multiple session serializers. The `PickleSerializer` deserializes session data using Python's `pickle` module, which can execute arbitrary code if an attacker can tamper with session data (e.g., via a leaked SECRET_KEY).
+
+```python
+# VULNERABLE: Pickle session serializer
+# settings.py
+SESSION_SERIALIZER = "django.contrib.sessions.serializers.PickleSerializer"
+
+# VULNERABLE: Custom pickle-based serializer
+SESSION_SERIALIZER = "myapp.serializers.CustomPickleSerializer"
+
+# VULNERABLE: Pickle combined with cookie session backend
+SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
+SESSION_SERIALIZER = "django.contrib.sessions.serializers.PickleSerializer"
+# Worst combination: cookie-based + pickle = RCE if SECRET_KEY leaks
+
+# SECURE: Use JSON serializer (Django default since 1.6)
+SESSION_SERIALIZER = "django.contrib.sessions.serializers.JSONSerializer"
+
+# SECURE: Use database-backed sessions (default engine)
+SESSION_ENGINE = "django.contrib.sessions.backends.db"
+SESSION_SERIALIZER = "django.contrib.sessions.serializers.JSONSerializer"
+
+# SECURE: Use cache-backed sessions with JSON
+SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+SESSION_SERIALIZER = "django.contrib.sessions.serializers.JSONSerializer"
+SESSION_CACHE_ALIAS = "sessions"
+```
+
+**Detection regex:** `PickleSerializer|SESSION_SERIALIZER.*[Pp]ickle`
+**Severity:** error
+
+### SA-DJANGO-08: File Upload Validation
+
+Django handles file uploads via `request.FILES`. Without proper validation, attackers can upload executable files, oversized files, or files with misleading extensions.
+
+```python
+from django.core.validators import FileExtensionValidator
+from django.db import models
+
+# VULNERABLE: No file type or size validation
+class Document(models.Model):
+    file = models.FileField(upload_to="documents/")
+
+# VULNERABLE: Trusting Content-Type header
+def upload_file(request):
+    uploaded = request.FILES["file"]
+    if uploaded.content_type == "image/png":  # easily spoofed
+        handle_upload(uploaded)
+
+# VULNERABLE: Saving to predictable location without sanitization
+import os
+def upload_avatar(request):
+    f = request.FILES["avatar"]
+    path = os.path.join("/media/avatars/", f.name)  # path traversal risk
+    with open(path, "wb+") as dest:
+        for chunk in f.chunks():
+            dest.write(chunk)
+
+# SECURE: Validate extension, size, and content type
+class Document(models.Model):
+    file = models.FileField(
+        upload_to="documents/%Y/%m/",
+        validators=[
+            FileExtensionValidator(allowed_extensions=["pdf", "docx", "txt"]),
+        ],
+    )
+
+    def clean(self):
+        super().clean()
+        if self.file.size > 10 * 1024 * 1024:  # 10 MB limit
+            raise ValidationError("File too large (max 10 MB)")
+
+# SECURE: Use python-magic to verify actual file type
+import magic
+
+def validate_file_type(uploaded_file):
+    mime = magic.from_buffer(uploaded_file.read(2048), mime=True)
+    uploaded_file.seek(0)
+    allowed = {"application/pdf", "image/png", "image/jpeg"}
+    if mime not in allowed:
+        raise ValidationError(f"Unsupported file type: {mime}")
+
+# SECURE: Django's default_storage with sanitized filename
+from django.core.files.storage import default_storage
+from django.utils.text import get_valid_filename
+import uuid
+
+def upload_avatar_safe(request):
+    f = request.FILES["avatar"]
+    ext = os.path.splitext(f.name)[1].lower()
+    if ext not in {".png", ".jpg", ".jpeg", ".gif"}:
+        return HttpResponseBadRequest("Invalid file type")
+    filename = f"{uuid.uuid4()}{ext}"
+    path = default_storage.save(f"avatars/{filename}", f)
+    return JsonResponse({"path": path})
+```
+
+**Detection regex:** `FileField\s*\(\s*upload_to\s*=\s*["\'][^"\']*["\'](?:\s*\)|\s*,\s*\))|request\.FILES\[`
+**Severity:** warning
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| SA-DJANGO-01: ORM injection (raw/extra) | Critical | Immediate | Medium |
+| SA-DJANGO-02: CSRF disabled (@csrf_exempt) | High | Immediate | Low |
+| SA-DJANGO-03: DEBUG=True in production | Critical | Immediate | Low |
+| SA-DJANGO-04: mark_safe XSS | High | 1 week | Medium |
+| SA-DJANGO-05: SECRET_KEY exposure | Critical | Immediate | Low |
+| SA-DJANGO-06: Pickle session backend | High | 1 week | Low |
+| SA-DJANGO-07: Admin site exposure | Medium | 1 month | Medium |
+| SA-DJANGO-08: File upload validation | Medium | 1 week | Medium |
+| SA-DJANGO-09: QuerySet field injection | Medium | 1 week | Medium |
+| SA-DJANGO-10: Template |safe filter | Medium | 1 week | Low |
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `python-security-features.md` — Language-level Python patterns
+- `flask-security.md` — Flask-specific patterns
+- `fastapi-security.md` — FastAPI-specific patterns
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 2: Python framework coverage |

--- a/skills/security-audit/references/fastapi-security.md
+++ b/skills/security-audit/references/fastapi-security.md
@@ -9,11 +9,16 @@ Security patterns, common misconfigurations, and detection regexes for FastAPI a
 FastAPI uses dependency injection for authentication and authorization via `Depends()`. Endpoints that lack auth dependencies are publicly accessible. Unlike Django, FastAPI has no global auth middleware by default -- each endpoint must explicitly declare its dependencies.
 
 ```python
+import os
 from fastapi import FastAPI, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
+from jose import jwt, JWTError  # python-jose
+from myapp.models import User   # your ORM / data access layer
 
 app = FastAPI()
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+SECRET_KEY = os.environ["APP_JWT_KEY"]  # fail fast if unset; never hardcode
 
 # VULNERABLE: No auth dependency -- endpoint is public
 @app.get("/users/{user_id}")
@@ -88,7 +93,20 @@ async def update_settings_router(settings: dict):
     return {"status": "updated"}
 ```
 
-**Detection regex:** `@app\.(get|post|put|patch|delete)\s*\(\s*["\'][^"\']*["\']\s*\)\s*\n\s*(async\s+)?def\s+\w+\s*\([^)]*\)\s*(?!.*Depends)`
+**Detection (two-pass, since line-oriented grep can't match across `\n`):**
+First flag all route decorators, then separately check that the function signature on the next line mentions `Depends(`.
+```bash
+# Pass 1: list files with route decorators (PCRE, supports \s):
+files=$(grep -rlP '@app\.(get|post|put|patch|delete)\s*\(' --include='*.py' .)
+# Pass 2: for each file, find decorators whose next signature lacks Depends(:
+for f in $files; do
+  awk '/^@app\.(get|post|put|patch|delete)\s*\(/ { deco=NR; next }
+       /^(async[[:space:]]+)?def[[:space:]]/ && deco {
+         if ($0 !~ /Depends/) print FILENAME":"deco": route without Depends(...) auth"
+         deco=0
+       }' "$f"
+done
+```
 **Severity:** warning
 
 ### SA-FASTAPI-02: Pydantic Validation Bypass
@@ -146,11 +164,22 @@ class Comment(BaseModel):
     body: str = Field(max_length=10000)
     title: str = Field(max_length=200)
 
-# SECURE: Use specific types, not Any
+# SECURE: Use specific types, not Any. Pydantic's `max_length` constraint
+# only applies to string/bytes/sequence types — not to `dict`. To cap the
+# number of entries in a metadata dict, add a validator.
+from pydantic import field_validator
+
 class UserUpdate(BaseModel):
     model_config = {"extra": "forbid"}
     role: str = Field(pattern=r"^(user|editor|admin)$")
-    metadata: dict[str, str] = Field(default_factory=dict, max_length=20)
+    metadata: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("metadata")
+    @classmethod
+    def _cap_metadata_size(cls, v: dict[str, str]) -> dict[str, str]:
+        if len(v) > 20:
+            raise ValueError("metadata may contain at most 20 keys")
+        return v
 ```
 
 **Detection regex:** `def\s+\w+\s*\([^)]*:\s*dict\s*[,\)]|:\s*Any\s*[,\)=]|extra\s*=\s*["\']allow["\']`
@@ -610,7 +639,7 @@ async def websocket_cookie_auth(websocket: WebSocket):
     # ... handle messages
 ```
 
-**Detection regex:** `@app\.websocket\s*\(\s*["\'][^"\']*["\']\s*\)\s*\n\s*async\s+def\s+\w+\s*\(\s*websocket\s*:\s*WebSocket\s*\)\s*:`
+**Detection regex:** `@app\.websocket\s*\(\s*["\'][^"\']*["\']\s*\)` — flag every WebSocket route, then manually verify each `async def` accepts an auth token / Depends parameter. A single-line regex cannot span the decorator and the signature; use the two-pass approach shown earlier for Depends() verification.
 **Severity:** warning
 
 ## Remediation Priority

--- a/skills/security-audit/references/fastapi-security.md
+++ b/skills/security-audit/references/fastapi-security.md
@@ -1,0 +1,640 @@
+# FastAPI Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for FastAPI applications. Covers Pydantic validation bypass, dependency injection auth patterns, CORS middleware misconfiguration, response header injection, file upload handling, OAuth2 implementation pitfalls, background task data exposure, and WebSocket authentication.
+
+## Authentication & Authorization
+
+### SA-FASTAPI-01: Missing Dependency Injection for Auth
+
+FastAPI uses dependency injection for authentication and authorization via `Depends()`. Endpoints that lack auth dependencies are publicly accessible. Unlike Django, FastAPI has no global auth middleware by default -- each endpoint must explicitly declare its dependencies.
+
+```python
+from fastapi import FastAPI, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+
+app = FastAPI()
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+# VULNERABLE: No auth dependency -- endpoint is public
+@app.get("/users/{user_id}")
+async def get_user(user_id: int):
+    user = await User.get(user_id)
+    return user
+
+# VULNERABLE: Auth check in function body (easy to forget, not enforced)
+@app.post("/admin/settings")
+async def update_settings(settings: dict):
+    # Developer might forget this check in some endpoints
+    # No compile-time or startup-time guarantee
+    return {"status": "updated"}
+
+# VULNERABLE: Optional auth that doesn't enforce
+@app.get("/data")
+async def get_data(token: str = None):
+    if token:
+        user = verify_token(token)
+    # Continues even without valid token
+
+# SECURE: Auth via Depends()
+async def get_current_user(token: str = Depends(oauth2_scheme)):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid authentication credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=["HS256"])
+        user_id: str = payload.get("sub")
+        if user_id is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    user = await User.get(user_id)
+    if user is None:
+        raise credentials_exception
+    return user
+
+@app.get("/users/{user_id}")
+async def get_user_safe(
+    user_id: int,
+    current_user: User = Depends(get_current_user),
+):
+    user = await User.get(user_id)
+    return user
+
+# SECURE: Role-based access via dependency chain
+async def require_admin(current_user: User = Depends(get_current_user)):
+    if not current_user.is_admin:
+        raise HTTPException(status_code=403, detail="Admin required")
+    return current_user
+
+@app.post("/admin/settings")
+async def update_settings_safe(
+    settings: dict,
+    admin: User = Depends(require_admin),
+):
+    return {"status": "updated"}
+
+# SECURE: Global auth via router-level dependency
+from fastapi import APIRouter
+
+admin_router = APIRouter(
+    prefix="/admin",
+    dependencies=[Depends(require_admin)],
+)
+
+@admin_router.post("/settings")
+async def update_settings_router(settings: dict):
+    return {"status": "updated"}
+```
+
+**Detection regex:** `@app\.(get|post|put|patch|delete)\s*\(\s*["\'][^"\']*["\']\s*\)\s*\n\s*(async\s+)?def\s+\w+\s*\([^)]*\)\s*(?!.*Depends)`
+**Severity:** warning
+
+### SA-FASTAPI-02: Pydantic Validation Bypass
+
+FastAPI relies on Pydantic for request validation. However, bypasses occur when using `dict` or `Any` types, when Pydantic models have overly permissive fields, or when `model_config` disables validation features.
+
+```python
+from fastapi import FastAPI, Body
+from pydantic import BaseModel, Field, field_validator
+from typing import Any
+
+app = FastAPI()
+
+# VULNERABLE: Accepting raw dict bypasses all validation
+@app.post("/users")
+async def create_user(data: dict):
+    # No type checking, no field validation
+    # Attacker can send any fields including internal ones
+    return await User.create(**data)
+
+# VULNERABLE: Using Any type
+class UserUpdate(BaseModel):
+    role: Any  # Accepts anything -- string, list, dict, None
+    metadata: Any
+
+# VULNERABLE: Extra fields allowed (mass assignment)
+class UserCreate(BaseModel):
+    model_config = {"extra": "allow"}
+    username: str
+    email: str
+    # Attacker can add: {"username": "x", "email": "x", "is_admin": true}
+
+# VULNERABLE: No string length limits
+class Comment(BaseModel):
+    body: str  # Could be 100MB string
+    title: str
+
+# SECURE: Strict Pydantic model with validation
+class UserCreate(BaseModel):
+    model_config = {"extra": "forbid"}  # Reject unknown fields
+
+    username: str = Field(min_length=3, max_length=50, pattern=r"^[a-zA-Z0-9_]+$")
+    email: str = Field(max_length=255)
+    password: str = Field(min_length=8, max_length=128)
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, v: str) -> str:
+        if "@" not in v or "." not in v.split("@")[1]:
+            raise ValueError("Invalid email format")
+        return v.lower()
+
+class Comment(BaseModel):
+    model_config = {"extra": "forbid"}
+    body: str = Field(max_length=10000)
+    title: str = Field(max_length=200)
+
+# SECURE: Use specific types, not Any
+class UserUpdate(BaseModel):
+    model_config = {"extra": "forbid"}
+    role: str = Field(pattern=r"^(user|editor|admin)$")
+    metadata: dict[str, str] = Field(default_factory=dict, max_length=20)
+```
+
+**Detection regex:** `def\s+\w+\s*\([^)]*:\s*dict\s*[,\)]|:\s*Any\s*[,\)=]|extra\s*=\s*["\']allow["\']`
+**Severity:** warning
+
+### SA-FASTAPI-06: OAuth2 Implementation Pitfalls
+
+FastAPI provides OAuth2 utilities, but common implementation mistakes include not verifying token expiration, using weak signing algorithms, not validating token audience/issuer, and storing tokens insecurely.
+
+```python
+from fastapi import FastAPI, Depends
+from fastapi.security import OAuth2PasswordBearer
+from jose import jwt, JWTError
+from datetime import datetime, timedelta
+
+app = FastAPI()
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+# VULNERABLE: No expiration check
+async def get_current_user_bad(token: str = Depends(oauth2_scheme)):
+    payload = jwt.decode(token, SECRET_KEY, algorithms=["HS256"])
+    # No check for expired tokens!
+    user_id = payload.get("sub")
+    return await User.get(user_id)
+
+# VULNERABLE: Algorithm confusion (accepts "none" algorithm)
+async def verify_token_bad(token: str = Depends(oauth2_scheme)):
+    payload = jwt.decode(token, SECRET_KEY, algorithms=["HS256", "none"])
+    return payload
+
+# VULNERABLE: Weak secret for JWT signing
+SECRET_KEY = "secret"
+ACCESS_TOKEN_EXPIRE_MINUTES = 525600  # 1 year -- too long
+
+# VULNERABLE: No audience/issuer validation
+def create_token(user_id: str):
+    payload = {"sub": user_id}  # No exp, aud, iss claims
+    return jwt.encode(payload, SECRET_KEY, algorithm="HS256")
+
+# SECURE: Complete token creation and verification
+import os
+from datetime import datetime, timedelta, timezone
+
+SECRET_KEY = os.environ["JWT_SECRET_KEY"]
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+ISSUER = "myapp.example.com"
+AUDIENCE = "myapp-api"
+
+def create_access_token(user_id: str, scopes: list[str] = None) -> str:
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": user_id,
+        "exp": now + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
+        "iat": now,
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "scopes": scopes or [],
+    }
+    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+
+async def get_current_user_safe(token: str = Depends(oauth2_scheme)):
+    credentials_exception = HTTPException(
+        status_code=401,
+        detail="Could not validate credentials",
+    )
+    try:
+        payload = jwt.decode(
+            token,
+            SECRET_KEY,
+            algorithms=[ALGORITHM],  # Single, specific algorithm
+            audience=AUDIENCE,
+            issuer=ISSUER,
+            options={"require": ["exp", "sub", "iss", "aud"]},
+        )
+        user_id = payload.get("sub")
+        if user_id is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    user = await User.get(user_id)
+    if user is None:
+        raise credentials_exception
+    return user
+```
+
+**Detection regex:** `algorithms\s*=\s*\[.*none.*\]|jwt\.decode\s*\(\s*token\s*,\s*[^,]+\s*\)\s*$|ACCESS_TOKEN_EXPIRE.*(?:525600|86400|43200)`
+**Severity:** error
+
+## Security Misconfiguration
+
+### SA-FASTAPI-03: CORS Middleware Misconfiguration
+
+FastAPI uses Starlette's `CORSMiddleware`. Misconfiguration with wildcard origins, especially combined with `allow_credentials=True`, exposes the API to cross-origin attacks.
+
+```python
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI()
+
+# VULNERABLE: Allow all origins
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# VULNERABLE: Wildcard with credentials (browsers block this, but shows intent)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,  # Dangerous with wildcard
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# VULNERABLE: allow_origin_regex too broad
+app.add_middleware(
+    CORSMiddleware,
+    allow_origin_regex=r"https://.*\.example\.com",
+    # Matches https://evil.example.com too
+)
+
+# SECURE: Specific origins
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "https://app.example.com",
+        "https://admin.example.com",
+    ],
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "DELETE"],
+    allow_headers=["Authorization", "Content-Type"],
+)
+
+# SECURE: Environment-based CORS configuration
+import os
+
+ALLOWED_ORIGINS = os.environ.get(
+    "CORS_ORIGINS", "https://app.example.com"
+).split(",")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "DELETE"],
+    allow_headers=["Authorization", "Content-Type"],
+    max_age=3600,
+)
+```
+
+**Detection regex:** `allow_origins\s*=\s*\[\s*["\']\*["\']\s*\]|CORSMiddleware.*allow_origins.*\*`
+**Severity:** error
+
+### SA-FASTAPI-04: Response Header Injection
+
+When user input is used in response headers without sanitization, attackers can inject additional headers or modify existing ones, potentially enabling cache poisoning, session fixation, or XSS via headers.
+
+```python
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, RedirectResponse
+
+app = FastAPI()
+
+# VULNERABLE: User input in response header
+@app.get("/download")
+async def download(request: Request):
+    filename = request.query_params.get("name", "file.txt")
+    response = JSONResponse(content={"status": "ok"})
+    response.headers["Content-Disposition"] = f"attachment; filename={filename}"
+    # Attacker: ?name=file.txt\r\nX-Injected: header
+    return response
+
+# VULNERABLE: User input in redirect Location header
+@app.get("/redirect")
+async def redirect_endpoint(request: Request):
+    url = request.query_params.get("url", "/")
+    return RedirectResponse(url=url)
+    # Attacker: ?url=https://evil.com or ?url=javascript:alert(1)
+
+# VULNERABLE: User input in Set-Cookie via header
+@app.get("/set-lang")
+async def set_language(request: Request):
+    lang = request.query_params.get("lang", "en")
+    response = JSONResponse(content={"lang": lang})
+    response.headers["Set-Cookie"] = f"lang={lang}; Path=/"
+    return response
+
+# SECURE: Sanitize header values
+import re
+
+def sanitize_header_value(value: str) -> str:
+    """Remove newlines and control characters from header values."""
+    return re.sub(r"[\r\n\x00-\x1f]", "", value)
+
+@app.get("/download")
+async def download_safe(request: Request):
+    filename = request.query_params.get("name", "file.txt")
+    safe_filename = sanitize_header_value(filename)
+    safe_filename = safe_filename.replace('"', '\\"')
+    response = JSONResponse(content={"status": "ok"})
+    response.headers["Content-Disposition"] = f'attachment; filename="{safe_filename}"'
+    return response
+
+# SECURE: Validate redirect URLs
+from urllib.parse import urlparse
+
+ALLOWED_REDIRECT_HOSTS = {"example.com", "app.example.com"}
+
+@app.get("/redirect")
+async def redirect_safe(request: Request):
+    url = request.query_params.get("url", "/")
+    parsed = urlparse(url)
+    if parsed.scheme and parsed.netloc not in ALLOWED_REDIRECT_HOSTS:
+        url = "/"
+    return RedirectResponse(url=url)
+
+# SECURE: Use response.set_cookie() instead of raw headers
+@app.get("/set-lang")
+async def set_language_safe(request: Request):
+    lang = request.query_params.get("lang", "en")
+    allowed_langs = {"en", "de", "fr", "es"}
+    if lang not in allowed_langs:
+        lang = "en"
+    response = JSONResponse(content={"lang": lang})
+    response.set_cookie(key="lang", value=lang, httponly=True, samesite="lax")
+    return response
+```
+
+**Detection regex:** `response\.headers\s*\[.*\]\s*=\s*f["\']|response\.headers\s*\[.*\]\s*=.*request\.|\.headers\s*\[\s*["\']Set-Cookie["\']\s*\]\s*=`
+**Severity:** warning
+
+### SA-FASTAPI-05: File Upload Handling
+
+FastAPI handles file uploads via `UploadFile`. Without proper validation of file size, type, and content, attackers can upload malicious files, cause denial of service with large files, or exploit path traversal via filenames.
+
+```python
+from fastapi import FastAPI, UploadFile, File, HTTPException
+import shutil
+import os
+
+app = FastAPI()
+
+# VULNERABLE: No file size or type validation
+@app.post("/upload")
+async def upload_file(file: UploadFile = File(...)):
+    with open(f"/app/uploads/{file.filename}", "wb") as f:
+        shutil.copyfileobj(file.file, f)
+    return {"filename": file.filename}
+
+# VULNERABLE: Trusting content_type header
+@app.post("/upload-image")
+async def upload_image(file: UploadFile = File(...)):
+    if file.content_type.startswith("image/"):  # easily spoofed
+        contents = await file.read()
+        # Process as image...
+
+# VULNERABLE: Path traversal via filename
+@app.post("/upload")
+async def upload_bad(file: UploadFile = File(...)):
+    path = os.path.join("/app/uploads", file.filename)
+    # file.filename = "../../etc/cron.d/backdoor"
+
+# SECURE: Validate file size, type, and sanitize filename
+import uuid
+import magic
+
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
+ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".pdf"}
+ALLOWED_MIMES = {"image/jpeg", "image/png", "image/gif", "application/pdf"}
+
+@app.post("/upload")
+async def upload_safe(file: UploadFile = File(...)):
+    # Check extension
+    ext = os.path.splitext(file.filename)[1].lower()
+    if ext not in ALLOWED_EXTENSIONS:
+        raise HTTPException(400, f"File type {ext} not allowed")
+
+    # Read with size limit
+    contents = await file.read()
+    if len(contents) > MAX_FILE_SIZE:
+        raise HTTPException(400, "File too large (max 10 MB)")
+
+    # Verify actual content type with python-magic
+    mime = magic.from_buffer(contents[:2048], mime=True)
+    if mime not in ALLOWED_MIMES:
+        raise HTTPException(400, f"Invalid file content type: {mime}")
+
+    # Generate safe filename
+    safe_filename = f"{uuid.uuid4()}{ext}"
+    filepath = os.path.join("/app/uploads", safe_filename)
+
+    with open(filepath, "wb") as f:
+        f.write(contents)
+
+    return {"filename": safe_filename}
+```
+
+**Detection regex:** `UploadFile.*filename|file\.filename|shutil\.copyfileobj\s*\(\s*file`
+**Severity:** warning
+
+## Data Exposure
+
+### SA-FASTAPI-07: Background Task Data Exposure
+
+FastAPI's `BackgroundTasks` run after the response is sent. If background tasks reference mutable request data, session objects, or database connections from the request scope, they may access stale or recycled data.
+
+```python
+from fastapi import FastAPI, BackgroundTasks, Depends, Request
+
+app = FastAPI()
+
+# VULNERABLE: Background task captures request object
+@app.post("/process")
+async def process_data(request: Request, background_tasks: BackgroundTasks):
+    background_tasks.add_task(log_request, request)
+    # request object may be recycled by the time the task runs
+    return {"status": "accepted"}
+
+async def log_request(request: Request):
+    # Request body may already be consumed or connection closed
+    body = await request.body()  # May fail or return wrong data
+    print(f"Logged: {body}")
+
+# VULNERABLE: Background task with db session from request scope
+@app.post("/orders")
+async def create_order(
+    order: OrderCreate,
+    db: Session = Depends(get_db),
+    background_tasks: BackgroundTasks,
+):
+    new_order = Order(**order.dict())
+    db.add(new_order)
+    db.commit()
+    # db session will be closed after response -- task may fail
+    background_tasks.add_task(send_confirmation, db, new_order.id)
+
+# VULNERABLE: Logging sensitive data in background task
+@app.post("/login")
+async def login(creds: LoginRequest, background_tasks: BackgroundTasks):
+    user = authenticate(creds.username, creds.password)
+    background_tasks.add_task(log_login_attempt, creds.username, creds.password)
+    # Password logged in background -- visible in logs
+    return {"token": create_token(user)}
+
+# SECURE: Extract needed data before passing to background task
+@app.post("/process")
+async def process_data_safe(request: Request, background_tasks: BackgroundTasks):
+    body = await request.body()
+    headers = dict(request.headers)
+    background_tasks.add_task(log_request_safe, body, headers)
+    return {"status": "accepted"}
+
+async def log_request_safe(body: bytes, headers: dict):
+    print(f"Logged: {len(body)} bytes")
+
+# SECURE: Create new db session in background task
+@app.post("/orders")
+async def create_order_safe(
+    order: OrderCreate,
+    db: Session = Depends(get_db),
+    background_tasks: BackgroundTasks,
+):
+    new_order = Order(**order.dict())
+    db.add(new_order)
+    db.commit()
+    order_id = new_order.id  # Extract the ID
+    background_tasks.add_task(send_confirmation_safe, order_id)
+
+async def send_confirmation_safe(order_id: int):
+    async with get_async_session() as db:
+        order = await db.get(Order, order_id)
+        await send_email(order.user.email, "Order confirmed", str(order))
+```
+
+**Detection regex:** `background_tasks\.add_task\s*\(.*request\b|background_tasks\.add_task\s*\(.*\bdb\b|BackgroundTasks.*password|BackgroundTasks.*secret`
+**Severity:** warning
+
+### SA-FASTAPI-08: WebSocket Authentication
+
+FastAPI WebSocket endpoints do not automatically inherit HTTP authentication. Without explicit auth checks, WebSocket connections can be established by unauthenticated users. Browsers do not send custom headers with WebSocket upgrade requests, so token-based auth must use query parameters or the first message.
+
+```python
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Depends, Query
+from fastapi.security import OAuth2PasswordBearer
+
+app = FastAPI()
+
+# VULNERABLE: No authentication on WebSocket
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    while True:
+        data = await websocket.receive_text()
+        await websocket.send_text(f"Echo: {data}")
+
+# VULNERABLE: Auth check after accept (connection already established)
+@app.websocket("/ws/chat")
+async def chat(websocket: WebSocket):
+    await websocket.accept()
+    token = await websocket.receive_text()  # First message is token
+    # Connection is already open -- attacker can send/receive before auth
+    user = verify_token(token)
+    if not user:
+        await websocket.close(code=1008)
+        return
+
+# SECURE: Auth via query parameter, verified before accept
+@app.websocket("/ws")
+async def websocket_safe(websocket: WebSocket, token: str = Query(...)):
+    user = verify_token(token)
+    if not user:
+        await websocket.close(code=1008)
+        return
+    await websocket.accept()
+    while True:
+        data = await websocket.receive_text()
+        await websocket.send_text(f"Echo: {data}")
+
+# SECURE: Auth via dependency injection
+async def get_ws_user(websocket: WebSocket) -> User:
+    token = websocket.query_params.get("token")
+    if not token:
+        await websocket.close(code=1008)
+        raise WebSocketDisconnect(code=1008)
+    user = verify_token(token)
+    if not user:
+        await websocket.close(code=1008)
+        raise WebSocketDisconnect(code=1008)
+    return user
+
+@app.websocket("/ws")
+async def websocket_with_dep(
+    websocket: WebSocket,
+    user: User = Depends(get_ws_user),
+):
+    await websocket.accept()
+    while True:
+        data = await websocket.receive_text()
+        await websocket.send_text(f"Hello {user.name}: {data}")
+
+# SECURE: Cookie-based auth for WebSockets
+@app.websocket("/ws")
+async def websocket_cookie_auth(websocket: WebSocket):
+    session_id = websocket.cookies.get("session_id")
+    if not session_id:
+        await websocket.close(code=1008)
+        return
+    user = await get_user_from_session(session_id)
+    if not user:
+        await websocket.close(code=1008)
+        return
+    await websocket.accept()
+    # ... handle messages
+```
+
+**Detection regex:** `@app\.websocket\s*\(\s*["\'][^"\']*["\']\s*\)\s*\n\s*async\s+def\s+\w+\s*\(\s*websocket\s*:\s*WebSocket\s*\)\s*:`
+**Severity:** warning
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| SA-FASTAPI-01: Missing auth dependency | High | Immediate | Low |
+| SA-FASTAPI-02: Pydantic validation bypass | Medium | 1 week | Medium |
+| SA-FASTAPI-03: CORS wildcard origins | High | Immediate | Low |
+| SA-FASTAPI-04: Response header injection | Medium | 1 week | Low |
+| SA-FASTAPI-05: File upload handling | Medium | 1 week | Medium |
+| SA-FASTAPI-06: OAuth2 pitfalls | High | Immediate | Medium |
+| SA-FASTAPI-07: Background task data exposure | Medium | 1 week | Medium |
+| SA-FASTAPI-08: WebSocket auth | High | 1 week | Medium |
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `python-security-features.md` — Language-level Python patterns
+- `django-security.md` — Django-specific patterns
+- `flask-security.md` — Flask-specific patterns
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 2: Python framework coverage |

--- a/skills/security-audit/references/flask-security.md
+++ b/skills/security-audit/references/flask-security.md
@@ -1,0 +1,467 @@
+# Flask Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for Flask applications. Covers Jinja2 SSTI, request parameter injection, path traversal, client-side session tampering, debug mode, CORS misconfiguration, session fixation, and SQLAlchemy raw query injection.
+
+## Injection
+
+### SA-FLASK-01: Jinja2 Server-Side Template Injection (SSTI)
+
+When user input is passed directly into Jinja2 template strings (not template files), attackers can execute arbitrary Python code on the server. This occurs when `render_template_string()` is used with unsanitized input or when templates are constructed from user data.
+
+```python
+from flask import Flask, request, render_template_string, render_template
+
+app = Flask(__name__)
+
+# VULNERABLE: User input in render_template_string
+@app.route("/greet")
+def greet():
+    name = request.args.get("name", "World")
+    template = f"<h1>Hello, {name}!</h1>"
+    return render_template_string(template)
+    # Attacker: ?name={{config.items()}}
+    # Attacker: ?name={{''.__class__.__mro__[1].__subclasses__()}}
+
+# VULNERABLE: Template constructed from user input
+@app.route("/page")
+def dynamic_page():
+    header = request.args.get("header", "Welcome")
+    body = request.args.get("body", "")
+    template = "<h1>" + header + "</h1><p>" + body + "</p>"
+    return render_template_string(template)
+
+# VULNERABLE: User input as format string then rendered
+@app.route("/email-preview")
+def email_preview():
+    template_str = request.form.get("template")
+    return render_template_string(template_str)  # Full SSTI
+
+# SECURE: Pass user input as template variable
+@app.route("/greet")
+def greet_safe():
+    name = request.args.get("name", "World")
+    return render_template_string("<h1>Hello, {{ name }}!</h1>", name=name)
+
+# SECURE: Use render_template with .html files
+@app.route("/greet")
+def greet_safest():
+    name = request.args.get("name", "World")
+    return render_template("greet.html", name=name)
+
+# SECURE: Use Jinja2 sandbox for user-provided templates
+from jinja2.sandbox import SandboxedEnvironment
+
+sandbox = SandboxedEnvironment()
+
+@app.route("/custom-template")
+def custom_template():
+    template_str = request.form.get("template")
+    template = sandbox.from_string(template_str)
+    return template.render(data=get_safe_data())
+```
+
+**Detection regex:** `render_template_string\s*\(`
+**Severity:** error
+
+### SA-FLASK-02: Request Parameter Injection
+
+Flask's `request.args`, `request.form`, and `request.values` return user-controlled data. Using this data without validation in database queries, shell commands, file operations, or URL construction leads to injection vulnerabilities.
+
+```python
+from flask import Flask, request, redirect
+import subprocess
+import os
+
+app = Flask(__name__)
+
+# VULNERABLE: request.args in shell command
+@app.route("/ping")
+def ping():
+    host = request.args.get("host", "localhost")
+    result = subprocess.run(f"ping -c 1 {host}", shell=True, capture_output=True)
+    return result.stdout.decode()
+    # Attacker: ?host=localhost;cat /etc/passwd
+
+# VULNERABLE: request.args in file path
+@app.route("/read")
+def read_file():
+    filename = request.args.get("file")
+    path = os.path.join("/app/data/", filename)
+    return open(path).read()
+    # Attacker: ?file=../../etc/passwd
+
+# VULNERABLE: request.args in redirect
+@app.route("/login")
+def login():
+    next_url = request.args.get("next", "/")
+    return redirect(next_url)
+    # Attacker: ?next=https://evil.com
+
+# SECURE: Validate and sanitize input
+import re
+from urllib.parse import urlparse
+
+@app.route("/ping")
+def ping_safe():
+    host = request.args.get("host", "localhost")
+    if not re.match(r"^[a-zA-Z0-9.\-]+$", host):
+        return "Invalid host", 400
+    result = subprocess.run(
+        ["ping", "-c", "1", host],  # list form, no shell=True
+        capture_output=True
+    )
+    return result.stdout.decode()
+
+@app.route("/login")
+def login_safe():
+    next_url = request.args.get("next", "/")
+    parsed = urlparse(next_url)
+    if parsed.netloc and parsed.netloc != request.host:
+        next_url = "/"
+    return redirect(next_url)
+```
+
+**Detection regex:** `request\.args\s*\[|request\.args\.get\s*\(|request\.form\s*\[|request\.form\.get\s*\(|request\.values`
+**Severity:** warning
+
+### SA-FLASK-06: SQLAlchemy Raw Query Injection
+
+SQLAlchemy provides an ORM that generates parameterized queries by default. However, using `text()`, `execute()`, or string concatenation to build queries introduces SQL injection vulnerabilities.
+
+```python
+from flask import Flask, request
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import text
+
+app = Flask(__name__)
+db = SQLAlchemy(app)
+
+# VULNERABLE: String formatting in execute()
+@app.route("/users")
+def search_users():
+    name = request.args.get("name")
+    result = db.session.execute(
+        f"SELECT * FROM users WHERE name = '{name}'"
+    )
+    return jsonify([dict(r) for r in result])
+
+# VULNERABLE: String concatenation with text()
+@app.route("/products")
+def search_products():
+    category = request.args.get("cat")
+    query = text("SELECT * FROM products WHERE category = '" + category + "'")
+    result = db.session.execute(query)
+    return jsonify([dict(r) for r in result])
+
+# VULNERABLE: %-formatting in raw SQL
+@app.route("/orders")
+def get_orders():
+    user_id = request.args.get("user_id")
+    sql = "SELECT * FROM orders WHERE user_id = %s" % user_id
+    result = db.engine.execute(sql)
+    return jsonify([dict(r) for r in result])
+
+# SECURE: Use parameterized text() queries
+@app.route("/users")
+def search_users_safe():
+    name = request.args.get("name")
+    result = db.session.execute(
+        text("SELECT * FROM users WHERE name = :name"),
+        {"name": name}
+    )
+    return jsonify([dict(r) for r in result])
+
+# SECURE: Use ORM query methods
+@app.route("/users")
+def search_users_orm():
+    name = request.args.get("name")
+    users = User.query.filter_by(name=name).all()
+    return jsonify([u.to_dict() for u in users])
+
+# SECURE: Use parameterized execute with bound parameters
+@app.route("/products")
+def search_products_safe():
+    category = request.args.get("cat")
+    stmt = text("SELECT * FROM products WHERE category = :cat")
+    result = db.session.execute(stmt.bindparams(cat=category))
+    return jsonify([dict(r) for r in result])
+```
+
+**Detection regex:** `db\.session\.execute\s*\(\s*f["\']|db\.session\.execute\s*\(\s*["\'].*%s.*["\']\s*%|db\.engine\.execute\s*\(\s*f["\']|\.execute\s*\(\s*f["\']SELECT|\.execute\s*\(\s*f["\']INSERT|\.execute\s*\(\s*f["\']UPDATE|\.execute\s*\(\s*f["\']DELETE`
+**Severity:** error
+
+## Security Misconfiguration
+
+### SA-FLASK-03: Path Traversal via send_file / send_from_directory
+
+Flask's `send_file()` and `send_from_directory()` serve files from the filesystem. If user input is used to construct file paths without proper sanitization, attackers can read arbitrary files.
+
+```python
+from flask import Flask, request, send_file, send_from_directory
+import os
+
+app = Flask(__name__)
+
+# VULNERABLE: send_file with user-controlled path
+@app.route("/download")
+def download():
+    filename = request.args.get("file")
+    return send_file(f"/app/uploads/{filename}")
+    # Attacker: ?file=../../etc/passwd
+
+# VULNERABLE: os.path.join does not prevent traversal
+@app.route("/static/<path:filename>")
+def serve_static(filename):
+    filepath = os.path.join("/app/static/", filename)
+    return send_file(filepath)
+    # Attacker: /static/../../etc/passwd
+
+# SECURE: Use send_from_directory (validates path stays within directory)
+@app.route("/download")
+def download_safe():
+    filename = request.args.get("file")
+    return send_from_directory("/app/uploads", filename)
+
+# SECURE: Validate filename against allowlist
+@app.route("/download")
+def download_allowlist():
+    filename = request.args.get("file")
+    allowed = {"report.pdf", "data.csv", "readme.txt"}
+    if filename not in allowed:
+        return "File not found", 404
+    return send_from_directory("/app/uploads", filename)
+
+# SECURE: Use secure_filename and validate extension
+from werkzeug.utils import secure_filename
+
+@app.route("/download/<filename>")
+def download_secure(filename):
+    safe_name = secure_filename(filename)
+    if not safe_name:
+        return "Invalid filename", 400
+    allowed_ext = {".pdf", ".csv", ".txt"}
+    ext = os.path.splitext(safe_name)[1].lower()
+    if ext not in allowed_ext:
+        return "Invalid file type", 400
+    return send_from_directory("/app/uploads", safe_name)
+```
+
+**Detection regex:** `send_file\s*\(\s*f["\']|send_file\s*\(\s*.*request\.|send_file\s*\(\s*os\.path\.join`
+**Severity:** error
+
+### SA-FLASK-04: debug=True in Production
+
+Flask's debug mode enables the Werkzeug interactive debugger, which allows arbitrary code execution in the browser. It also exposes detailed tracebacks, environment variables, and source code.
+
+```python
+from flask import Flask
+
+app = Flask(__name__)
+
+# VULNERABLE: debug=True in app.run()
+if __name__ == "__main__":
+    app.run(debug=True)
+
+# VULNERABLE: Debug mode via config
+app.config["DEBUG"] = True
+
+# VULNERABLE: ENV set to development (enables debug features)
+app.config["ENV"] = "development"
+
+# VULNERABLE: FLASK_DEBUG=1 in .env or .flaskenv
+# .flaskenv:
+# FLASK_DEBUG=1
+
+# SECURE: debug=False (default)
+if __name__ == "__main__":
+    app.run(debug=False, host="0.0.0.0", port=8000)
+
+# SECURE: Use environment variable with safe default
+import os
+debug_mode = os.environ.get("FLASK_DEBUG", "0") == "1"
+if __name__ == "__main__":
+    app.run(debug=debug_mode)
+
+# SECURE: Use a WSGI server in production
+# gunicorn -w 4 -b 0.0.0.0:8000 myapp:app
+# uwsgi --http 0.0.0.0:8000 --module myapp:app
+```
+
+**Detection regex:** `app\.run\s*\(.*debug\s*=\s*True|\.config\s*\[\s*["\']DEBUG["\']\s*\]\s*=\s*True|FLASK_DEBUG\s*=\s*1`
+**Severity:** error
+
+### SA-FLASK-05: Client-Side Session Tampering
+
+Flask's default session implementation uses signed cookies. The session data is encoded (not encrypted) and visible to clients. If the `SECRET_KEY` is weak or leaked, attackers can forge session cookies.
+
+```python
+from flask import Flask, session
+
+app = Flask(__name__)
+
+# VULNERABLE: Weak SECRET_KEY
+app.secret_key = "dev"
+app.secret_key = "changeme"
+app.secret_key = "super-secret"
+
+# VULNERABLE: Storing sensitive data in client-side session
+@app.route("/login", methods=["POST"])
+def login():
+    user = authenticate(request.form["username"], request.form["password"])
+    if user:
+        session["user_id"] = user.id
+        session["is_admin"] = user.is_admin  # Visible to client!
+        session["permissions"] = user.permissions  # Visible to client!
+
+# VULNERABLE: SECRET_KEY in source code
+app.config["SECRET_KEY"] = "my-production-secret-key-2024"
+
+# SECURE: Strong, random SECRET_KEY from environment
+import os
+app.secret_key = os.environ["FLASK_SECRET_KEY"]
+
+# SECURE: Use server-side session storage
+# pip install flask-session
+from flask_session import Session
+
+app.config["SESSION_TYPE"] = "redis"  # or "filesystem", "sqlalchemy"
+app.config["SESSION_PERMANENT"] = False
+app.config["SESSION_USE_SIGNER"] = True
+app.config["SECRET_KEY"] = os.environ["FLASK_SECRET_KEY"]
+Session(app)
+
+# SECURE: Minimal data in session, verify server-side
+@app.route("/login", methods=["POST"])
+def login_safe():
+    user = authenticate(request.form["username"], request.form["password"])
+    if user:
+        session["user_id"] = user.id
+        # Check is_admin from database on each request, not from session
+```
+
+**Detection regex:** `secret_key\s*=\s*["\'][^"\']{1,30}["\']|app\.config\s*\[\s*["\']SECRET_KEY["\']\s*\]\s*=\s*["\']`
+**Severity:** error
+
+### SA-FLASK-07: Session Fixation with Flask-Login
+
+Session fixation occurs when an application does not regenerate the session ID after authentication. If Flask-Login or custom session handling does not rotate sessions on login, attackers can pre-set a session cookie for the victim.
+
+```python
+from flask import Flask, session, request
+from flask_login import LoginManager, login_user
+
+app = Flask(__name__)
+login_manager = LoginManager(app)
+
+# VULNERABLE: No session regeneration on login
+@app.route("/login", methods=["POST"])
+def login():
+    user = User.query.filter_by(
+        username=request.form["username"]
+    ).first()
+    if user and user.check_password(request.form["password"]):
+        login_user(user)  # Session ID not regenerated
+        return redirect("/dashboard")
+
+# SECURE: Regenerate session on login
+@app.route("/login", methods=["POST"])
+def login_safe():
+    user = User.query.filter_by(
+        username=request.form["username"]
+    ).first()
+    if user and user.check_password(request.form["password"]):
+        # Clear and regenerate session
+        old_data = dict(session)
+        session.clear()
+        session.regenerate()  # Flask-Session >=0.6
+        # Restore non-sensitive session data if needed
+        login_user(user)
+        return redirect("/dashboard")
+
+# SECURE: Configure session cookie security
+app.config.update(
+    SESSION_COOKIE_HTTPONLY=True,
+    SESSION_COOKIE_SECURE=True,  # HTTPS only
+    SESSION_COOKIE_SAMESITE="Lax",
+    PERMANENT_SESSION_LIFETIME=1800,  # 30 minutes
+)
+```
+
+**Detection regex:** `login_user\s*\(|flask_login\s+import.*login_user`
+**Severity:** warning
+
+### SA-FLASK-08: CORS Misconfiguration
+
+Flask-CORS or manual CORS header configuration can expose APIs to cross-origin requests from any domain if configured with wildcards or overly permissive origins.
+
+```python
+from flask import Flask
+from flask_cors import CORS
+
+app = Flask(__name__)
+
+# VULNERABLE: Allow all origins
+CORS(app)  # Defaults to allow all origins (*)
+
+# VULNERABLE: Wildcard with credentials
+CORS(app, origins="*", supports_credentials=True)
+
+# VULNERABLE: Reflecting Origin header
+@app.after_request
+def add_cors(response):
+    origin = request.headers.get("Origin")
+    response.headers["Access-Control-Allow-Origin"] = origin  # reflects any origin
+    response.headers["Access-Control-Allow-Credentials"] = "true"
+    return response
+
+# SECURE: Specific origins only
+CORS(app, origins=["https://app.example.com", "https://admin.example.com"])
+
+# SECURE: Per-route CORS with specific origins
+from flask_cors import cross_origin
+
+@app.route("/api/public")
+@cross_origin(origins=["https://app.example.com"])
+def public_api():
+    return jsonify({"data": "public"})
+
+# SECURE: Validate origin against allowlist
+ALLOWED_ORIGINS = {"https://app.example.com", "https://admin.example.com"}
+
+@app.after_request
+def add_cors_safe(response):
+    origin = request.headers.get("Origin")
+    if origin in ALLOWED_ORIGINS:
+        response.headers["Access-Control-Allow-Origin"] = origin
+        response.headers["Access-Control-Allow-Credentials"] = "true"
+    return response
+```
+
+**Detection regex:** `CORS\s*\(\s*app\s*\)|origins\s*=\s*["\']\*["\']|Access-Control-Allow-Origin.*\*`
+**Severity:** error
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| SA-FLASK-01: Jinja2 SSTI | Critical | Immediate | Medium |
+| SA-FLASK-02: Request parameter injection | High | 1 week | Medium |
+| SA-FLASK-03: Path traversal (send_file) | High | Immediate | Low |
+| SA-FLASK-04: debug=True in production | Critical | Immediate | Low |
+| SA-FLASK-05: Client-side session tampering | High | 1 week | Medium |
+| SA-FLASK-06: SQLAlchemy raw query injection | Critical | Immediate | Medium |
+| SA-FLASK-07: Session fixation | Medium | 1 week | Medium |
+| SA-FLASK-08: CORS misconfiguration | High | 1 week | Low |
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `python-security-features.md` — Language-level Python patterns
+- `django-security.md` — Django-specific patterns
+- `fastapi-security.md` — FastAPI-specific patterns
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 2: Python framework coverage |

--- a/skills/security-audit/references/flask-security.md
+++ b/skills/security-audit/references/flask-security.md
@@ -129,7 +129,7 @@ def login_safe():
 SQLAlchemy provides an ORM that generates parameterized queries by default. However, using `text()`, `execute()`, or string concatenation to build queries introduces SQL injection vulnerabilities.
 
 ```python
-from flask import Flask, request
+from flask import Flask, jsonify, request
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import text
 
@@ -295,9 +295,12 @@ if __name__ == "__main__":
 Flask's default session implementation uses signed cookies. The session data is encoded (not encrypted) and visible to clients. If the `SECRET_KEY` is weak or leaked, attackers can forge session cookies.
 
 ```python
-from flask import Flask, session
+from flask import Flask, request, session
 
 app = Flask(__name__)
+
+def authenticate(username: str, password: str):
+    ...  # look up + verify user; return user object or None
 
 # VULNERABLE: Weak SECRET_KEY
 app.secret_key = "dev"
@@ -363,19 +366,23 @@ def login():
         login_user(user)  # Session ID not regenerated
         return redirect("/dashboard")
 
-# SECURE: Regenerate session on login
+# SECURE: Rotate the session on login. Flask's built-in session has no
+# first-class "regenerate ID" API (it's a signed-cookie implementation, so
+# every session payload is already bound to the current signing key).
+# Portable approach: clear() the old session before populating it with the
+# authenticated identity, which invalidates the previous cookie value.
+# If you use server-side sessions (Flask-Session, Flask-Login), rotate the
+# backend session ID with the backend's documented call — the exact name
+# varies (flask_session.SessionInterface backends expose their own rotate
+# hook; consult your backend's docs).
 @app.route("/login", methods=["POST"])
 def login_safe():
     user = User.query.filter_by(
         username=request.form["username"]
     ).first()
     if user and user.check_password(request.form["password"]):
-        # Clear and regenerate session
-        old_data = dict(session)
-        session.clear()
-        session.regenerate()  # Flask-Session >=0.6
-        # Restore non-sensitive session data if needed
-        login_user(user)
+        session.clear()            # drop any pre-login session state
+        login_user(user)           # Flask-Login writes a fresh session
         return redirect("/dashboard")
 
 # SECURE: Configure session cookie security

--- a/skills/security-audit/references/python-security-features.md
+++ b/skills/security-audit/references/python-security-features.md
@@ -1,0 +1,937 @@
+# Python Security Features by Version
+
+Modern Python versions introduce language features and standard library changes that directly improve security when used correctly. This reference documents security-relevant patterns and features from Python 3.9 through 3.13, with detection regexes for automated auditing.
+
+## Core Python Security Patterns
+
+These patterns apply across all supported Python versions (3.9+) and represent the most common vulnerability classes found in Python codebases.
+
+### 1. Insecure Deserialization via pickle / shelve / marshal
+
+The `pickle` module can execute arbitrary code during deserialization. Any data from an untrusted source that is unpickled can lead to remote code execution. The `shelve` module uses `pickle` internally and inherits the same risk. `marshal` is similarly unsafe.
+
+```python
+# VULNERABLE: Deserializing untrusted data with pickle
+import pickle
+
+def load_user_session(session_data: bytes):
+    # An attacker can craft a pickle payload that executes os.system("rm -rf /")
+    return pickle.loads(session_data)
+
+# VULNERABLE: shelve uses pickle internally
+import shelve
+
+def load_cache(cache_path: str):
+    db = shelve.open(cache_path)  # If cache_path is user-controlled, RCE is possible
+    return db["settings"]
+
+# VULNERABLE: marshal is not safe for untrusted data
+import marshal
+
+def load_bytecode(data: bytes):
+    return marshal.loads(data)
+```
+
+```python
+# SECURE: Use JSON or other safe serialization formats
+import json
+from typing import Any
+
+def load_user_session(session_data: str) -> dict[str, Any]:
+    return json.loads(session_data)
+
+# SECURE: If pickle is necessary, use hmac to verify integrity
+import hmac
+import hashlib
+
+SECRET_KEY = b"server-side-secret"
+
+def load_verified_data(signed_data: bytes, signature: bytes) -> Any:
+    expected = hmac.new(SECRET_KEY, signed_data, hashlib.sha256).digest()
+    if not hmac.compare_digest(signature, expected):
+        raise ValueError("Data integrity check failed")
+    return json.loads(signed_data)
+
+# SECURE: Use RestrictedUnpickler to whitelist allowed classes
+import pickle
+import io
+
+class RestrictedUnpickler(pickle.Unpickler):
+    ALLOWED_CLASSES = {("builtins", "dict"), ("builtins", "list")}
+
+    def find_class(self, module: str, name: str) -> type:
+        if (module, name) not in self.ALLOWED_CLASSES:
+            raise pickle.UnpicklingError(f"Forbidden: {module}.{name}")
+        return super().find_class(module, name)
+
+def safe_unpickle(data: bytes):
+    return RestrictedUnpickler(io.BytesIO(data)).load()
+```
+
+**Security implication:** Insecure deserialization (CWE-502) is consistently ranked in the OWASP Top 10. Pickle payloads can execute arbitrary system commands, exfiltrate data, or establish reverse shells. Never unpickle data from untrusted sources.
+
+### 2. Code Injection via eval() / exec() / compile()
+
+The `eval()` and `exec()` builtins execute arbitrary Python code. When user input reaches these functions, attackers gain full code execution.
+
+```python
+# VULNERABLE: eval with user input
+def calculate(expression: str) -> float:
+    return eval(expression)  # User sends: __import__('os').system('id')
+
+# VULNERABLE: exec with user input
+def run_user_script(code: str):
+    exec(code)  # Full arbitrary code execution
+
+# VULNERABLE: compile + exec
+def execute_template(template_code: str):
+    compiled = compile(template_code, "<string>", "exec")
+    exec(compiled)
+```
+
+```python
+# SECURE: Use ast.literal_eval for safe evaluation of literals
+import ast
+
+def parse_value(user_input: str):
+    return ast.literal_eval(user_input)  # Only allows literals: strings, numbers, tuples, lists, dicts, bools, None
+
+# SECURE: Use a math expression parser for calculations
+from decimal import Decimal
+import operator
+
+SAFE_OPS = {
+    "+": operator.add,
+    "-": operator.sub,
+    "*": operator.mul,
+    "/": operator.truediv,
+}
+
+def safe_calculate(left: str, op: str, right: str) -> Decimal:
+    if op not in SAFE_OPS:
+        raise ValueError(f"Unsupported operator: {op}")
+    return SAFE_OPS[op](Decimal(left), Decimal(right))
+```
+
+**Security implication:** Code injection (CWE-94, CWE-95) allows full system compromise. Even `eval()` with restricted globals can be bypassed. There is no safe way to sandbox `eval()` or `exec()` in CPython.
+
+### 3. Server-Side Template Injection (SSTI) in Jinja2 and Mako
+
+When user input is passed directly as a template string rather than as a template variable, attackers can execute arbitrary code through the template engine.
+
+```python
+# VULNERABLE: User input used as Jinja2 template source
+from jinja2 import Template
+
+def render_greeting(user_input: str) -> str:
+    template = Template(user_input)  # SSTI! User sends: {{ config.__class__.__init__.__globals__['os'].popen('id').read() }}
+    return template.render()
+
+# VULNERABLE: Jinja2 Environment without sandboxing
+from jinja2 import Environment
+
+env = Environment()
+template = env.from_string(user_input)  # Same SSTI risk
+
+# VULNERABLE: Mako template injection
+from mako.template import Template as MakoTemplate
+
+def render_mako(user_input: str) -> str:
+    return MakoTemplate(user_input).render()  # RCE via ${__import__('os').system('id')}
+```
+
+```python
+# SECURE: Pass user input as a variable, not as the template itself
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+env = Environment(
+    loader=FileSystemLoader("templates"),
+    autoescape=select_autoescape(["html", "xml"]),
+)
+
+def render_greeting(username: str) -> str:
+    template = env.get_template("greeting.html")
+    return template.render(username=username)
+
+# SECURE: Use Jinja2 SandboxedEnvironment if dynamic templates are required
+from jinja2.sandbox import SandboxedEnvironment
+
+sandbox_env = SandboxedEnvironment()
+
+def render_sandboxed(template_str: str, variables: dict) -> str:
+    # SandboxedEnvironment restricts attribute access and method calls
+    template = sandbox_env.from_string(template_str)
+    return template.render(**variables)
+```
+
+**Security implication:** SSTI (CWE-1336) in Python template engines typically leads to Remote Code Execution. Jinja2's default `Environment` does not sandbox templates. Always load templates from files and pass user data as variables.
+
+### 4. Command Injection via subprocess / os.system / os.popen
+
+Passing user input to shell commands without proper sanitization leads to command injection.
+
+```python
+# VULNERABLE: subprocess with shell=True
+import subprocess
+
+def ping_host(hostname: str):
+    subprocess.call(f"ping -c 1 {hostname}", shell=True)
+    # User sends: "127.0.0.1; cat /etc/passwd"
+
+# VULNERABLE: os.system always uses the shell
+import os
+
+def list_directory(path: str):
+    os.system(f"ls -la {path}")  # User sends: "/tmp; rm -rf /"
+
+# VULNERABLE: os.popen uses the shell
+def get_disk_usage(path: str) -> str:
+    return os.popen(f"du -sh {path}").read()
+```
+
+```python
+# SECURE: Use subprocess with shell=False (the default) and argument list
+import subprocess
+import shlex
+
+def ping_host(hostname: str):
+    # Validate hostname format first
+    if not hostname.replace(".", "").replace("-", "").isalnum():
+        raise ValueError("Invalid hostname")
+    result = subprocess.run(
+        ["ping", "-c", "1", hostname],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return result.stdout
+
+# SECURE: Use pathlib for filesystem operations instead of shell commands
+from pathlib import Path
+
+def list_directory(path: str) -> list[str]:
+    target = Path(path).resolve()
+    allowed_root = Path("/var/data").resolve()
+    if not str(target).startswith(str(allowed_root)):
+        raise ValueError("Path outside allowed directory")
+    return [str(p) for p in target.iterdir()]
+```
+
+**Security implication:** OS command injection (CWE-78) is a critical vulnerability. Using `shell=True` with `subprocess` or any function in the `os.system` / `os.popen` family exposes the application to shell metacharacter injection.
+
+### 5. Unsafe YAML Loading
+
+`yaml.load()` without a safe Loader can execute arbitrary Python objects, leading to code execution.
+
+```python
+# VULNERABLE: yaml.load without Loader argument
+import yaml
+
+def parse_config(config_str: str) -> dict:
+    return yaml.load(config_str)  # Default Loader can instantiate arbitrary Python objects
+
+# VULNERABLE: yaml.load with FullLoader (still allows some dangerous tags)
+def parse_data(data: str) -> dict:
+    return yaml.load(data, Loader=yaml.FullLoader)
+```
+
+```python
+# SECURE: Use yaml.safe_load (or SafeLoader)
+import yaml
+
+def parse_config(config_str: str) -> dict:
+    return yaml.safe_load(config_str)  # Only allows basic Python types
+
+# SECURE: Use yaml.safe_load_all for multi-document YAML
+def parse_multi_doc(data: str) -> list:
+    return list(yaml.safe_load_all(data))
+```
+
+**Security implication:** Unsafe YAML deserialization (CWE-502) allows instantiation of arbitrary Python objects. The `!!python/object` tag in YAML can trigger code execution. Always use `yaml.safe_load()`.
+
+### 6. SQL Injection via String Formatting
+
+Building SQL queries with f-strings, `.format()`, or `%` string formatting with user input causes SQL injection.
+
+```python
+# VULNERABLE: f-string in SQL query
+import sqlite3
+
+def get_user(db: sqlite3.Connection, username: str):
+    cursor = db.execute(f"SELECT * FROM users WHERE name = '{username}'")
+    return cursor.fetchone()
+
+# VULNERABLE: .format() in SQL query
+def search_users(db, query: str):
+    sql = "SELECT * FROM users WHERE name LIKE '%{}%'".format(query)
+    return db.execute(sql).fetchall()
+
+# VULNERABLE: % formatting in SQL query
+def get_order(db, order_id: str):
+    return db.execute("SELECT * FROM orders WHERE id = %s" % order_id).fetchone()
+
+# VULNERABLE: String concatenation in Django raw query
+from django.db import connection
+
+def get_user_django(name: str):
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT * FROM users WHERE name = '" + name + "'")
+        return cursor.fetchone()
+```
+
+```python
+# SECURE: Parameterized queries
+import sqlite3
+
+def get_user(db: sqlite3.Connection, username: str):
+    cursor = db.execute("SELECT * FROM users WHERE name = ?", (username,))
+    return cursor.fetchone()
+
+# SECURE: Django ORM (parameterized by default)
+from myapp.models import User
+
+def get_user_django(name: str):
+    return User.objects.filter(name=name).first()
+
+# SECURE: SQLAlchemy parameterized query
+from sqlalchemy import text
+
+def get_user_alchemy(session, username: str):
+    result = session.execute(text("SELECT * FROM users WHERE name = :name"), {"name": username})
+    return result.fetchone()
+
+# SECURE: psycopg2 parameterized query
+def get_user_pg(conn, username: str):
+    with conn.cursor() as cur:
+        cur.execute("SELECT * FROM users WHERE name = %s", (username,))
+        return cur.fetchone()
+```
+
+**Security implication:** SQL injection (CWE-89) remains one of the most exploited vulnerability classes. Python's DB-API 2.0 (PEP 249) supports parameterized queries across all database adapters. Never use string formatting to build SQL.
+
+### 7. XML External Entity (XXE) and Billion Laughs
+
+Python's `xml.etree.ElementTree` and other XML parsers are vulnerable to XXE and entity expansion attacks.
+
+```python
+# VULNERABLE: ElementTree with untrusted XML
+import xml.etree.ElementTree as ET
+
+def parse_xml(xml_string: str):
+    return ET.fromstring(xml_string)
+    # Vulnerable to billion laughs (exponential entity expansion)
+    # Limited XXE in ElementTree but still risky with other parsers
+
+# VULNERABLE: xml.dom.minidom
+from xml.dom.minidom import parseString
+
+def parse_dom(xml_data: str):
+    return parseString(xml_data)
+
+# VULNERABLE: lxml without disabling entities
+from lxml import etree
+
+def parse_lxml(xml_data: bytes):
+    return etree.fromstring(xml_data)  # XXE enabled by default in older lxml
+```
+
+```python
+# SECURE: Use defusedxml which blocks all XML attacks
+import defusedxml.ElementTree as ET
+
+def parse_xml(xml_string: str):
+    return ET.fromstring(xml_string)  # XXE and entity expansion blocked
+
+# SECURE: lxml with safe parser settings
+from lxml import etree
+
+def parse_lxml(xml_data: bytes):
+    parser = etree.XMLParser(
+        resolve_entities=False,
+        no_network=True,
+        dtd_validation=False,
+        load_dtd=False,
+    )
+    return etree.fromstring(xml_data, parser=parser)
+```
+
+**Security implication:** XXE (CWE-611) can lead to file disclosure, SSRF, and denial of service. The billion laughs attack (CWE-776) causes exponential memory consumption. Use `defusedxml` as a drop-in replacement for all standard library XML parsers.
+
+### 8. Path Traversal via os.path.join
+
+`os.path.join()` silently discards previous path components when a segment is an absolute path, enabling path traversal.
+
+```python
+# VULNERABLE: os.path.join with user-supplied filename
+import os
+
+UPLOAD_DIR = "/var/uploads"
+
+def get_upload(filename: str) -> str:
+    # If filename is "/etc/passwd", os.path.join returns "/etc/passwd"
+    return os.path.join(UPLOAD_DIR, filename)
+
+# VULNERABLE: Relative path traversal
+def read_document(doc_name: str) -> bytes:
+    path = os.path.join(UPLOAD_DIR, doc_name)
+    # doc_name = "../../etc/passwd" traverses out of UPLOAD_DIR
+    with open(path, "rb") as f:
+        return f.read()
+```
+
+```python
+# SECURE: Use pathlib with resolve() and prefix check
+from pathlib import Path
+
+UPLOAD_DIR = Path("/var/uploads").resolve()
+
+def get_upload(filename: str) -> Path:
+    # Strip leading slashes and resolve to prevent traversal
+    safe_name = Path(filename).name  # Takes only the filename component
+    resolved = (UPLOAD_DIR / safe_name).resolve()
+    if not str(resolved).startswith(str(UPLOAD_DIR)):
+        raise ValueError("Path traversal detected")
+    return resolved
+
+# SECURE: os.path.realpath with validation
+import os
+
+def read_document(doc_name: str) -> bytes:
+    base = os.path.realpath(UPLOAD_DIR)
+    full_path = os.path.realpath(os.path.join(base, doc_name))
+    if not full_path.startswith(base + os.sep):
+        raise ValueError("Path traversal detected")
+    with open(full_path, "rb") as f:
+        return f.read()
+```
+
+**Security implication:** Path traversal (CWE-22) allows attackers to read or write arbitrary files. `os.path.join` is deceptive because it silently handles absolute paths and `..` segments. Always resolve paths and verify they remain within the intended directory.
+
+### 9. JWT Handling Pitfalls
+
+Common JWT library misconfigurations allow token forgery and algorithm confusion attacks.
+
+```python
+# VULNERABLE: Not specifying algorithms parameter
+import jwt
+
+def verify_token(token: str, secret: str) -> dict:
+    return jwt.decode(token, secret)
+    # Attacker can set alg: "none" in header to bypass verification
+
+# VULNERABLE: Accepting "none" algorithm
+def verify_token_weak(token: str, secret: str) -> dict:
+    return jwt.decode(token, secret, algorithms=["HS256", "none"])
+
+# VULNERABLE: Using symmetric secret to verify RS256 token
+# If the server expects RS256 but accepts HS256, an attacker can sign
+# with the public key (which is often public) using HS256
+PUBLIC_KEY = open("public.pem").read()
+
+def verify_token_confused(token: str) -> dict:
+    return jwt.decode(token, PUBLIC_KEY, algorithms=["RS256", "HS256"])
+```
+
+```python
+# SECURE: Explicit algorithm list, no "none"
+import jwt
+
+def verify_token(token: str, secret: str) -> dict:
+    return jwt.decode(
+        token,
+        secret,
+        algorithms=["HS256"],  # Explicit, single algorithm
+        options={"require": ["exp", "iat", "sub"]},
+    )
+
+# SECURE: Asymmetric verification with strict algorithm
+def verify_token_rsa(token: str, public_key: str) -> dict:
+    return jwt.decode(
+        token,
+        public_key,
+        algorithms=["RS256"],  # Only RS256, never HS256
+        options={"require": ["exp", "iat", "sub"]},
+    )
+```
+
+**Security implication:** JWT algorithm confusion (CWE-327) and the "none" algorithm bypass allow token forgery. Always specify an explicit `algorithms` list with a single expected algorithm. Never mix symmetric and asymmetric algorithms.
+
+### 10. Weak Hashing Algorithms
+
+Using MD5 or SHA1 for security-sensitive operations (password hashing, integrity verification) is unsafe due to collision attacks.
+
+```python
+# VULNERABLE: MD5 for password hashing
+import hashlib
+
+def hash_password(password: str) -> str:
+    return hashlib.md5(password.encode()).hexdigest()
+
+# VULNERABLE: SHA1 for integrity checking
+def verify_integrity(data: bytes, expected_hash: str) -> bool:
+    return hashlib.sha1(data).hexdigest() == expected_hash
+```
+
+```python
+# SECURE: Use bcrypt or argon2 for passwords
+from argon2 import PasswordHasher
+
+ph = PasswordHasher()
+
+def hash_password(password: str) -> str:
+    return ph.hash(password)
+
+def verify_password(stored_hash: str, password: str) -> bool:
+    try:
+        return ph.verify(stored_hash, password)
+    except Exception:
+        return False
+
+# SECURE: Use SHA-256 or SHA-3 for integrity, with HMAC for authentication
+import hashlib
+import hmac
+
+def compute_integrity(data: bytes, key: bytes) -> str:
+    return hmac.new(key, data, hashlib.sha256).hexdigest()
+
+def verify_integrity(data: bytes, key: bytes, expected: str) -> bool:
+    computed = hmac.new(key, data, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(computed, expected)
+```
+
+**Security implication:** MD5 (CWE-328) and SHA1 are cryptographically broken for collision resistance. MD5 collisions can be computed in seconds. Use bcrypt, scrypt, or argon2 for passwords. Use SHA-256+ or SHA-3 for integrity verification.
+
+### 11. Dynamic Import Abuse via __import__ / importlib
+
+Dynamic imports with user-controlled module names allow loading arbitrary modules.
+
+```python
+# VULNERABLE: __import__ with user input
+def load_plugin(plugin_name: str):
+    module = __import__(plugin_name)  # User sends: "os" -> access to os.system
+    return module
+
+# VULNERABLE: importlib with user input
+import importlib
+
+def load_handler(handler_name: str):
+    module = importlib.import_module(handler_name)
+    return module.handle
+```
+
+```python
+# SECURE: Whitelist allowed modules
+ALLOWED_PLUGINS = {"analytics", "reporting", "notifications"}
+
+def load_plugin(plugin_name: str):
+    if plugin_name not in ALLOWED_PLUGINS:
+        raise ValueError(f"Unknown plugin: {plugin_name}")
+    module = importlib.import_module(f"app.plugins.{plugin_name}")
+    return module
+
+# SECURE: Use entry_points for plugin discovery
+from importlib.metadata import entry_points
+
+def load_plugins():
+    discovered = entry_points(group="myapp.plugins")
+    return {ep.name: ep.load() for ep in discovered}
+```
+
+**Security implication:** Unrestricted dynamic imports (CWE-94) allow loading arbitrary standard library modules (e.g., `os`, `subprocess`, `socket`), enabling code execution, file access, and network connections. Always validate module names against a whitelist.
+
+### 12. tempfile Race Conditions
+
+`tempfile.mktemp()` creates a filename but not the file, introducing a TOCTOU (time-of-check to time-of-use) race condition.
+
+```python
+# VULNERABLE: mktemp has a race condition
+import tempfile
+import os
+
+def write_temp_data(data: bytes):
+    path = tempfile.mktemp()  # Returns a name, but file doesn't exist yet
+    # Another process could create a symlink at this path before we write
+    with open(path, "wb") as f:
+        f.write(data)
+```
+
+```python
+# SECURE: Use mkstemp which atomically creates the file
+import tempfile
+import os
+
+def write_temp_data(data: bytes) -> str:
+    fd, path = tempfile.mkstemp(prefix="app_", suffix=".tmp")
+    try:
+        os.write(fd, data)
+    finally:
+        os.close(fd)
+    return path
+
+# SECURE: Use NamedTemporaryFile or TemporaryDirectory
+def write_temp_managed(data: bytes) -> str:
+    with tempfile.NamedTemporaryFile(delete=False, prefix="app_") as f:
+        f.write(data)
+        return f.name
+```
+
+**Security implication:** TOCTOU race conditions (CWE-367) in temporary file creation can be exploited via symlink attacks to overwrite arbitrary files. `tempfile.mktemp()` is deprecated precisely for this reason. Use `mkstemp()` or `NamedTemporaryFile`.
+
+### 13. Regular Expression Denial of Service (ReDoS)
+
+Poorly constructed regular expressions with nested quantifiers can cause catastrophic backtracking, freezing the application.
+
+```python
+# VULNERABLE: Catastrophic backtracking
+import re
+
+# This regex takes exponential time on inputs like "aaaaaaaaaaaaaaaaaaaaa!"
+EMAIL_REGEX = re.compile(r"^([a-zA-Z0-9]+)*@[a-zA-Z0-9]+\.[a-zA-Z]+$")
+
+def validate_email(email: str) -> bool:
+    return bool(EMAIL_REGEX.match(email))
+
+# VULNERABLE: Nested quantifiers
+URL_REGEX = re.compile(r"^(https?://)?([a-z0-9-]+\.)+[a-z]{2,}(/.*)*$")
+```
+
+```python
+# SECURE: Avoid nested quantifiers, use possessive-style patterns
+import re
+
+# Flattened regex without nested quantifiers
+EMAIL_REGEX = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
+
+def validate_email(email: str) -> bool:
+    if len(email) > 254:  # RFC 5321 maximum
+        return False
+    return bool(EMAIL_REGEX.match(email))
+
+# SECURE: Use a dedicated validation library
+from email_validator import validate_email as ev_validate
+
+def validate_email_safe(email: str) -> bool:
+    try:
+        ev_validate(email, check_deliverability=False)
+        return True
+    except Exception:
+        return False
+
+# SECURE: Set a timeout with re2 (Google's linear-time regex engine)
+# pip install google-re2
+# import re2
+# re2.compile(pattern)  # Guaranteed O(n) matching time
+```
+
+**Security implication:** ReDoS (CWE-1333) can cause application-level denial of service. A single malicious input to a vulnerable regex can freeze a web server thread for minutes or hours. Audit all regex patterns that process user input for nested quantifiers.
+
+## Python 3.9
+
+### Dictionary Union Operators for Safe Config Merging
+
+Python 3.9 introduced `|` and `|=` operators for dictionaries, providing a cleaner way to merge configuration defaults with overrides.
+
+```python
+# VULNERABLE: Using **kwargs merging allows override of security defaults
+def get_config(user_prefs: dict) -> dict:
+    defaults = {"debug": False, "allow_admin": False, "max_retries": 3}
+    return {**defaults, **user_prefs}  # user_prefs can override "allow_admin"!
+
+# SECURE: Whitelist allowed overrides with 3.9 union operator
+ALLOWED_USER_KEYS = {"theme", "language", "max_retries"}
+
+def get_config(user_prefs: dict) -> dict:
+    defaults = {"debug": False, "allow_admin": False, "max_retries": 3}
+    safe_prefs = {k: v for k, v in user_prefs.items() if k in ALLOWED_USER_KEYS}
+    return defaults | safe_prefs  # Clean merge with whitelisted keys only
+```
+
+**Security implication:** Uncontrolled dictionary merging can override security-critical configuration keys. The `|` operator itself does not add security, but its readability encourages explicit merge patterns where input filtering is visible.
+
+### Type Hinting Generics in Built-in Collections
+
+Python 3.9 allows `list[int]`, `dict[str, Any]` in annotations without importing from `typing`, making type hints easier and encouraging their use in security-critical code.
+
+```python
+# Python 3.9+: Built-in generics for clearer security-related type hints
+def validate_allowed_ips(ip_list: list[str]) -> list[str]:
+    """Type hints make it clear this expects a list of strings, not raw bytes."""
+    import ipaddress
+    validated = []
+    for ip in ip_list:
+        addr = ipaddress.ip_address(ip)  # Raises ValueError on invalid IP
+        validated.append(str(addr))
+    return validated
+```
+
+**Security implication:** Easier type annotations encourage static type checking which catches type confusion bugs at development time rather than runtime.
+
+## Python 3.10
+
+### Structural Pattern Matching for Input Validation
+
+The `match`/`case` statement provides exhaustive pattern matching, ideal for validating and dispatching on structured input.
+
+```python
+# VULNERABLE: Complex if/elif chains miss edge cases
+def handle_request(action: str, payload: dict):
+    if action == "read":
+        return read_file(payload["path"])
+    elif action == "write":
+        write_file(payload["path"], payload["data"])
+    # Forgot to handle "delete" -> silently does nothing
+    # Forgot to validate payload structure
+
+# SECURE: Structural pattern matching with exhaustive handling
+def handle_request(request: dict):
+    match request:
+        case {"action": "read", "path": str(path)} if path.startswith("/allowed/"):
+            return read_file(path)
+        case {"action": "write", "path": str(path), "data": str(data)} if path.startswith("/allowed/"):
+            return write_file(path, data)
+        case {"action": action}:
+            raise ValueError(f"Unknown or unauthorized action: {action}")
+        case _:
+            raise ValueError("Malformed request: missing 'action' field")
+```
+
+**Security implication:** Structural pattern matching (PEP 634) enforces structure validation at the language level. The mandatory `case _` wildcard catch-all prevents silent pass-through of malformed or unauthorized requests. Guards (`if` clauses) enable inline authorization checks.
+
+### Parenthesized Context Managers
+
+Python 3.10 allows parenthesized context managers, improving readability for multi-resource security operations.
+
+```python
+# SECURE: Multiple security-critical resources managed together
+from pathlib import Path
+import tempfile
+
+def secure_file_copy(src: Path, dst: Path):
+    with (
+        open(src, "rb") as source,
+        tempfile.NamedTemporaryFile(dir=dst.parent, delete=False) as tmp,
+    ):
+        tmp.write(source.read())
+        # Atomic rename after successful write
+        Path(tmp.name).rename(dst)
+```
+
+**Security implication:** Grouping multiple context managers ensures all resources are properly cleaned up even when errors occur. This prevents file descriptor leaks and partial writes that could leave systems in insecure states.
+
+## Python 3.11
+
+### tomllib for Safe TOML Parsing
+
+Python 3.11 added `tomllib` to the standard library, providing a safe TOML parser that replaces third-party libraries which may have had code execution vulnerabilities.
+
+```python
+# VULNERABLE: Some third-party TOML parsers had code execution issues
+# (e.g., toml library with custom decoders)
+import toml
+
+config = toml.load("config.toml")  # Depends on third-party library security
+
+# SECURE: Use stdlib tomllib (Python 3.11+)
+import tomllib
+
+def load_config(path: str) -> dict:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+# tomllib only parses — no code execution possible
+# It reads bytes, preventing encoding-related attacks
+```
+
+**Security implication:** Standard library inclusion means fewer third-party dependencies in the trust chain. `tomllib` is read-only and cannot execute code, making it safe for parsing untrusted TOML configuration files.
+
+### Exception Groups and except*
+
+Exception groups allow handling multiple exceptions simultaneously, which is valuable for reporting multiple security validation failures.
+
+```python
+# SECURE: Report all validation errors at once using ExceptionGroup
+class ValidationError(Exception):
+    pass
+
+def validate_input(data: dict) -> dict:
+    errors = []
+    if not isinstance(data.get("email"), str):
+        errors.append(ValidationError("email must be a string"))
+    if not isinstance(data.get("age"), int) or data["age"] < 0:
+        errors.append(ValidationError("age must be a non-negative integer"))
+    if len(data.get("password", "")) < 12:
+        errors.append(ValidationError("password must be at least 12 characters"))
+    if errors:
+        raise ExceptionGroup("Validation failed", errors)
+    return data
+
+# Caller handles with except*
+try:
+    validate_input(user_data)
+except* ValidationError as eg:
+    for err in eg.exceptions:
+        log_validation_failure(str(err))
+```
+
+**Security implication:** Exception groups prevent early-exit validation where only the first error is reported, allowing comprehensive input validation in a single pass.
+
+### Fine-grained Error Locations
+
+Python 3.11 provides precise error locations pointing to the exact expression that caused an error, not just the line. This aids security debugging.
+
+**Security implication:** More precise tracebacks reduce debugging time for security issues and make it easier to identify the exact sub-expression involved in a vulnerability.
+
+## Python 3.12
+
+### Type Parameter Syntax (PEP 695)
+
+Python 3.12 introduces cleaner generic type syntax, making security-critical generic code more readable.
+
+```python
+# Python 3.12+: New type parameter syntax
+type UserId = int
+type SessionToken = str
+
+# Clear type aliases for security boundaries
+type SanitizedHTML = str
+type RawUserInput = str
+
+def sanitize(raw: RawUserInput) -> SanitizedHTML:
+    import html
+    return html.escape(raw)
+
+# Generic validator with new syntax
+def validate_bounded[T: (int, float)](value: T, min_val: T, max_val: T) -> T:
+    if not (min_val <= value <= max_val):
+        raise ValueError(f"Value {value} out of bounds [{min_val}, {max_val}]")
+    return value
+```
+
+**Security implication:** Type aliases like `SanitizedHTML` vs `RawUserInput` create semantic boundaries that make it obvious when unsanitized data is being used where sanitized data is expected. Static type checkers can then catch these mismatches.
+
+### Per-Interpreter GIL (PEP 684)
+
+Python 3.12 introduces per-interpreter GIL, enabling true parallel execution with separate interpreters that have isolated state.
+
+```python
+# SECURE: Separate interpreters have isolated state
+# This prevents cross-contamination between security contexts
+# Each interpreter has its own modules, globals, and builtins
+# Useful for multi-tenant applications where isolation is critical
+```
+
+**Security implication:** Per-interpreter GIL provides stronger isolation than threading for multi-tenant Python applications, as each interpreter has completely separate state, reducing the risk of data leakage between tenants.
+
+## Python 3.13
+
+### warnings.deprecated (PEP 702)
+
+Python 3.13 introduces a `@warnings.deprecated` decorator that can mark security-deprecated functions with clear messages.
+
+```python
+# SECURE: Mark insecure functions as deprecated
+import warnings
+
+@warnings.deprecated("Use hash_password_argon2() instead — MD5 is cryptographically broken")
+def hash_password_md5(password: str) -> str:
+    import hashlib
+    return hashlib.md5(password.encode()).hexdigest()
+
+def hash_password_argon2(password: str) -> str:
+    from argon2 import PasswordHasher
+    return PasswordHasher().hash(password)
+
+# Type checkers and linters will flag calls to hash_password_md5()
+```
+
+**Security implication:** `warnings.deprecated` enables gradual migration away from insecure functions. Unlike comments, the decorator is machine-readable and can be enforced by type checkers and CI tools.
+
+### Improved Error Messages
+
+Python 3.13 continues to improve error messages with better suggestions and more context.
+
+**Security implication:** Clearer error messages help developers identify and fix security misconfigurations faster during development, reducing the risk of deploying vulnerable code.
+
+### Free-Threaded CPython (Experimental)
+
+Python 3.13 introduces an experimental build without the GIL. Multi-threaded code requires more careful attention to thread safety.
+
+```python
+# CAUTION: With free-threaded Python, shared mutable state needs explicit synchronization
+import threading
+
+# VULNERABLE in free-threaded mode: unsynchronized shared state
+rate_limit_counts: dict[str, int] = {}
+
+def check_rate_limit(ip: str) -> bool:
+    count = rate_limit_counts.get(ip, 0)  # TOCTOU race
+    rate_limit_counts[ip] = count + 1
+    return count < 100
+
+# SECURE: Use threading.Lock for shared security state
+rate_lock = threading.Lock()
+
+def check_rate_limit_safe(ip: str) -> bool:
+    with rate_lock:
+        count = rate_limit_counts.get(ip, 0)
+        rate_limit_counts[ip] = count + 1
+        return count < 100
+```
+
+**Security implication:** Free-threaded Python removes the GIL safety net. Race conditions in security-critical code (rate limiting, authentication checks, session management) that were previously masked by the GIL will now manifest as real bugs.
+
+## Detection Patterns for Auditing Python Security Features
+
+| Pattern | Regex | Severity | Checkpoint ID |
+|---------|-------|----------|---------------|
+| Insecure deserialization via pickle | `pickle\.(loads\|load)\(` | error | SA-PY-01 |
+| Code injection via eval() | `eval\(` | error | SA-PY-02 |
+| Code injection via exec() | `exec\(` | error | SA-PY-03 |
+| Command injection via subprocess shell=True | `subprocess\.\w+\(.*shell\s*=\s*True` | error | SA-PY-04 |
+| Command injection via os.system | `os\.system\(` | error | SA-PY-05 |
+| Unsafe YAML loading | `yaml\.load\(` | error | SA-PY-06 |
+| SQL injection via f-string in query | `execute\(f"` | error | SA-PY-07 |
+| SQL injection via .format() in query | `execute\(.*\.format\(` | error | SA-PY-08 |
+| Weak hash: MD5 for security | `hashlib\.md5\(` | warning | SA-PY-09 |
+| Weak hash: SHA1 for security | `hashlib\.sha1\(` | warning | SA-PY-10 |
+| Deprecated tempfile.mktemp | `tempfile\.mktemp\(` | error | SA-PY-11 |
+| Dynamic import with __import__ | `__import__\(` | warning | SA-PY-12 |
+| XML parsing without defusedxml | `xml\.etree\.ElementTree` | warning | SA-PY-13 |
+| Jinja2 Template with variable | `Template\s*\(.*\w+.*\)` | warning | SA-PY-14 |
+| Command injection via os.popen | `os\.popen\(` | error | SA-PY-15 |
+| Code injection via compile() | `compile\(.*,.*,` | warning | SA-PY-16 |
+| Insecure deserialization via shelve | `shelve\.open\(` | warning | SA-PY-17 |
+| Insecure deserialization via marshal | `marshal\.loads\(` | warning | SA-PY-18 |
+
+## Version Adoption Security Checklist
+
+- [ ] Audit all `pickle.loads()` / `shelve.open()` / `marshal.loads()` calls for untrusted data
+- [ ] Replace all `eval()` / `exec()` with safe alternatives (`ast.literal_eval`, parser libraries)
+- [ ] Ensure Jinja2 templates load from files, not from user-supplied strings
+- [ ] Verify all `subprocess` calls use `shell=False` (the default) with argument lists
+- [ ] Replace `yaml.load()` with `yaml.safe_load()` everywhere
+- [ ] Audit all SQL queries for string formatting; use parameterized queries
+- [ ] Replace `xml.etree.ElementTree` with `defusedxml.ElementTree`
+- [ ] Validate all file paths with `resolve()` and prefix checks
+- [ ] Verify JWT `algorithms` parameter is explicit and does not include `"none"`
+- [ ] Replace `hashlib.md5` / `hashlib.sha1` with SHA-256+ for integrity, argon2/bcrypt for passwords
+- [ ] Replace `tempfile.mktemp()` with `tempfile.mkstemp()` or `NamedTemporaryFile`
+- [ ] Audit regex patterns processing user input for catastrophic backtracking
+- [ ] (3.11+) Migrate TOML parsing to `tomllib`
+- [ ] (3.12+) Adopt type aliases for security boundaries (`SanitizedHTML` vs `RawUserInput`)
+- [ ] (3.13+) Mark deprecated insecure functions with `@warnings.deprecated`
+- [ ] (3.13+) Audit thread safety for free-threaded CPython builds
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `cwe-top25.md` — CWE Top 25 mapping
+- `input-validation.md` — Input validation patterns
+- `php-security-features.md` — PHP security features reference
+- `node-security-features.md` — Node.js security features reference
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 4 |

--- a/skills/security-audit/references/python-security-features.md
+++ b/skills/security-audit/references/python-security-features.md
@@ -40,14 +40,19 @@ from typing import Any
 def load_user_session(session_data: str) -> dict[str, Any]:
     return json.loads(session_data)
 
-# SECURE: If pickle is necessary, use hmac to verify integrity
+# SECURE: Sign a JSON payload if you must round-trip server-to-server data.
+# Signing a pickle does NOT make it safe — the signature only stops third-
+# party tampering; the server still deserializes attacker-crafted data the
+# moment its own signature verifies. Use JSON and read the HMAC key from the
+# environment (not from source).
 import hmac
 import hashlib
+import os
 
-SECRET_KEY = b"server-side-secret"
+SIGNING_KEY = os.environb[b"APP_SIGNING_KEY"]  # fail hard if unset
 
-def load_verified_data(signed_data: bytes, signature: bytes) -> Any:
-    expected = hmac.new(SECRET_KEY, signed_data, hashlib.sha256).digest()
+def load_verified_json(signed_data: bytes, signature: bytes) -> Any:
+    expected = hmac.new(SIGNING_KEY, signed_data, hashlib.sha256).digest()
     if not hmac.compare_digest(signature, expected):
         raise ValueError("Data integrity check failed")
     return json.loads(signed_data)
@@ -882,26 +887,26 @@ def check_rate_limit_safe(ip: str) -> bool:
 
 ## Detection Patterns for Auditing Python Security Features
 
-| Pattern | Regex | Severity | Checkpoint ID |
-|---------|-------|----------|---------------|
-| Insecure deserialization via pickle | `pickle\.(loads\|load)\(` | error | SA-PY-01 |
-| Code injection via eval() | `eval\(` | error | SA-PY-02 |
-| Code injection via exec() | `exec\(` | error | SA-PY-03 |
-| Command injection via subprocess shell=True | `subprocess\.\w+\(.*shell\s*=\s*True` | error | SA-PY-04 |
-| Command injection via os.system | `os\.system\(` | error | SA-PY-05 |
-| Unsafe YAML loading | `yaml\.load\(` | error | SA-PY-06 |
-| SQL injection via f-string in query | `execute\(f"` | error | SA-PY-07 |
-| SQL injection via .format() in query | `execute\(.*\.format\(` | error | SA-PY-08 |
-| Weak hash: MD5 for security | `hashlib\.md5\(` | warning | SA-PY-09 |
-| Weak hash: SHA1 for security | `hashlib\.sha1\(` | warning | SA-PY-10 |
-| Deprecated tempfile.mktemp | `tempfile\.mktemp\(` | error | SA-PY-11 |
-| Dynamic import with __import__ | `__import__\(` | warning | SA-PY-12 |
-| XML parsing without defusedxml | `xml\.etree\.ElementTree` | warning | SA-PY-13 |
-| Jinja2 Template with variable | `Template\s*\(.*\w+.*\)` | warning | SA-PY-14 |
-| Command injection via os.popen | `os\.popen\(` | error | SA-PY-15 |
-| Code injection via compile() | `compile\(.*,.*,` | warning | SA-PY-16 |
-| Insecure deserialization via shelve | `shelve\.open\(` | warning | SA-PY-17 |
-| Insecure deserialization via marshal | `marshal\.loads\(` | warning | SA-PY-18 |
+| Pattern | Regex | Severity |
+|---------|-------|----------|
+| Insecure deserialization via pickle | `pickle\.(loads\|load)\(` | error |
+| Code injection via eval() | `eval\(` | error |
+| Code injection via exec() | `exec\(` | error |
+| Command injection via subprocess shell=True | `subprocess\.\w+\(.*shell\s*=\s*True` | error |
+| Command injection via os.system | `os\.system\(` | error |
+| Unsafe YAML loading | `yaml\.load\(` | error |
+| SQL injection via f-string in query | `execute\(f"` | error |
+| SQL injection via .format() in query | `execute\(.*\.format\(` | error |
+| Weak hash: MD5 for security | `hashlib\.md5\(` | warning |
+| Weak hash: SHA1 for security | `hashlib\.sha1\(` | warning |
+| Deprecated tempfile.mktemp | `tempfile\.mktemp\(` | error |
+| Dynamic import with __import__ | `__import__\(` | warning |
+| XML parsing without defusedxml | `xml\.etree\.ElementTree` | warning |
+| Jinja2 Template with variable | `Template\s*\(.*\w+.*\)` | warning |
+| Command injection via os.popen | `os\.popen\(` | error |
+| Code injection via compile() | `compile\(.*,.*,` | warning |
+| Insecure deserialization via shelve | `shelve\.open\(` | warning |
+| Insecure deserialization via marshal | `marshal\.loads\(` | warning |
 
 ## Version Adoption Security Checklist
 
@@ -928,7 +933,7 @@ def check_rate_limit_safe(ip: str) -> bool:
 - `cwe-top25.md` — CWE Top 25 mapping
 - `input-validation.md` — Input validation patterns
 - `php-security-features.md` — PHP security features reference
-- `node-security-features.md` — Node.js security features reference
+- `nodejs-security-features.md` — Node.js security features reference
 
 ## Changelog
 


### PR DESCRIPTION
## Summary

Tier 2 ecosystem PR — Python stack. Four new standalone reference guides (~2,534 lines total):

- **`python-security-features.md`** (~1050 lines): Python 3.9–3.13 language + stdlib security patterns
- **`django-security.md`** (~550 lines): middleware, CSRF, ORM, DEBUG, format_html
- **`flask-security.md`** (~500 lines): sessions, WTForms CSRF, Jinja2, ProxyFix
- **`fastapi-security.md`** (~700 lines): DI authZ, CORS, background tasks, async SQL

Each guide has vulnerable vs secure examples and detection regex hints.

## Provenance

Imported from [evandervecht/security-audit-skill](https://github.com/evandervecht/security-audit-skill). Dual-licensed MIT + CC-BY-SA-4.0. Fork-specific `SA-PY-*` / `SA-DJANGO-*` / `SA-FLASK-*` / `SA-FASTAPI-*` checkpoint IDs stripped (matches Tier 1 pattern from #43/#44/#45).

Attribution: [E van der Vecht](mailto:evandervecht@schubergphilis.com).

## Follow-up

SKILL.md Reference Files index + description broadening will land in a single PR after all Tier 2 merges, to avoid merge conflicts between parallel PRs.

## Test plan

- [ ] CI green
- [ ] References render in GitHub preview