### PR TITLE
feat(references): add Go, Rust, and Ruby ecosystem security guides

### DIFF
--- a/skills/security-audit/references/gin-security.md
+++ b/skills/security-audit/references/gin-security.md
@@ -1,0 +1,508 @@
+# Gin Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for Gin (Go) web applications. Gin's middleware-based architecture introduces unique security considerations around middleware ordering, input binding, template rendering, file serving, and proxy trust. Many vulnerabilities arise from implicit trust in user input and misconfigured middleware chains.
+
+---
+
+## Middleware Ordering
+
+### SA-GIN-01: Middleware Ordering Vulnerabilities
+
+Gin executes middleware in registration order. If authentication or authorization middleware is registered after route handlers, or if security middleware (CORS, rate limiting, logging) is placed incorrectly, routes may be exposed without protection.
+
+```go
+// VULNERABLE: Auth middleware registered after routes
+func main() {
+    r := gin.Default()
+
+    // These routes have NO authentication!
+    api := r.Group("/api")
+    api.GET("/users", listUsers)
+    api.DELETE("/users/:id", deleteUser)
+
+    // Auth middleware registered too late — does not protect routes above
+    r.Use(authMiddleware())
+
+    r.Run(":8080")
+}
+
+// VULNERABLE: Recovery middleware missing — panics crash the server
+func main() {
+    r := gin.New() // No default middleware
+    r.Use(authMiddleware())
+    // Missing gin.Recovery() — a panic in any handler kills the process
+    r.GET("/api/data", dataHandler)
+    r.Run(":8080")
+}
+```
+
+```go
+// SECURE: Middleware registered before routes, correct ordering
+func main() {
+    r := gin.New()
+
+    // 1. Recovery first — catches panics from all subsequent middleware/handlers
+    r.Use(gin.Recovery())
+    // 2. Logging
+    r.Use(gin.Logger())
+    // 3. Security headers / CORS
+    r.Use(corsMiddleware())
+    // 4. Rate limiting
+    r.Use(rateLimitMiddleware())
+
+    // 5. Auth on protected groups
+    api := r.Group("/api")
+    api.Use(authMiddleware())
+    api.GET("/users", listUsers)
+    api.DELETE("/users/:id", deleteUser)
+
+    // Public routes defined separately
+    r.GET("/health", healthCheck)
+
+    r.Run(":8080")
+}
+```
+
+**Detection regex:** `\.Use\(auth[A-Za-z]*\(`
+**Severity:** error
+
+---
+
+## Mass Assignment
+
+### SA-GIN-02: c.Bind / ShouldBind Mass Assignment
+
+Gin's binding functions (`c.Bind`, `c.ShouldBindJSON`, `c.BindJSON`, etc.) map request data directly to Go structs. If the struct contains sensitive fields (e.g., `IsAdmin`, `Role`, `ID`), attackers can set these by including them in the request body.
+
+```go
+// VULNERABLE: Binding directly to a model with sensitive fields
+type User struct {
+    ID        uint   `json:"id" gorm:"primaryKey"`
+    Name      string `json:"name"`
+    Email     string `json:"email"`
+    IsAdmin   bool   `json:"is_admin"`
+    Role      string `json:"role"`
+    CreatedAt time.Time
+}
+
+func createUser(c *gin.Context) {
+    var user User
+    // Attacker sends: {"name":"evil","email":"a@b.c","is_admin":true,"role":"superadmin"}
+    if err := c.ShouldBindJSON(&user); err != nil {
+        c.JSON(400, gin.H{"error": err.Error()})
+        return
+    }
+    db.Create(&user) // is_admin=true, role=superadmin persisted!
+    c.JSON(201, user)
+}
+```
+
+```go
+// SECURE: Use a dedicated input DTO that excludes sensitive fields
+type CreateUserInput struct {
+    Name  string `json:"name" binding:"required,min=1,max=100"`
+    Email string `json:"email" binding:"required,email"`
+}
+
+func createUser(c *gin.Context) {
+    var input CreateUserInput
+    if err := c.ShouldBindJSON(&input); err != nil {
+        c.JSON(400, gin.H{"error": err.Error()})
+        return
+    }
+
+    user := User{
+        Name:    input.Name,
+        Email:   input.Email,
+        IsAdmin: false,          // Explicitly set server-side
+        Role:    "user",         // Explicitly set server-side
+    }
+    db.Create(&user)
+    c.JSON(201, user)
+}
+```
+
+**Detection regex:** `c\.(Bind|ShouldBind|ShouldBindJSON|BindJSON|ShouldBindQuery)\s*\(`
+**Severity:** warning
+
+---
+
+## Cross-Site Scripting (XSS)
+
+### SA-GIN-03: c.HTML Template Injection
+
+Gin uses Go's `html/template` package which auto-escapes by default. However, using `template.HTML()` to cast user input bypasses escaping entirely, creating XSS vulnerabilities. Similarly, rendering user-controlled strings via `c.Data` or `c.Writer.WriteString` with `text/html` content type bypasses template escaping.
+
+```go
+// VULNERABLE: Casting user input to template.HTML bypasses auto-escaping
+func profileHandler(c *gin.Context) {
+    username := c.Query("name")
+    // template.HTML tells Go "this is already safe" — it is NOT
+    c.HTML(200, "profile.html", gin.H{
+        "username": template.HTML(username),
+    })
+}
+
+// VULNERABLE: Writing raw HTML from user input
+func searchHandler(c *gin.Context) {
+    query := c.Query("q")
+    c.Data(200, "text/html; charset=utf-8",
+        []byte("<h1>Results for: "+query+"</h1>"))
+}
+
+// VULNERABLE: Using fmt.Sprintf to build HTML
+func renderPage(c *gin.Context) {
+    title := c.Param("title")
+    html := fmt.Sprintf("<html><head><title>%s</title></head></html>", title)
+    c.Writer.WriteString(html)
+}
+```
+
+```go
+// SECURE: Let html/template handle escaping automatically
+func profileHandler(c *gin.Context) {
+    username := c.Query("name")
+    // Pass as plain string — html/template auto-escapes
+    c.HTML(200, "profile.html", gin.H{
+        "username": username,
+    })
+}
+
+// SECURE: Use templates for all HTML output
+func searchHandler(c *gin.Context) {
+    query := c.Query("q")
+    c.HTML(200, "search.html", gin.H{
+        "query": query, // Auto-escaped by template engine
+    })
+}
+```
+
+**Detection regex:** `template\.HTML\s*\(|c\.Data\s*\([^)]*"text/html|c\.Writer\.WriteString\s*\(`
+**Severity:** error
+
+---
+
+## CORS Misconfiguration
+
+### SA-GIN-04: CORS Middleware Misconfiguration
+
+The popular `gin-contrib/cors` middleware can be misconfigured to allow all origins, expose credentials, or use wildcard origins with credentials — all of which weaken the same-origin policy.
+
+```go
+// VULNERABLE: Allow all origins with credentials
+import "github.com/gin-contrib/cors"
+
+func main() {
+    r := gin.Default()
+    r.Use(cors.New(cors.Config{
+        AllowOrigins:     []string{"*"},       // Any origin
+        AllowCredentials: true,                // With cookies!
+        AllowHeaders:     []string{"*"},
+        AllowMethods:     []string{"*"},
+    }))
+    r.Run(":8080")
+}
+
+// VULNERABLE: AllowAllOrigins with credentials
+func main() {
+    r := gin.Default()
+    r.Use(cors.New(cors.Config{
+        AllowAllOrigins:  true,
+        AllowCredentials: true,
+    }))
+    r.Run(":8080")
+}
+
+// VULNERABLE: Dynamic origin reflection without validation
+func main() {
+    r := gin.Default()
+    r.Use(cors.New(cors.Config{
+        AllowOriginFunc: func(origin string) bool {
+            return true // Reflects any origin — same as wildcard
+        },
+        AllowCredentials: true,
+    }))
+    r.Run(":8080")
+}
+```
+
+```go
+// SECURE: Explicit allowlist of trusted origins
+func main() {
+    r := gin.Default()
+    r.Use(cors.New(cors.Config{
+        AllowOrigins: []string{
+            "https://app.example.com",
+            "https://admin.example.com",
+        },
+        AllowMethods:     []string{"GET", "POST", "PUT", "DELETE"},
+        AllowHeaders:     []string{"Authorization", "Content-Type"},
+        AllowCredentials: true,
+        MaxAge:           12 * time.Hour,
+    }))
+    r.Run(":8080")
+}
+
+// SECURE: Dynamic origin with strict validation
+func main() {
+    r := gin.Default()
+    r.Use(cors.New(cors.Config{
+        AllowOriginFunc: func(origin string) bool {
+            u, err := url.Parse(origin)
+            if err != nil {
+                return false
+            }
+            return u.Hostname() == "example.com" ||
+                strings.HasSuffix(u.Hostname(), ".example.com")
+        },
+        AllowCredentials: true,
+    }))
+    r.Run(":8080")
+}
+```
+
+**Detection regex:** `AllowAllOrigins\s*:\s*true|AllowOrigins\s*:\s*\[\s*"\*"\s*\]|AllowOriginFunc\s*:.*return\s+true`
+**Severity:** error
+
+---
+
+## Path Traversal
+
+### SA-GIN-05: c.File / c.FileAttachment Path Traversal
+
+`c.File()` and `c.FileAttachment()` serve files from the server filesystem. If the filename or path includes user input without sanitization, attackers can traverse directories to access arbitrary files.
+
+```go
+// VULNERABLE: User-controlled path passed directly to c.File
+func downloadHandler(c *gin.Context) {
+    filename := c.Param("filename")
+    // Attacker sends: /download/../../../etc/passwd
+    c.File("/uploads/" + filename)
+}
+
+// VULNERABLE: Query parameter used in file path
+func serveFile(c *gin.Context) {
+    path := c.Query("path")
+    c.FileAttachment(path, "download.pdf")
+}
+
+// VULNERABLE: Insufficient sanitization
+func downloadHandler(c *gin.Context) {
+    filename := c.Param("filename")
+    // strings.Replace only handles "../" but not "..\" or encoded variants
+    safe := strings.Replace(filename, "../", "", -1)
+    c.File("/uploads/" + safe)
+}
+```
+
+```go
+// SECURE: Validate filename, use filepath.Base, and verify resolved path
+func downloadHandler(c *gin.Context) {
+    filename := c.Param("filename")
+
+    // Strip to base filename — removes all directory components
+    base := filepath.Base(filename)
+
+    // Reject hidden files and empty base
+    if base == "." || base == ".." || strings.HasPrefix(base, ".") {
+        c.JSON(400, gin.H{"error": "invalid filename"})
+        return
+    }
+
+    // Resolve full path and verify it's within the uploads directory
+    uploadsDir := "/var/app/uploads"
+    fullPath := filepath.Join(uploadsDir, base)
+    resolved, err := filepath.EvalSymlinks(fullPath)
+    if err != nil || !strings.HasPrefix(resolved, uploadsDir) {
+        c.JSON(404, gin.H{"error": "file not found"})
+        return
+    }
+
+    c.File(resolved)
+}
+```
+
+**Detection regex:** `c\.(File|FileAttachment)\s*\([^)]*c\.(Param|Query|PostForm)\s*\(`
+**Severity:** error
+
+---
+
+## Panic Recovery
+
+### SA-GIN-06: Panic Recovery Middleware
+
+Without `gin.Recovery()` middleware, an unhandled panic in any handler or middleware will crash the entire server process. In production, this creates a denial-of-service vector. Additionally, the default recovery middleware may leak stack traces to clients.
+
+```go
+// VULNERABLE: No recovery middleware — panic crashes server
+func main() {
+    r := gin.New()
+    r.GET("/api/data", func(c *gin.Context) {
+        // Any nil pointer dereference, index out of range, etc.
+        // will kill the process
+        var data *MyStruct
+        c.JSON(200, data.Field) // panic: nil pointer dereference
+    })
+    r.Run(":8080")
+}
+
+// VULNERABLE: Recovery middleware in wrong position
+func main() {
+    r := gin.New()
+    r.Use(authMiddleware()) // Panic here is NOT caught
+    r.Use(gin.Recovery())   // Too late for panics in auth
+    r.Run(":8080")
+}
+```
+
+```go
+// SECURE: Recovery as first middleware with custom handler
+func main() {
+    r := gin.New()
+
+    // Recovery FIRST — catches panics from all middleware and handlers
+    r.Use(gin.CustomRecovery(func(c *gin.Context, err interface{}) {
+        // Log the full error internally
+        log.Printf("panic recovered: %v\n%s", err, debug.Stack())
+        // Return generic error to client — no stack trace leak
+        c.AbortWithStatusJSON(500, gin.H{
+            "error": "internal server error",
+        })
+    }))
+
+    r.Use(gin.Logger())
+    r.Use(authMiddleware())
+
+    r.GET("/api/data", dataHandler)
+    r.Run(":8080")
+}
+```
+
+**Detection regex:** `gin\.New\s*\(\s*\)(?![\s\S]*?\.Use\s*\(\s*gin\.(Recovery|CustomRecovery))`
+**Severity:** error
+
+---
+
+## Trusted Proxy Configuration
+
+### SA-GIN-07: Trusted Proxy Configuration
+
+Gin trusts all proxies by default, meaning `c.ClientIP()` can be spoofed via `X-Forwarded-For` or `X-Real-IP` headers. This undermines rate limiting, IP-based access control, and audit logging.
+
+```go
+// VULNERABLE: Default configuration trusts all proxies
+func main() {
+    r := gin.Default()
+    // gin trusts all proxies by default
+    // c.ClientIP() can be spoofed by any client via X-Forwarded-For header
+
+    r.GET("/api/data", func(c *gin.Context) {
+        ip := c.ClientIP() // Can be spoofed!
+        log.Printf("Request from: %s", ip)
+        c.JSON(200, gin.H{"data": "sensitive"})
+    })
+    r.Run(":8080")
+}
+```
+
+```go
+// SECURE: Explicitly configure trusted proxies
+func main() {
+    r := gin.Default()
+
+    // Only trust your known reverse proxy/load balancer IPs
+    r.SetTrustedProxies([]string{"10.0.0.0/8", "172.16.0.0/12"})
+
+    // Or trust no proxies at all (direct client connections)
+    // r.SetTrustedProxies(nil)
+
+    r.GET("/api/data", func(c *gin.Context) {
+        ip := c.ClientIP() // Now reliable
+        log.Printf("Request from: %s", ip)
+        c.JSON(200, gin.H{"data": "sensitive"})
+    })
+    r.Run(":8080")
+}
+```
+
+**Detection regex:** `gin\.(Default|New)\s*\(\s*\)(?![\s\S]*?SetTrustedProxies)`
+**Severity:** warning
+
+---
+
+## Rate Limiting
+
+### SA-GIN-08: Rate Limiting
+
+Without rate limiting, Gin applications are vulnerable to brute-force attacks, credential stuffing, and denial-of-service. Rate limiting should be applied as middleware, ideally per-IP or per-user, and configured before authentication to protect login endpoints.
+
+```go
+// VULNERABLE: No rate limiting on sensitive endpoints
+func main() {
+    r := gin.Default()
+
+    r.POST("/api/login", loginHandler)        // No rate limit — brute force
+    r.POST("/api/reset-password", resetHandler) // No rate limit — account enumeration
+    r.GET("/api/search", searchHandler)         // No rate limit — DoS
+
+    r.Run(":8080")
+}
+```
+
+```go
+// SECURE: Rate limiting with a middleware library
+import "github.com/ulule/limiter/v3"
+import mgin "github.com/ulule/limiter/v3/drivers/middleware/gin"
+import "github.com/ulule/limiter/v3/drivers/store/memory"
+
+func main() {
+    r := gin.Default()
+
+    // Global rate limit: 100 requests per minute per IP
+    rate, _ := limiter.NewRateFromFormatted("100-M")
+    store := memory.NewStore()
+    globalLimiter := mgin.NewMiddleware(limiter.New(store, rate))
+    r.Use(globalLimiter)
+
+    // Stricter limit on auth endpoints: 5 per minute
+    authRate, _ := limiter.NewRateFromFormatted("5-M")
+    authLimiter := mgin.NewMiddleware(limiter.New(store, authRate))
+
+    auth := r.Group("/api/auth")
+    auth.Use(authLimiter)
+    auth.POST("/login", loginHandler)
+    auth.POST("/reset-password", resetHandler)
+
+    r.Run(":8080")
+}
+```
+
+**Detection regex:** `\.(POST|PUT)\s*\(\s*"[^"]*(?:login|auth|token|password|reset)[^"]*"\s*,\s*\w+\s*\)`
+**Severity:** warning
+
+---
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| SA-GIN-01 Middleware ordering | Critical | Immediate | Low |
+| SA-GIN-02 Mass assignment via Bind | High | 1 week | Medium |
+| SA-GIN-03 Template injection | Critical | Immediate | Low |
+| SA-GIN-04 CORS misconfiguration | High | 1 week | Low |
+| SA-GIN-05 Path traversal via c.File | Critical | Immediate | Medium |
+| SA-GIN-06 Missing panic recovery | High | Immediate | Low |
+| SA-GIN-07 Trusted proxy config | Medium | 1 week | Low |
+| SA-GIN-08 Missing rate limiting | Medium | 1 month | Medium |
+
+## Related References
+
+- `owasp-top10.md` -- OWASP Top 10 mapping
+- `api-security.md` -- API-level security patterns
+- Go standard library `html/template` auto-escaping documentation
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 3 framework expansion |

--- a/skills/security-audit/references/gin-security.md
+++ b/skills/security-audit/references/gin-security.md
@@ -309,11 +309,21 @@ func downloadHandler(c *gin.Context) {
         return
     }
 
-    // Resolve full path and verify it's within the uploads directory
+    // Resolve full path and verify it's within the uploads directory.
+    // HasPrefix alone is not enough: "/var/app/uploads" is a prefix of
+    // "/var/app/uploads_secret/…", so a sibling directory with a matching
+    // prefix would pass the check. Enforce a directory boundary either by
+    // appending the OS separator before the compare, or (preferred) by
+    // using filepath.Rel and rejecting results that start with "..".
     uploadsDir := "/var/app/uploads"
     fullPath := filepath.Join(uploadsDir, base)
     resolved, err := filepath.EvalSymlinks(fullPath)
-    if err != nil || !strings.HasPrefix(resolved, uploadsDir) {
+    if err != nil {
+        c.JSON(404, gin.H{"error": "file not found"})
+        return
+    }
+    rel, err := filepath.Rel(uploadsDir, resolved)
+    if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
         c.JSON(404, gin.H{"error": "file not found"})
         return
     }

--- a/skills/security-audit/references/go-security-features.md
+++ b/skills/security-audit/references/go-security-features.md
@@ -1,0 +1,685 @@
+# Go Security Features by Version
+
+Modern Go versions introduce language features that directly improve security when used correctly. This reference documents security-relevant features and vulnerability patterns from Go 1.18 through Go 1.22.
+
+## Core Go Security Patterns
+
+### 1. Goroutine Race Conditions (CWE-362)
+
+Shared mutable state accessed by multiple goroutines without synchronization leads to data races that can corrupt security-critical data such as authentication state, permission checks, or financial calculations.
+
+```go
+// VULNERABLE: Shared state without synchronization
+var isAuthenticated bool
+
+func handleLogin(w http.ResponseWriter, r *http.Request) {
+    go func() {
+        // Race condition: multiple goroutines read/write isAuthenticated
+        if validateCredentials(r) {
+            isAuthenticated = true // DATA RACE
+        }
+    }()
+    if isAuthenticated {
+        grantAccess(w) // May grant access based on stale/corrupt value
+    }
+}
+
+// SECURE: Use sync primitives for shared state
+var (
+    mu              sync.RWMutex
+    sessionStore    = make(map[string]bool)
+)
+
+func handleLoginSafe(w http.ResponseWriter, r *http.Request) {
+    token := r.Header.Get("X-Session-Token")
+    mu.RLock()
+    authenticated := sessionStore[token]
+    mu.RUnlock()
+
+    if !authenticated {
+        http.Error(w, "Unauthorized", http.StatusUnauthorized)
+        return
+    }
+    grantAccess(w)
+}
+```
+
+**Security implication:** Data races on security-critical variables can cause authentication bypass, privilege escalation, or inconsistent authorization decisions. Always run tests with `-race` flag: `go test -race ./...`
+
+**Detection regex:** `go\s+(func|test)\b` combined with shared variable writes — best detected with `go vet -race` or `go build -race`.
+
+### 2. Unsafe Pointer Usage (CWE-119, CWE-787)
+
+The `unsafe` package bypasses Go's type safety and memory safety guarantees. It enables arbitrary memory access, buffer overflows, and use-after-free vulnerabilities.
+
+```go
+// VULNERABLE: unsafe pointer arithmetic
+import "unsafe"
+
+func readBeyondBuffer(data []byte) byte {
+    ptr := unsafe.Pointer(&data[0])
+    // Read beyond slice bounds — buffer over-read
+    farPtr := unsafe.Pointer(uintptr(ptr) + uintptr(len(data)+100))
+    return *(*byte)(farPtr) // Undefined behavior, potential info leak
+}
+
+// VULNERABLE: unsafe type casting bypasses type safety
+func unsafeCast(i int64) *http.Request {
+    return (*http.Request)(unsafe.Pointer(&i)) // Nonsensical cast, memory corruption
+}
+
+// SECURE: Use encoding/binary for type conversions
+import "encoding/binary"
+
+func safeConvert(data []byte) (uint32, error) {
+    if len(data) < 4 {
+        return 0, fmt.Errorf("insufficient data: need 4 bytes, got %d", len(data))
+    }
+    return binary.BigEndian.Uint32(data[:4]), nil
+}
+```
+
+**Security implication:** `unsafe` operations can cause buffer overflows, information disclosure, and arbitrary code execution. Any use of `unsafe` in security-critical code requires manual audit.
+
+**Detection regex:** `unsafe\.Pointer|unsafe\.Sizeof|unsafe\.Offsetof|unsafe\.Alignof|unsafe\.Slice|unsafe\.String`
+
+### 3. Template Injection: text/template vs html/template (CWE-79)
+
+Go's `text/template` package performs no output escaping. Using it for HTML output enables XSS attacks. The `html/template` package automatically escapes output for the HTML context.
+
+```go
+// VULNERABLE: text/template does NOT escape HTML
+import "text/template"
+
+func renderPage(w http.ResponseWriter, username string) {
+    tmpl := template.Must(template.New("page").Parse(
+        `<h1>Hello, {{.Username}}</h1>`,
+    ))
+    tmpl.Execute(w, map[string]string{
+        "Username": username, // If username is "<script>alert(1)</script>", XSS occurs
+    })
+}
+
+// SECURE: html/template auto-escapes for HTML context
+import "html/template"
+
+func renderPageSafe(w http.ResponseWriter, username string) {
+    tmpl := template.Must(template.New("page").Parse(
+        `<h1>Hello, {{.Username}}</h1>`,
+    ))
+    // html/template escapes: <script> becomes &lt;script&gt;
+    tmpl.Execute(w, map[string]string{
+        "Username": username,
+    })
+}
+```
+
+**Security implication:** Using `text/template` for HTML output allows stored/reflected XSS. Always use `html/template` for web responses. Note: `html/template` only escapes for HTML — for JavaScript or URL contexts, additional care is needed.
+
+**Detection regex:** `"text/template"`
+
+### 4. SQL Injection in database/sql (CWE-89)
+
+String concatenation in SQL queries creates injection vulnerabilities. Go's `database/sql` package supports parameterized queries that prevent injection.
+
+```go
+// VULNERABLE: String concatenation in SQL query
+func getUser(db *sql.DB, username string) (*User, error) {
+    query := "SELECT id, name, email FROM users WHERE name = '" + username + "'"
+    row := db.QueryRow(query) // SQL injection if username contains ' OR 1=1 --
+    var u User
+    err := row.Scan(&u.ID, &u.Name, &u.Email)
+    return &u, err
+}
+
+// VULNERABLE: fmt.Sprintf for SQL queries
+func getUserFmt(db *sql.DB, username string) (*User, error) {
+    query := fmt.Sprintf("SELECT id, name FROM users WHERE name = '%s'", username)
+    row := db.QueryRow(query) // SQL injection
+    var u User
+    err := row.Scan(&u.ID, &u.Name)
+    return &u, err
+}
+
+// SECURE: Parameterized query with placeholder
+func getUserSafe(db *sql.DB, username string) (*User, error) {
+    row := db.QueryRow("SELECT id, name, email FROM users WHERE name = $1", username)
+    var u User
+    err := row.Scan(&u.ID, &u.Name, &u.Email)
+    return &u, err
+}
+
+// SECURE: Using prepared statements
+func getUserPrepared(db *sql.DB, username string) (*User, error) {
+    stmt, err := db.Prepare("SELECT id, name, email FROM users WHERE name = $1")
+    if err != nil {
+        return nil, err
+    }
+    defer stmt.Close()
+    row := stmt.QueryRow(username)
+    var u User
+    err = row.Scan(&u.ID, &u.Name, &u.Email)
+    return &u, err
+}
+```
+
+**Security implication:** SQL injection can lead to full database compromise. Always use parameterized queries. Be cautious with ORMs — raw query methods (e.g., `gorm.Raw()`) can still be vulnerable.
+
+**Detection regex:** `(Sprintf|"|')\s*\+.*SELECT|Sprintf.*SELECT|Sprintf.*INSERT|Sprintf.*UPDATE|Sprintf.*DELETE|\.Query\(.*\+|\.Exec\(.*\+`
+
+### 5. Command Injection via os/exec (CWE-78)
+
+Using `exec.Command` with shell invocation (`sh -c`) combined with user input enables command injection. Direct execution without a shell is safer.
+
+```go
+// VULNERABLE: Shell invocation with user input
+import "os/exec"
+
+func processFile(filename string) ([]byte, error) {
+    // sh -c allows shell metacharacters: filename = "; rm -rf /"
+    cmd := exec.Command("sh", "-c", "cat "+filename)
+    return cmd.Output()
+}
+
+// VULNERABLE: bash -c with string concatenation
+func convert(input string) error {
+    cmd := exec.Command("bash", "-c", "convert "+input+" output.png")
+    return cmd.Run()
+}
+
+// SECURE: Direct execution without shell — no metacharacter interpretation
+func processFileSafe(filename string) ([]byte, error) {
+    // Arguments passed directly to the binary, not interpreted by shell
+    cmd := exec.Command("cat", filename)
+    return cmd.Output()
+}
+
+// SECURE: Validate input before execution
+func processFileValidated(filename string) ([]byte, error) {
+    // Allowlist: only alphanumeric, dots, hyphens, underscores
+    if !regexp.MustCompile(`^[a-zA-Z0-9._-]+$`).MatchString(filename) {
+        return nil, fmt.Errorf("invalid filename")
+    }
+    cmd := exec.Command("cat", filepath.Join("/safe/dir", filename))
+    return cmd.Output()
+}
+```
+
+**Security implication:** Shell injection via `sh -c` or `bash -c` allows arbitrary command execution. Pass arguments directly to `exec.Command` and validate inputs.
+
+**Detection regex:** `exec\.Command\s*\(\s*"(sh|bash|cmd|powershell)"`
+
+### 6. Path Traversal (CWE-22)
+
+`filepath.Join` does not prevent path traversal — joining with `..` segments can escape the intended directory.
+
+```go
+// VULNERABLE: filepath.Join does not sanitize ".."
+func serveFile(w http.ResponseWriter, r *http.Request) {
+    filename := r.URL.Query().Get("file")
+    // filepath.Join("/data", "../../etc/passwd") => "/etc/passwd"
+    path := filepath.Join("/data", filename)
+    http.ServeFile(w, r, path)
+}
+
+// SECURE: Validate resolved path is within base directory
+func serveFileSafe(w http.ResponseWriter, r *http.Request) {
+    filename := r.URL.Query().Get("file")
+    basePath := "/data"
+    // Clean and resolve the path
+    resolved := filepath.Clean(filepath.Join(basePath, filename))
+    // Verify the resolved path starts with the base directory
+    if !strings.HasPrefix(resolved, basePath+string(filepath.Separator)) &&
+        resolved != basePath {
+        http.Error(w, "Forbidden", http.StatusForbidden)
+        return
+    }
+    http.ServeFile(w, r, resolved)
+}
+```
+
+**Security implication:** Path traversal can expose sensitive files (`/etc/passwd`, application configuration, secrets). Always validate that resolved paths remain within the intended directory.
+
+**Detection regex:** `filepath\.Join\s*\(.*\b(r\.|req\.|request\.|params|query|URL)`
+
+### 7. HTTP Header Injection (CWE-113)
+
+Setting HTTP headers with unsanitized user input can inject additional headers or split responses.
+
+```go
+// VULNERABLE: User input directly in response header
+func redirect(w http.ResponseWriter, r *http.Request) {
+    target := r.URL.Query().Get("url")
+    // If target contains \r\n, attacker can inject headers
+    w.Header().Set("Location", target)
+    w.WriteHeader(http.StatusFound)
+}
+
+// SECURE: Validate and sanitize redirect URLs
+func redirectSafe(w http.ResponseWriter, r *http.Request) {
+    target := r.URL.Query().Get("url")
+    // Parse and validate the URL
+    parsed, err := url.Parse(target)
+    if err != nil || parsed.Host != "" {
+        http.Error(w, "Invalid redirect", http.StatusBadRequest)
+        return
+    }
+    // Only allow relative redirects
+    http.Redirect(w, r, parsed.Path, http.StatusFound)
+}
+```
+
+**Security implication:** HTTP header injection can enable response splitting, cache poisoning, and session fixation. Validate all user input before placing in headers.
+
+**Detection regex:** `Header\(\)\.Set\s*\(.*\b(r\.|req\.|request\.|params|query)`
+
+### 8. SSRF via http.Get with User Input (CWE-918)
+
+Passing user-controlled URLs to `http.Get` or `http.Client.Do` without validation allows Server-Side Request Forgery.
+
+```go
+// VULNERABLE: User-controlled URL in HTTP request
+func fetchProxy(w http.ResponseWriter, r *http.Request) {
+    target := r.URL.Query().Get("url")
+    resp, err := http.Get(target) // SSRF: attacker can reach internal services
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusBadGateway)
+        return
+    }
+    defer resp.Body.Close()
+    io.Copy(w, resp.Body)
+}
+
+// SECURE: Validate URL against allowlist and block internal networks
+func fetchProxySafe(w http.ResponseWriter, r *http.Request) {
+    target := r.URL.Query().Get("url")
+    parsed, err := url.Parse(target)
+    if err != nil {
+        http.Error(w, "Invalid URL", http.StatusBadRequest)
+        return
+    }
+    // Only allow HTTPS to specific domains
+    allowed := map[string]bool{"api.example.com": true, "cdn.example.com": true}
+    if parsed.Scheme != "https" || !allowed[parsed.Host] {
+        http.Error(w, "URL not allowed", http.StatusForbidden)
+        return
+    }
+    // Use a client with timeouts and no redirect following
+    client := &http.Client{
+        Timeout: 10 * time.Second,
+        CheckRedirect: func(req *http.Request, via []*http.Request) error {
+            return http.ErrUseLastResponse
+        },
+    }
+    resp, err := client.Get(parsed.String())
+    if err != nil {
+        http.Error(w, "Fetch failed", http.StatusBadGateway)
+        return
+    }
+    defer resp.Body.Close()
+    io.Copy(w, resp.Body)
+}
+```
+
+**Security implication:** SSRF can expose internal services, cloud metadata endpoints (169.254.169.254), and enable network scanning from the server.
+
+**Detection regex:** `http\.(Get|Post|Head)\s*\(.*\b(r\.|req\.|request\.|params|query|URL)`
+
+### 9. Insecure TLS Configuration (CWE-295)
+
+Setting `InsecureSkipVerify: true` disables TLS certificate validation, enabling man-in-the-middle attacks.
+
+```go
+// VULNERABLE: Skip TLS certificate verification
+client := &http.Client{
+    Transport: &http.Transport{
+        TLSClientConfig: &tls.Config{
+            InsecureSkipVerify: true, // Accepts ANY certificate, including forged ones
+        },
+    },
+}
+resp, err := client.Get("https://api.example.com/secrets")
+
+// VULNERABLE: Minimum TLS version too low
+tlsConfig := &tls.Config{
+    MinVersion: tls.VersionTLS10, // TLS 1.0 has known vulnerabilities
+}
+
+// SECURE: Proper TLS configuration
+client := &http.Client{
+    Transport: &http.Transport{
+        TLSClientConfig: &tls.Config{
+            MinVersion: tls.VersionTLS12,
+            // Default InsecureSkipVerify is false — certificates are validated
+        },
+    },
+}
+resp, err := client.Get("https://api.example.com/secrets")
+
+// SECURE: Pin specific CA certificates
+certPool := x509.NewCertPool()
+certPool.AppendCertsFromPEM(caCert)
+client := &http.Client{
+    Transport: &http.Transport{
+        TLSClientConfig: &tls.Config{
+            RootCAs:    certPool,
+            MinVersion: tls.VersionTLS12,
+        },
+    },
+}
+```
+
+**Security implication:** Disabling certificate verification allows attackers to intercept encrypted traffic. This is commonly left in code after debugging.
+
+**Detection regex:** `InsecureSkipVerify\s*:\s*true`
+
+### 10. Insecure Randomness: crypto/rand vs math/rand (CWE-330)
+
+`math/rand` uses a deterministic PRNG unsuitable for security-sensitive operations. Use `crypto/rand` for tokens, keys, and nonces.
+
+```go
+// VULNERABLE: math/rand for security-sensitive values
+import "math/rand"
+
+func generateToken() string {
+    // math/rand is deterministic — tokens are predictable
+    token := make([]byte, 32)
+    for i := range token {
+        token[i] = byte(rand.Intn(256))
+    }
+    return hex.EncodeToString(token)
+}
+
+// VULNERABLE: math/rand seeded with time (still predictable)
+func generateTokenSeeded() string {
+    rand.Seed(time.Now().UnixNano()) // Seed is guessable
+    return fmt.Sprintf("%d", rand.Int63())
+}
+
+// SECURE: crypto/rand for cryptographically secure random values
+import "crypto/rand"
+
+func generateTokenSecure() (string, error) {
+    token := make([]byte, 32)
+    if _, err := rand.Read(token); err != nil {
+        return "", fmt.Errorf("failed to generate token: %w", err)
+    }
+    return hex.EncodeToString(token), nil
+}
+```
+
+**Security implication:** Predictable tokens allow session hijacking, CSRF bypass, and password reset token forgery. Always use `crypto/rand` for security-critical randomness.
+
+**Detection regex:** `"math/rand"`
+
+### 11. Integer Overflow in Calculations (CWE-190)
+
+Go does not panic on integer overflow — values silently wrap around. This can cause incorrect security decisions, buffer size miscalculations, or financial errors.
+
+```go
+// VULNERABLE: Integer overflow in allocation size
+func allocateBuffer(count int, size int) []byte {
+    total := count * size // Silent overflow: 1<<31 * 2 wraps to 0
+    buf := make([]byte, total)
+    return buf
+}
+
+// VULNERABLE: Overflow in bounds check
+func isValidIndex(index int32, length int32) bool {
+    return index+1 <= length // If index == math.MaxInt32, index+1 wraps to -2147483648
+}
+
+// SECURE: Check for overflow before arithmetic
+func allocateBufferSafe(count, size int) ([]byte, error) {
+    if count < 0 || size < 0 {
+        return nil, fmt.Errorf("negative size")
+    }
+    if count > 0 && size > math.MaxInt/count {
+        return nil, fmt.Errorf("allocation size overflow")
+    }
+    return make([]byte, count*size), nil
+}
+```
+
+**Security implication:** Integer overflows can bypass bounds checks, cause undersized allocations leading to buffer overflows, or produce incorrect financial calculations.
+
+**Detection regex:** Best detected via static analysis (`go vet`, `staticcheck`). Regex detection is unreliable for this pattern.
+
+## Go 1.18+ Security Features
+
+### Generics for Type-Safe Validation
+
+Go 1.18 introduced generics, enabling reusable, type-safe validation functions that reduce copy-paste errors in security-critical code.
+
+```go
+// BEFORE Go 1.18: Repeated validation logic prone to copy-paste errors
+func validateStringLength(s string, max int) error {
+    if len(s) > max {
+        return fmt.Errorf("string too long: %d > %d", len(s), max)
+    }
+    return nil
+}
+
+// AFTER Go 1.18: Generic bounded validator
+type Bounded interface {
+    ~int | ~int32 | ~int64 | ~float64 | ~string
+}
+
+func ValidateRange[T constraints.Ordered](value T, min, max T) error {
+    if value < min || value > max {
+        return fmt.Errorf("value %v out of range [%v, %v]", value, min, max)
+    }
+    return nil
+}
+
+// Type-safe allowlist check
+func InAllowlist[T comparable](value T, allowed []T) bool {
+    for _, a := range allowed {
+        if value == a {
+            return true
+        }
+    }
+    return false
+}
+
+// Usage: compile-time type safety prevents mixing types
+err := ValidateRange(userAge, 0, 150)
+ok := InAllowlist(role, []string{"admin", "editor", "viewer"})
+```
+
+**Security implication:** Generic validators reduce the risk of bugs in repeated validation logic across types.
+
+### Fuzzing Support (go test -fuzz)
+
+Go 1.18 added native fuzzing to the testing framework, enabling automated discovery of edge cases and vulnerabilities.
+
+```go
+// Fuzz test for input validation
+func FuzzValidateInput(f *testing.F) {
+    f.Add("normal-input")
+    f.Add("<script>alert(1)</script>")
+    f.Add("'; DROP TABLE users; --")
+    f.Add(strings.Repeat("A", 10000))
+
+    f.Fuzz(func(t *testing.T, input string) {
+        result, err := ValidateInput(input)
+        if err == nil {
+            // If validation passes, result must be safe
+            if strings.Contains(result, "<script>") {
+                t.Error("XSS payload passed validation")
+            }
+        }
+    })
+}
+```
+
+**Security implication:** Fuzzing discovers crashes, panics, and logic bugs in parsers and validators that manual testing misses.
+
+## Go 1.21+ Security Features
+
+### log/slog for Structured Security Logging
+
+Go 1.21 introduced `log/slog`, the standard library structured logger. Structured logging prevents log injection and enables security event correlation.
+
+```go
+// VULNERABLE: Unstructured logging with user input (log injection)
+import "log"
+
+func handleRequest(r *http.Request) {
+    user := r.URL.Query().Get("user")
+    // Attacker can inject: user=admin\n[INFO] Access granted to admin
+    log.Printf("[INFO] Login attempt for user: %s", user)
+}
+
+// SECURE: Structured logging with slog
+import "log/slog"
+
+func handleRequestSafe(r *http.Request) {
+    user := r.URL.Query().Get("user")
+    slog.Info("login_attempt",
+        slog.String("user", user),           // Properly escaped as structured field
+        slog.String("ip", r.RemoteAddr),
+        slog.String("method", r.Method),
+    )
+}
+
+// SECURE: Security event logger with required fields
+var securityLogger = slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+    Level: slog.LevelInfo,
+}))
+
+func logSecurityEvent(event string, attrs ...slog.Attr) {
+    securityLogger.LogAttrs(context.Background(), slog.LevelWarn, event, attrs...)
+}
+```
+
+**Security implication:** Structured logging prevents log injection attacks and produces machine-parseable security audit trails.
+
+**Detection regex:** `log\.(Print|Fatal|Panic)(f|ln)?\s*\(` (warning: suggests migration to `slog`)
+
+### maps and slices Packages
+
+Go 1.21 added `maps` and `slices` packages with safe operations that reduce off-by-one errors and race conditions.
+
+```go
+// SECURE: slices.Contains for safe allowlist check (replaces manual loops)
+import "slices"
+
+func isAllowedRole(role string) bool {
+    allowed := []string{"admin", "editor", "viewer"}
+    return slices.Contains(allowed, role)
+}
+
+// SECURE: maps.Clone for safe copy (prevents unintended shared state)
+import "maps"
+
+func clonePermissions(original map[string]bool) map[string]bool {
+    return maps.Clone(original) // Deep copy, no shared references
+}
+```
+
+**Security implication:** Standard library functions for common operations reduce the chance of logic errors in security-critical code paths.
+
+## Go 1.22+ Security Features
+
+### Loop Variable Semantics Fix
+
+Go 1.22 changed loop variable semantics so that each iteration creates a new variable, fixing a longstanding class of bugs where closures captured the loop variable by reference.
+
+```go
+// BEFORE Go 1.22: Loop variable captured by reference (bug)
+func startHandlers(ports []int) {
+    for _, port := range ports {
+        go func() {
+            // BUG: all goroutines use the same 'port' variable
+            // They all bind to the LAST port in the slice
+            http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+        }()
+    }
+}
+
+// Go 1.22+: Each iteration gets its own variable (fixed)
+func startHandlers(ports []int) {
+    for _, port := range ports {
+        go func() {
+            // CORRECT in Go 1.22+: each goroutine has its own 'port'
+            http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+        }()
+    }
+}
+```
+
+**Security implication:** The old behavior could cause services to bind to wrong ports, security checks to use wrong values, and goroutines to process wrong data. Go 1.22 eliminates this class of bugs.
+
+### Enhanced Routing Patterns in net/http
+
+Go 1.22 added method-based routing and path parameters to the standard `net/http` mux, reducing reliance on third-party routers.
+
+```go
+// Go 1.22+: Method-specific routes prevent method confusion
+mux := http.NewServeMux()
+mux.HandleFunc("GET /api/users/{id}", getUser)    // Only matches GET
+mux.HandleFunc("DELETE /api/users/{id}", deleteUser) // Only matches DELETE
+
+func getUser(w http.ResponseWriter, r *http.Request) {
+    id := r.PathValue("id") // Safe path parameter extraction
+    // Validate id before use
+    if !isValidID(id) {
+        http.Error(w, "Invalid ID", http.StatusBadRequest)
+        return
+    }
+    // ...
+}
+```
+
+**Security implication:** Method-specific routing prevents unauthorized operations via HTTP method confusion (e.g., GET reaching a DELETE handler).
+
+## Detection Patterns for Auditing Go Security Features
+
+| Pattern | Regex | Severity | Checkpoint ID |
+|---------|-------|----------|---------------|
+| `unsafe` package usage | `unsafe\.Pointer\|unsafe\.Sizeof\|unsafe\.Slice` | error | SA-GO-01 |
+| `text/template` for HTML | `"text/template"` | error | SA-GO-02 |
+| SQL string concatenation | `(Sprintf\|"\s*\+).*(?i)(SELECT\|INSERT\|UPDATE\|DELETE)` | error | SA-GO-03 |
+| Shell command injection | `exec\.Command\s*\(\s*"(sh\|bash\|cmd)"` | error | SA-GO-04 |
+| Path traversal via Join | `filepath\.Join\s*\(.*req\.\|r\.URL` | warning | SA-GO-05 |
+| `InsecureSkipVerify: true` | `InsecureSkipVerify\s*:\s*true` | error | SA-GO-06 |
+| `math/rand` for security | `"math/rand"` | warning | SA-GO-07 |
+| SSRF via user-supplied URL | `http\.(Get\|Post)\s*\(.*req\.\|r\.URL` | error | SA-GO-08 |
+| Unstructured log with user input | `log\.(Print\|Fatal)(f\|ln)?\s*\(` | warning | SA-GO-09 |
+| HTTP header injection | `Header\(\)\.Set\s*\(.*r\.\|req\.` | warning | SA-GO-10 |
+| `VersionTLS10` or `VersionTLS11` | `VersionTLS1[01]\b` | error | SA-GO-11 |
+| Hardcoded credentials | `(password\|secret\|apiKey\|token)\s*[:=]\s*"[^"]{8,}"` | error | SA-GO-12 |
+| Missing error check on crypto | `rand\.Read\(.*\)\s*$` without error check | warning | SA-GO-13 |
+| `net.Listen` on 0.0.0.0 | `net\.Listen\s*\(\s*"tcp"\s*,\s*":` | warning | SA-GO-14 |
+| Goroutine leak (unbounded) | `go\s+func\s*\(` without context/cancel pattern | warning | SA-GO-15 |
+
+## Version Adoption Security Checklist
+
+- [ ] Enable `-race` flag in CI test pipeline
+- [ ] Run `go vet ./...` and `staticcheck ./...` in CI
+- [ ] Audit all uses of `unsafe` package
+- [ ] Replace `text/template` with `html/template` for HTML output
+- [ ] Replace all SQL string concatenation with parameterized queries
+- [ ] Verify no `InsecureSkipVerify: true` in production code
+- [ ] Replace `math/rand` with `crypto/rand` for tokens, keys, nonces
+- [ ] Validate all user-supplied URLs before HTTP requests
+- [ ] Migrate from `log.Printf` to `log/slog` for security events (Go 1.21+)
+- [ ] Run `go test -fuzz` on parsers and validators (Go 1.18+)
+- [ ] Update to Go 1.22+ to get loop variable fix
+- [ ] Run `govulncheck ./...` to detect known vulnerabilities in dependencies
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `cwe-top25.md` — CWE Top 25 mapping
+- `input-validation.md` — Input validation patterns
+- `path-traversal-prevention.md` — Path traversal prevention
+- `cryptography-guide.md` — Cryptographic best practices
+- `security-logging.md` — Security logging patterns
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Multi-language security references expansion |

--- a/skills/security-audit/references/go-security-features.md
+++ b/skills/security-audit/references/go-security-features.md
@@ -46,7 +46,15 @@ func handleLoginSafe(w http.ResponseWriter, r *http.Request) {
 
 **Security implication:** Data races on security-critical variables can cause authentication bypass, privilege escalation, or inconsistent authorization decisions. Always run tests with `-race` flag: `go test -race ./...`
 
-**Detection regex:** `go\s+(func|test)\b` combined with shared variable writes — best detected with `go vet -race` or `go build -race`.
+**Detection:** static regexes catch obvious `go func(){ ... }()` sites but can't reason about shared state. The Go toolchain's built-in data-race detector is the right answer — it instruments the binary and reports races at runtime:
+
+```bash
+go test -race ./...            # run tests with the race detector
+go run -race ./cmd/server      # instrument a running binary
+go build -race -o ./bin/server ./cmd/server   # produce an instrumented build
+```
+
+`go vet` does not have a `-race` mode; the `-race` flag belongs to `go test` / `go run` / `go build` (it instruments the binary — you still have to exercise it).
 
 ### 2. Unsafe Pointer Usage (CWE-119, CWE-787)
 
@@ -570,11 +578,25 @@ func isAllowedRole(role string) bool {
     return slices.Contains(allowed, role)
 }
 
-// SECURE: maps.Clone for safe copy (prevents unintended shared state)
+// SECURE: maps.Clone produces a SHALLOW copy — the returned map has
+// its own backing store, so the caller can add or remove keys without
+// touching `original`. But reference-typed values (slices, maps,
+// pointers, structs containing them) are still shared. For `map[string]bool`
+// this is safe because bool is a value type; for a map of slices or
+// structs-with-slices you must deep-copy the values yourself.
 import "maps"
 
 func clonePermissions(original map[string]bool) map[string]bool {
-    return maps.Clone(original) // Deep copy, no shared references
+    return maps.Clone(original) // OK: bool values are not references.
+}
+
+// Example: when values are slices, maps.Clone is NOT enough.
+func cloneRoleAssignments(original map[string][]string) map[string][]string {
+    out := make(map[string][]string, len(original))
+    for k, v := range original {
+        out[k] = append([]string(nil), v...)   // copy each slice
+    }
+    return out
 }
 ```
 

--- a/skills/security-audit/references/rails-security.md
+++ b/skills/security-audit/references/rails-security.md
@@ -36,11 +36,19 @@ class UsersController < ApplicationController
   end
 end
 
-# VULNERABLE: Using attributes= or update_attributes without strong params
+# VULNERABLE: Bypassing strong parameters. Modern Rails raises
+# ActiveModel::ForbiddenAttributesError if you assign raw
+# ActionController::Parameters to a model; the bypass shapes to look
+# for in audits are:
+#   1. An explicit .permit!  (permit everything)
+#   2. to_unsafe_h / to_unsafe_hash (strips the "forbidden" flag)
+#   3. .to_h after permit(*Model.attribute_names)  (allowlists every
+#      attribute, including role / is_admin)
 class UsersController < ApplicationController
   def update
     @user = User.find(params[:id])
-    @user.attributes = params[:user]  # No filtering at all
+    @user.attributes = params[:user].permit!        # permit-everything
+    # @user.attributes = params[:user].to_unsafe_h  # equivalent bypass
     @user.save
   end
 end
@@ -309,15 +317,19 @@ end
 ```
 
 ```ruby
-# SECURE: Validate filename and verify resolved path
+# SECURE: Validate filename and verify resolved path. Enforce a
+# directory boundary when comparing — plain `start_with?(UPLOADS_DIR)`
+# would accept "#{UPLOADS_DIR}_private/..." because that's a prefix
+# of the allowed root. Append File::SEPARATOR before comparing.
 class DownloadsController < ApplicationController
   UPLOADS_DIR = Rails.root.join("uploads").to_s
+  UPLOADS_ROOT = UPLOADS_DIR + File::SEPARATOR
 
   def show
     basename = File.basename(params[:filename]) # Strip directory components
     full_path = File.realpath(File.join(UPLOADS_DIR, basename))
 
-    unless full_path.start_with?(UPLOADS_DIR)
+    unless full_path == UPLOADS_DIR || full_path.start_with?(UPLOADS_ROOT)
       head :not_found
       return
     end

--- a/skills/security-audit/references/rails-security.md
+++ b/skills/security-audit/references/rails-security.md
@@ -1,0 +1,615 @@
+# Rails Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for Ruby on Rails applications. Rails provides many security protections by default (CSRF tokens, parameterized queries, automatic HTML escaping), but developers frequently bypass these safeguards through mass assignment misconfiguration, raw HTML output, inline SQL, and improper file handling. Understanding these patterns is essential for auditing Rails applications.
+
+---
+
+## Mass Assignment
+
+### SA-RAILS-01: Strong Parameters Bypass
+
+Rails requires explicit parameter whitelisting via `permit`. However, developers sometimes use `permit!` (which allows all parameters), bypass strong parameters entirely, or permit sensitive fields that should be set server-side.
+
+```ruby
+# VULNERABLE: permit! allows ALL parameters including role, is_admin, etc.
+class UsersController < ApplicationController
+  def create
+    @user = User.new(params[:user].permit!)
+    @user.save
+    redirect_to @user
+  end
+end
+
+# VULNERABLE: Permitting sensitive fields
+class UsersController < ApplicationController
+  def update
+    @user = User.find(params[:id])
+    @user.update(user_params)
+    redirect_to @user
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :role, :is_admin)
+    # :role and :is_admin should NEVER be user-controllable
+  end
+end
+
+# VULNERABLE: Using attributes= or update_attributes without strong params
+class UsersController < ApplicationController
+  def update
+    @user = User.find(params[:id])
+    @user.attributes = params[:user]  # No filtering at all
+    @user.save
+  end
+end
+```
+
+```ruby
+# SECURE: Only permit safe fields, set sensitive fields server-side
+class UsersController < ApplicationController
+  def create
+    @user = User.new(user_params)
+    @user.role = "user"        # Explicitly set server-side
+    @user.is_admin = false     # Explicitly set server-side
+    @user.save
+    redirect_to @user
+  end
+
+  def update
+    @user = current_user # Use authenticated user, not params[:id]
+    @user.update(user_params)
+    redirect_to @user
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :avatar, :bio)
+  end
+end
+```
+
+**Detection regex:** `\.permit!|params\[:[a-z_]+\]\.permit\([^)]*(?:role|admin|superuser|permission)`
+**Severity:** error
+
+---
+
+## Cross-Site Scripting (XSS)
+
+### SA-RAILS-02: html_safe / raw XSS
+
+Rails auto-escapes all output in ERB templates by default. However, calling `html_safe`, `raw()`, or using `<%== %>` explicitly marks content as safe, bypassing escaping. When applied to user-controlled input, this creates XSS vulnerabilities.
+
+```erb
+<%# VULNERABLE: html_safe on user input %>
+<p>Welcome, <%= @user.name.html_safe %></p>
+
+<%# VULNERABLE: raw() on user input %>
+<div><%= raw @comment.body %></div>
+
+<%# VULNERABLE: <%== bypasses escaping %>
+<h1><%== @post.title %></h1>
+
+<%# VULNERABLE: html_safe on interpolated user input %>
+<div><%= "<b>#{@user.bio}</b>".html_safe %></div>
+```
+
+```ruby
+# VULNERABLE: html_safe in helper
+module ApplicationHelper
+  def format_comment(comment)
+    comment.body.gsub("\n", "<br>").html_safe
+  end
+end
+```
+
+```erb
+<%# SECURE: Default escaping (no html_safe/raw) %>
+<p>Welcome, <%= @user.name %></p>
+<div><%= @comment.body %></div>
+
+<%# SECURE: Sanitize if HTML is needed %>
+<div><%= sanitize @comment.body, tags: %w[b i em strong p br] %></div>
+
+<%# SECURE: Use content_tag for safe HTML generation %>
+<%= content_tag :div, @user.bio, class: "bio" %>
+```
+
+```ruby
+# SECURE: Sanitize in helper
+module ApplicationHelper
+  def format_comment(comment)
+    sanitize(
+      simple_format(comment.body),
+      tags: %w[p br b i em strong]
+    )
+  end
+end
+```
+
+**Detection regex:** `\.html_safe|raw\s*\(|<%==`
+**Severity:** error
+
+---
+
+## SQL Injection
+
+### SA-RAILS-03: find_by_sql and String Interpolation in Queries
+
+Rails' ActiveRecord ORM uses parameterized queries by default, but developers can bypass this with `find_by_sql`, string interpolation in `where` clauses, raw SQL fragments, and `order` clauses built from user input.
+
+```ruby
+# VULNERABLE: String interpolation in find_by_sql
+class User < ApplicationRecord
+  def self.search(query)
+    find_by_sql("SELECT * FROM users WHERE name LIKE '%#{query}%'")
+  end
+end
+
+# VULNERABLE: String interpolation in where clause
+class PostsController < ApplicationController
+  def index
+    @posts = Post.where("title LIKE '%#{params[:search]}%'")
+  end
+end
+
+# VULNERABLE: User-controlled order clause
+class PostsController < ApplicationController
+  def index
+    @posts = Post.order(params[:sort])
+    # Attacker sends: sort=(CASE WHEN (SELECT...) THEN name ELSE id END)
+  end
+end
+
+# VULNERABLE: String interpolation in pluck/select
+class ReportsController < ApplicationController
+  def show
+    columns = params[:columns]
+    @data = Report.select(columns).all
+  end
+end
+```
+
+```ruby
+# SECURE: Parameterized queries
+class User < ApplicationRecord
+  def self.search(query)
+    where("name LIKE ?", "%#{sanitize_sql_like(query)}%")
+  end
+end
+
+# SECURE: Using hash conditions
+class PostsController < ApplicationController
+  def index
+    @posts = Post.where(published: true)
+    @posts = @posts.where("title LIKE ?", "%#{Post.sanitize_sql_like(params[:search])}%") if params[:search]
+  end
+end
+
+# SECURE: Allowlist for order clause
+ALLOWED_SORT = %w[title created_at updated_at].freeze
+
+class PostsController < ApplicationController
+  def index
+    sort_col = ALLOWED_SORT.include?(params[:sort]) ? params[:sort] : "created_at"
+    direction = params[:dir] == "asc" ? :asc : :desc
+    @posts = Post.order(sort_col => direction)
+  end
+end
+```
+
+**Detection regex:** `find_by_sql\s*\(.*#\{|\.where\s*\(.*#\{|\.order\s*\(\s*params`
+**Severity:** error
+
+---
+
+## CSRF Protection
+
+### SA-RAILS-04: CSRF Token Configuration
+
+Rails includes CSRF protection by default via `protect_from_forgery`. However, it can be disabled, misconfigured, or bypassed. API-only apps, `skip_before_action`, and wrong `:with` strategies are common pitfalls.
+
+```ruby
+# VULNERABLE: CSRF protection disabled
+class ApplicationController < ActionController::Base
+  skip_before_action :verify_authenticity_token
+end
+
+# VULNERABLE: CSRF protection with null_session on non-API controllers
+class ApplicationController < ActionController::Base
+  protect_from_forgery with: :null_session
+  # Attacker can forge requests — session is just silently reset
+end
+
+# VULNERABLE: Skipping CSRF for specific actions that modify state
+class PaymentsController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [:webhook, :create]
+  # :create should NOT skip CSRF! Only webhooks with signature verification.
+
+  def create
+    Payment.create(amount: params[:amount], user: current_user)
+  end
+end
+```
+
+```ruby
+# SECURE: Default CSRF with exception strategy
+class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+end
+
+# SECURE: API controllers use null_session (no cookie-based auth)
+class Api::BaseController < ActionController::Base
+  protect_from_forgery with: :null_session
+  before_action :authenticate_api_token!
+
+  private
+
+  def authenticate_api_token!
+    token = request.headers["Authorization"]&.remove("Bearer ")
+    @current_user = User.find_by(api_token: token) or head :unauthorized
+  end
+end
+
+# SECURE: Skip CSRF only for webhook with signature verification
+class PaymentsController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [:webhook]
+
+  def webhook
+    verify_webhook_signature!(request)
+    # Process webhook...
+  end
+
+  def create
+    # CSRF token is verified for this action
+    Payment.create(amount: params[:amount], user: current_user)
+  end
+end
+```
+
+**Detection regex:** `skip_before_action\s*:verify_authenticity_token|protect_from_forgery\s+with:\s*:null_session`
+**Severity:** error
+
+---
+
+## Path Traversal
+
+### SA-RAILS-05: send_file / send_data Path Traversal
+
+`send_file` and `send_data` serve files from the server. If the file path includes user input without sanitization, attackers can traverse directories.
+
+```ruby
+# VULNERABLE: User-controlled path in send_file
+class DownloadsController < ApplicationController
+  def show
+    # Attacker sends: filename=../../../etc/passwd
+    send_file Rails.root.join("uploads", params[:filename])
+  end
+end
+
+# VULNERABLE: Insufficient sanitization
+class DownloadsController < ApplicationController
+  def show
+    filename = params[:filename].gsub("..", "")
+    # Can be bypassed with "....//", URL encoding, etc.
+    send_file Rails.root.join("uploads", filename)
+  end
+end
+
+# VULNERABLE: send_data with user-controlled filename in disposition
+class ExportsController < ApplicationController
+  def download
+    send_data @report.csv_data,
+      filename: params[:name], # Header injection via filename
+      type: "text/csv"
+  end
+end
+```
+
+```ruby
+# SECURE: Validate filename and verify resolved path
+class DownloadsController < ApplicationController
+  UPLOADS_DIR = Rails.root.join("uploads").to_s
+
+  def show
+    basename = File.basename(params[:filename]) # Strip directory components
+    full_path = File.realpath(File.join(UPLOADS_DIR, basename))
+
+    unless full_path.start_with?(UPLOADS_DIR)
+      head :not_found
+      return
+    end
+
+    send_file full_path
+  end
+end
+
+# SECURE: Use database lookup instead of filesystem path
+class DownloadsController < ApplicationController
+  def show
+    attachment = current_user.attachments.find(params[:id])
+    send_file attachment.file_path, filename: attachment.original_filename
+  end
+end
+```
+
+**Detection regex:** `send_file\s*.*params\[|send_data\s*.*filename:\s*params\[`
+**Severity:** error
+
+---
+
+## Template Injection
+
+### SA-RAILS-06: render inline: Template Injection
+
+`render inline:` compiles and executes ERB templates at runtime. If the template string includes user input, attackers can execute arbitrary Ruby code via ERB tags.
+
+```ruby
+# VULNERABLE: User input in inline template
+class PagesController < ApplicationController
+  def preview
+    template = params[:template]
+    # Attacker sends: template=<%= system('id') %>
+    render inline: template
+  end
+end
+
+# VULNERABLE: String interpolation in inline template
+class NotificationsController < ApplicationController
+  def show
+    message = params[:message]
+    render inline: "<p>Message: #{message}</p>"
+  end
+end
+
+# VULNERABLE: User input in render with layout
+class PagesController < ApplicationController
+  def show
+    render inline: "Hello", layout: params[:layout]
+  end
+end
+```
+
+```ruby
+# SECURE: Use templates with variables, never inline with user input
+class PagesController < ApplicationController
+  def preview
+    @message = params[:message]
+    render template: "pages/preview" # Uses app/views/pages/preview.html.erb
+  end
+end
+
+# SECURE: Allowlist for layout
+ALLOWED_LAYOUTS = %w[default minimal print].freeze
+
+class PagesController < ApplicationController
+  def show
+    layout = ALLOWED_LAYOUTS.include?(params[:layout]) ? params[:layout] : "default"
+    render template: "pages/show", layout: layout
+  end
+end
+```
+
+**Detection regex:** `render\s+inline:\s*.*params\[|render\s+inline:\s*.*#\{`
+**Severity:** error
+
+---
+
+## File Upload Validation
+
+### SA-RAILS-07: Active Storage File Validation
+
+Active Storage does not validate file types or sizes by default. Without validation, attackers can upload executable files, oversized files (DoS), or files with mismatched content types.
+
+```ruby
+# VULNERABLE: No file validation
+class User < ApplicationRecord
+  has_one_attached :avatar
+  # No content_type or size validation!
+end
+
+# VULNERABLE: Client-side only validation (easily bypassed)
+class UsersController < ApplicationController
+  def update
+    # Client-side accept attribute is NOT security
+    @user.avatar.attach(params[:avatar])
+  end
+end
+```
+
+```ruby
+# SECURE: Server-side validation with Active Storage validations
+class User < ApplicationRecord
+  has_one_attached :avatar
+
+  validates :avatar,
+    content_type: %w[image/png image/jpeg image/gif image/webp],
+    size: { less_than: 5.megabytes }
+end
+
+# SECURE: Manual validation in controller
+class UsersController < ApplicationController
+  ALLOWED_TYPES = %w[image/png image/jpeg image/gif].freeze
+  MAX_SIZE = 5.megabytes
+
+  def update
+    file = params[:avatar]
+    unless file.content_type.in?(ALLOWED_TYPES) && file.size <= MAX_SIZE
+      flash[:error] = "Invalid file"
+      redirect_to edit_user_path and return
+    end
+
+    @user.avatar.attach(file)
+    redirect_to @user
+  end
+end
+```
+
+**Detection regex:** `has_one_attached\s+:\w+(?![\s\S]*?validates\s+:\w+.*content_type)|has_many_attached\s+:\w+(?![\s\S]*?validates\s+:\w+.*content_type)`
+**Severity:** warning
+
+---
+
+## Action Cable Authentication
+
+### SA-RAILS-08: Action Cable Auth
+
+Action Cable (WebSocket) connections require explicit authentication. Without it, any client can subscribe to channels and receive real-time data.
+
+```ruby
+# VULNERABLE: No authentication in connection
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    # No identified_by — anyone can connect
+  end
+end
+
+# VULNERABLE: Channel without authorization
+class AdminChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "admin_notifications"
+    # Any connected user (or anonymous user) receives admin data!
+  end
+end
+```
+
+```ruby
+# SECURE: Authenticate connection via cookies/session
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    private
+
+    def find_verified_user
+      user = User.find_by(id: cookies.encrypted[:user_id])
+      user || reject_unauthorized_connection
+    end
+  end
+end
+
+# SECURE: Authorize channel subscriptions
+class AdminChannel < ApplicationCable::Channel
+  def subscribed
+    reject unless current_user.admin?
+    stream_from "admin_notifications"
+  end
+end
+```
+
+**Detection regex:** `class\s+\w+Channel\s*<\s*ApplicationCable::Channel[\s\S]*?def\s+subscribed(?![\s\S]*?reject\b)`
+**Severity:** error
+
+---
+
+## protect_from_forgery Ordering
+
+### SA-RAILS-09: protect_from_forgery Ordering
+
+When `protect_from_forgery with: :exception` is placed after `before_action` callbacks that modify state, a CSRF attack can trigger those callbacks before the token is verified.
+
+```ruby
+# VULNERABLE: State-changing callback runs before CSRF check
+class ApplicationController < ActionController::Base
+  before_action :set_locale_from_param  # Runs first
+  before_action :track_visit            # Runs second — writes to DB!
+  protect_from_forgery with: :exception # Runs third — too late
+end
+```
+
+```ruby
+# SECURE: protect_from_forgery before state-changing callbacks
+class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception  # Runs first
+  before_action :set_locale_from_param
+  before_action :track_visit
+end
+```
+
+**Detection regex:** `before_action\s+:\w+[\s\S]*?protect_from_forgery`
+**Severity:** warning
+
+---
+
+## Unsafe Deserialization
+
+### SA-RAILS-10: Marshal.load / YAML.load with User Input
+
+`Marshal.load` and `YAML.load` can execute arbitrary Ruby code when deserializing untrusted data. Rails historically used YAML for session serialization, making this a well-known attack vector.
+
+```ruby
+# VULNERABLE: Marshal.load on user input
+class ImportController < ApplicationController
+  def create
+    data = Marshal.load(Base64.decode64(params[:data]))
+    # Arbitrary code execution via crafted Marshal payload
+  end
+end
+
+# VULNERABLE: YAML.load on user input
+class ConfigController < ApplicationController
+  def update
+    config = YAML.load(params[:yaml_content])
+    # Arbitrary code execution via YAML deserialization gadgets
+  end
+end
+```
+
+```ruby
+# SECURE: Use JSON or YAML.safe_load
+class ImportController < ApplicationController
+  def create
+    data = JSON.parse(params[:data])
+    process_import(data)
+  end
+end
+
+# SECURE: YAML.safe_load with permitted classes
+class ConfigController < ApplicationController
+  def update
+    config = YAML.safe_load(
+      params[:yaml_content],
+      permitted_classes: [Symbol, Date, Time]
+    )
+    apply_config(config)
+  end
+end
+```
+
+**Detection regex:** `Marshal\.load\s*\(|YAML\.load\s*\([^)]*params`
+**Severity:** error
+
+---
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| SA-RAILS-01 Mass assignment | Critical | Immediate | Low |
+| SA-RAILS-02 html_safe/raw XSS | Critical | Immediate | Low |
+| SA-RAILS-03 SQL injection | Critical | Immediate | Medium |
+| SA-RAILS-04 CSRF misconfiguration | High | Immediate | Low |
+| SA-RAILS-05 Path traversal | Critical | Immediate | Medium |
+| SA-RAILS-06 Template injection | Critical | Immediate | Low |
+| SA-RAILS-07 Active Storage validation | Medium | 1 week | Low |
+| SA-RAILS-08 Action Cable auth | High | 1 week | Medium |
+| SA-RAILS-09 protect_from_forgery ordering | Medium | 1 week | Low |
+| SA-RAILS-10 Unsafe deserialization | Critical | Immediate | Low |
+
+## Related References
+
+- `owasp-top10.md` -- OWASP Top 10 mapping
+- `api-security.md` -- API-level security patterns
+- Rails Security Guide: https://guides.rubyonrails.org/security.html
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Phase 3 framework expansion |

--- a/skills/security-audit/references/ruby-security-features.md
+++ b/skills/security-audit/references/ruby-security-features.md
@@ -112,7 +112,15 @@ end
 
 **Security implication:** Ruby's `system`, `exec`, `%x{}`, and backticks all invoke a shell when given a single string argument. The array form of `system` and `exec` bypasses the shell entirely, making it immune to injection. Always prefer the array form. CWE-78: Improper Neutralization of Special Elements used in an OS Command.
 
-**Detection regex:** `\bsystem\s*\(` , `\bexec\s*\(` , `` `.+#\{`` (backtick with interpolation)
+**Detection regex (run each separately):**
+
+```bash
+# System / exec calls that take a single string (shell invocation) — check the array-vs-string form manually.
+grep -rnE '\b(system|exec)\s*\(' --include='*.rb' .
+# Backtick invocations containing #{...} interpolation — the backtick
+# here is escaped with a backslash to keep the inline code span intact.
+grep -rnP '\x60[^\x60]*#\{' --include='*.rb' .
+```
 
 ---
 
@@ -198,10 +206,10 @@ end
 
 # SECURE: Pass user input as data, not template content
 def render_greeting(name)
-  template = ERB.new("Hello, <%= @name %>!")
-  b = binding
-  b.local_variable_set(:name, name)
-  # Or use a struct/OpenStruct for the binding context
+  # Match the template variable to the hash key. `result_with_hash`
+  # binds locals, so the template must reference `<%= name %>`, not
+  # `@name` (which is an instance variable and wouldn't be set).
+  template = ERB.new("Hello, <%= name %>!")
   template.result_with_hash(name: ERB::Util.html_escape(name))
 end
 

--- a/skills/security-audit/references/ruby-security-features.md
+++ b/skills/security-audit/references/ruby-security-features.md
@@ -1,0 +1,681 @@
+# Ruby Security Features by Version
+
+Modern Ruby versions introduce language features that directly improve security when used correctly. This reference documents security-relevant patterns and version-specific features from Ruby 3.0 through 3.3, covering the most critical vulnerability classes in Ruby and Ruby on Rails applications.
+
+## Core Ruby Security Patterns
+
+### SA-RB-01: eval / instance_eval / class_eval Code Injection
+
+Ruby's `eval` family executes arbitrary strings as code. When user input reaches these methods, attackers gain full code execution on the server.
+
+```ruby
+# VULNERABLE: eval with user-controlled input (CWE-94)
+# An attacker sending "system('rm -rf /')" as input gets shell access
+def calculate(user_expression)
+  eval(user_expression)
+end
+
+# SECURE: Use a predefined method dispatch instead of eval
+ALLOWED_FILTERS = {
+  'uppercase' => ->(obj) { obj.to_s.upcase },
+  'lowercase' => ->(obj) { obj.to_s.downcase },
+  'strip'     => ->(obj) { obj.to_s.strip }
+}.freeze
+
+def apply_filter(obj, filter_name)
+  handler = ALLOWED_FILTERS[filter_name]
+  raise ArgumentError, "Unknown filter: #{filter_name}" unless handler
+  handler.call(obj)
+end
+```
+
+**Security implication:** `eval` is the most dangerous method in Ruby. Any path from user input to `eval`, `instance_eval`, or `class_eval` with a string argument constitutes a Remote Code Execution (RCE) vulnerability. Even indirect paths through template engines or configuration parsers must be audited. CWE-94: Improper Control of Generation of Code.
+
+**Detection regex:** `\beval\s*\(` , `\binstance_eval\s*[\(\s]` , `\bclass_eval\s*[\(\s]`
+
+---
+
+### SA-RB-02: send / public_send Method Injection
+
+Ruby's `send` method invokes any method by name, including private ones. When the method name comes from user input, attackers can call arbitrary methods on any object.
+
+```ruby
+# VULNERABLE: send with user-controlled method name (CWE-470)
+# Attacker sends method_name="system" with args=["cat /etc/passwd"]
+def perform_action(obj, method_name, *args)
+  obj.send(method_name, *args)
+end
+
+# SECURE: Allowlist of permitted methods
+ALLOWED_METHODS = %w[name email created_at updated_at].freeze
+
+def perform_action(obj, method_name)
+  unless ALLOWED_METHODS.include?(method_name)
+    raise ArgumentError, "Method not allowed: #{method_name}"
+  end
+  obj.public_send(method_name)
+end
+
+# SECURE: Use a case/when dispatch
+def perform_action(obj, action)
+  case action
+  when 'activate'   then obj.activate
+  when 'deactivate' then obj.deactivate
+  else raise ArgumentError, "Unknown action: #{action}"
+  end
+end
+```
+
+**Security implication:** `send` bypasses method visibility (private/protected). Even `public_send` is dangerous when the method name is attacker-controlled, as it can invoke destructive public methods like `delete`, `destroy`, or `system`. CWE-470: Use of Externally-Controlled Input to Select Classes or Code.
+
+**Detection regex:** `\.send\s*\(` , `\.public_send\s*\(`
+
+---
+
+### SA-RB-03: system / exec / backtick Command Injection
+
+Ruby provides multiple ways to execute shell commands. String interpolation or concatenation with user input enables OS command injection.
+
+```ruby
+# VULNERABLE: system() with string interpolation (CWE-78)
+# Attacker sends filename="; rm -rf /"
+def convert_file(filename)
+  system("convert #{filename} output.png")
+end
+
+# VULNERABLE: backticks with user input
+def get_file_info(path)
+  `file #{path}`
+end
+
+# SECURE: Use array form to avoid shell interpretation
+def convert_file(filename)
+  system('convert', filename, 'output.png')
+end
+
+# SECURE: Use Open3 for capturing output safely
+require 'open3'
+
+def get_file_info(path)
+  stdout, stderr, status = Open3.capture3('file', path)
+  raise "Command failed: #{stderr}" unless status.success?
+  stdout
+end
+
+# SECURE: Shellwords.shellescape if shell form is unavoidable
+require 'shellwords'
+
+def convert_file(filename)
+  system("convert #{Shellwords.shellescape(filename)} output.png")
+end
+```
+
+**Security implication:** Ruby's `system`, `exec`, `%x{}`, and backticks all invoke a shell when given a single string argument. The array form of `system` and `exec` bypasses the shell entirely, making it immune to injection. Always prefer the array form. CWE-78: Improper Neutralization of Special Elements used in an OS Command.
+
+**Detection regex:** `\bsystem\s*\(` , `\bexec\s*\(` , `` `.+#\{`` (backtick with interpolation)
+
+---
+
+### SA-RB-04: Marshal.load Insecure Deserialization
+
+`Marshal.load` deserializes arbitrary Ruby objects. A crafted payload can instantiate any class and trigger code execution through methods like `initialize`, method_missing, or finalizers.
+
+```ruby
+# VULNERABLE: Marshal.load on untrusted data (CWE-502)
+# Attacker can craft a payload that executes arbitrary code on deserialization
+def restore_session(cookie_data)
+  session = Marshal.load(Base64.decode64(cookie_data))
+  session
+end
+
+# SECURE: Use JSON for untrusted data
+require 'json'
+
+def restore_session(cookie_data)
+  session = JSON.parse(Base64.decode64(cookie_data))
+  session
+end
+
+# SECURE: If Marshal is absolutely needed, use a class filter
+def restore_session(cookie_data)
+  raw = Base64.decode64(cookie_data)
+  allowed = [String, Integer, Float, Symbol, TrueClass, FalseClass, NilClass, Array, Hash]
+  Marshal.load(raw, ->(obj) {
+    raise TypeError, "Disallowed: #{obj.class}" unless allowed.include?(obj.class)
+    obj
+  })
+end
+```
+
+**Security implication:** `Marshal.load` is functionally equivalent to `eval` for attacker-controlled data. There are well-known gadget chains in Ruby and Rails that achieve RCE through crafted Marshal payloads. Never use Marshal for data from untrusted sources. CWE-502: Deserialization of Untrusted Data.
+
+**Detection regex:** `Marshal\.load\s*\(`
+
+---
+
+### SA-RB-05: YAML Deserialization (YAML.load vs YAML.safe_load)
+
+`YAML.load` can instantiate arbitrary Ruby objects via YAML tags like `!ruby/object:`. This enables RCE when parsing untrusted YAML input.
+
+```ruby
+# VULNERABLE: YAML.load on untrusted input (CWE-502)
+# Payload: "--- !ruby/object:Gem::Installer\ni: x\n" triggers code execution
+def parse_config(user_yaml)
+  config = YAML.load(user_yaml)
+  config
+end
+
+# SECURE: Use YAML.safe_load (restricts to basic types)
+def parse_config(user_yaml)
+  config = YAML.safe_load(user_yaml, permitted_classes: [Date, Time])
+  config
+end
+
+# SECURE: In Ruby 3.1+, YAML.load requires permitted_classes by default
+# But explicit safe_load is still clearer and safer
+def parse_config(user_yaml)
+  YAML.safe_load(user_yaml)
+end
+```
+
+**Security implication:** `YAML.load` was the source of multiple critical Rails CVEs (CVE-2013-0156). Since Psych 4.0 (Ruby 3.1+), `YAML.load` raises on unknown tags by default, but `YAML.safe_load` remains the explicit safe choice. Always use `safe_load` for untrusted data. CWE-502: Deserialization of Untrusted Data.
+
+**Detection regex:** `YAML\.load\s*\(` (not preceded by `safe_`)
+
+---
+
+### SA-RB-06: ERB Template Injection
+
+ERB templates execute arbitrary Ruby code within `<%= %>` tags. When user input is embedded into ERB template strings before rendering, server-side template injection (SSTI) occurs.
+
+```ruby
+# VULNERABLE: ERB template injection (CWE-94)
+# Attacker sends name="<%= system('id') %>"
+def render_greeting(name)
+  template = ERB.new("Hello, #{name}!")
+  template.result(binding)
+end
+
+# SECURE: Pass user input as data, not template content
+def render_greeting(name)
+  template = ERB.new("Hello, <%= @name %>!")
+  b = binding
+  b.local_variable_set(:name, name)
+  # Or use a struct/OpenStruct for the binding context
+  template.result_with_hash(name: ERB::Util.html_escape(name))
+end
+
+# SECURE: Use a safe templating engine like Liquid for user templates
+require 'liquid'
+
+def render_page(user_template, data)
+  template = Liquid::Template.parse(user_template)
+  template.render(data)
+end
+```
+
+**Security implication:** ERB has full access to the Ruby runtime. If user input becomes part of an ERB template string before compilation, the attacker controls what Ruby code runs on the server. Use sandboxed template engines (Liquid, Mustache) for user-facing templates. CWE-94: Improper Control of Generation of Code.
+
+**Detection regex:** `ERB\.new\s*\(` (audit when argument contains interpolation or variables)
+
+---
+
+### SA-RB-07: SQL Injection in ActiveRecord
+
+While ActiveRecord parameterizes queries by default, several methods accept raw SQL strings. String interpolation in these contexts creates SQL injection vulnerabilities.
+
+```ruby
+# VULNERABLE: String interpolation in where clause (CWE-89)
+def search_users(query)
+  User.where("name LIKE '%#{query}%'")
+end
+
+# VULNERABLE: find_by_sql with interpolation
+def find_user(id)
+  User.find_by_sql("SELECT * FROM users WHERE id = #{id}")
+end
+
+# SECURE: Use parameterized queries
+def search_users(query)
+  User.where('name LIKE ?', "%#{query}%")
+end
+
+# SECURE: Use hash conditions
+def find_active_users(status)
+  User.where(status: status)
+end
+
+```
+
+**Security implication:** ActiveRecord's `where` with a string, `find_by_sql`, `order`, `group`, `having`, `pluck`, `select`, and `from` all accept raw SQL. String interpolation in any of these is a SQL injection vector. Always use parameterized queries (`?` placeholders) or hash conditions. CWE-89: SQL Injection.
+
+**Detection regex:** `find_by_sql\s*\(` , `\.where\s*\(\s*"[^"]*#\{`
+
+---
+
+### SA-RB-08: html_safe / raw XSS Bypass in Rails Views
+
+Rails auto-escapes output in ERB views by default. However, `html_safe`, `raw()`, and `<%== %>` bypass this protection, creating XSS vulnerabilities when used with user-controlled data.
+
+```ruby
+# VULNERABLE: html_safe on user input (CWE-79)
+# In a Rails view:
+# <%= user.bio.html_safe %>
+
+# VULNERABLE: raw() helper with user data
+# <%= raw(params[:message]) %>
+
+# VULNERABLE: <%== %> shorthand (equivalent to raw)
+# <%== comment.body %>
+
+# SECURE: Let Rails auto-escape (default behavior)
+# <%= user.bio %>
+
+# SECURE: Use sanitize helper for partial HTML
+# <%= sanitize(user.bio, tags: %w[b i em strong], attributes: %w[]) %>
+
+```
+
+**Security implication:** Rails' automatic output escaping is the primary XSS defense. Every use of `html_safe`, `raw()`, or `<%== %>` is a deliberate bypass that must be audited. The content must either be fully trusted (generated server-side with no user input) or sanitized before marking as safe. CWE-79: Cross-site Scripting.
+
+**Detection regex:** `\.html_safe\b` , `\braw\s*\(`
+
+---
+
+### SA-RB-09: Mass Assignment Without Strong Parameters
+
+Rails strong parameters protect against mass assignment attacks. Without them, attackers can set any model attribute, including admin flags and foreign keys.
+
+```ruby
+# VULNERABLE: Mass assignment without strong parameters (CWE-915)
+def create
+  @user = User.new(params[:user])
+  @user.save
+end
+
+# VULNERABLE: permit! allows all parameters
+def update
+  @user.update(params[:user].permit!)
+  redirect_to @user
+end
+
+# SECURE: Use strong parameters to allowlist attributes
+def user_params
+  params.require(:user).permit(:name, :email, :password, :password_confirmation)
+end
+
+def create
+  @user = User.new(user_params)
+  @user.save
+end
+
+```
+
+**Security implication:** Without strong parameters, an attacker can add `admin=true` or `role=superadmin` to form submissions. Always use `permit` with an explicit list of allowed attributes. Never use `permit!` in production code. CWE-915: Improperly Controlled Modification of Dynamically-Determined Object Attributes.
+
+**Detection regex:** `\.permit!\b`
+
+---
+
+### SA-RB-10: Kernel.open / open-uri SSRF and Pipe Injection
+
+Ruby's `Kernel.open` (and the `open-uri` library) can open URLs, files, and even execute commands via the pipe (`|`) prefix. User input in `open()` calls can lead to SSRF or RCE.
+
+```ruby
+# VULNERABLE: Kernel.open with user input (CWE-918, CWE-78)
+# Attacker sends url="|cat /etc/passwd"
+def fetch_content(url)
+  content = open(url).read
+  content
+end
+
+# SECURE: Use Net::HTTP with URL validation
+require 'net/http'
+require 'uri'
+
+ALLOWED_HOSTS = %w[api.example.com cdn.example.com].freeze
+
+def fetch_content(url)
+  uri = URI.parse(url)
+  raise "Invalid scheme" unless %w[http https].include?(uri.scheme)
+  raise "Host not allowed" unless ALLOWED_HOSTS.include?(uri.host)
+  raise "Private IP" if private_ip?(uri.host)
+
+  Net::HTTP.get(uri)
+end
+
+# SECURE: Use specific file operations instead of open()
+def read_file(path)
+  File.read(path)  # Does not interpret pipe prefix
+end
+```
+
+**Security implication:** `Kernel.open` with a string starting with `|` executes the rest as a shell command. Even without the pipe prefix, user-controlled URLs enable SSRF attacks against internal services. Always use `Net::HTTP`, `URI.open` with strict validation, or `File.read` for files. CWE-918: Server-Side Request Forgery, CWE-78: OS Command Injection.
+
+**Detection regex:** `\bKernel\.open\s*\(` , `\bopen\s*\(\s*[^)]*(?:params|request|user|input|url|uri)`
+
+---
+
+### SA-RB-11: Path Traversal
+
+`File.join`, `send_file`, and path concatenation with user input can allow directory traversal to access files outside the intended directory.
+
+```ruby
+# VULNERABLE: Path traversal via File.join (CWE-22)
+# Attacker sends filename="../../etc/passwd"
+def serve_file(filename)
+  path = File.join(Rails.root, 'public', 'uploads', filename)
+  send_file(path)
+end
+
+# SECURE: Validate the resolved path stays within the base directory
+def serve_file(filename)
+  base_dir = File.realpath(File.join(Rails.root, 'public', 'uploads'))
+  full_path = File.realpath(File.join(base_dir, filename))
+
+  unless full_path.start_with?(base_dir + '/')
+    raise SecurityError, "Path traversal detected"
+  end
+
+  send_file(full_path)
+end
+
+```
+
+**Security implication:** `File.join` does not sanitize `..` sequences. An attacker can traverse to any file readable by the application process. Always resolve the full path with `File.realpath` and verify it stays within the expected base directory. CWE-22: Improper Limitation of a Pathname to a Restricted Directory.
+
+**Detection regex:** `send_file\s*\(` , `File\.join\s*\([^)]*params`
+
+---
+
+### SA-RB-12: Weak Cryptography (MD5, SHA1 for Security Tokens)
+
+Using MD5 or SHA1 for password hashing, token generation, or integrity verification provides inadequate security against modern attacks.
+
+```ruby
+# VULNERABLE: MD5 for password hashing (CWE-327)
+require 'digest'
+
+def hash_password(password)
+  Digest::MD5.hexdigest(password)
+end
+
+# VULNERABLE: SHA1 for API tokens
+def generate_token(user_id)
+  Digest::SHA1.hexdigest("#{user_id}-#{Time.now}")
+end
+
+# SECURE: Use bcrypt for password hashing
+require 'bcrypt'
+
+def hash_password(password)
+  BCrypt::Password.create(password, cost: 12)
+end
+
+def verify_password(password, hash)
+  BCrypt::Password.new(hash) == password
+end
+
+# SECURE: Use SecureRandom for token generation
+require 'securerandom'
+
+def generate_token
+  SecureRandom.urlsafe_base64(32)
+end
+
+# SECURE: Use SHA-256 or stronger for integrity checks
+def compute_checksum(data)
+  Digest::SHA256.hexdigest(data)
+end
+```
+
+**Security implication:** MD5 has known collision attacks and is broken for any security use. SHA1 is deprecated for security purposes (SHAttered attack). Use bcrypt/scrypt/argon2 for passwords and SecureRandom for tokens. CWE-327: Use of a Broken or Risky Cryptographic Algorithm.
+
+**Detection regex:** `Digest::MD5` , `Digest::SHA1`
+
+---
+
+## Ruby 3.0
+
+### Ractor for Thread-Safe Concurrency
+
+Ractors provide actor-based concurrency with strict object isolation. Objects shared between Ractors must be immutable (frozen), preventing race conditions on shared mutable state.
+
+```ruby
+# VULNERABLE: Thread with shared mutable state (CWE-362)
+session_store = {}
+threads = 10.times.map do |i|
+  Thread.new { session_store["user_#{i}"] = { role: 'admin' } }
+end
+threads.each(&:join)
+
+# SECURE: Ractor enforces isolation — no shared mutable state
+results = 10.times.map do |i|
+  Ractor.new(i) do |idx|
+    { "user_#{idx}" => { role: 'viewer' } }
+  end
+end
+session_store = results.map(&:take).reduce({}, :merge)
+```
+
+**Security implication:** Ractors make data races impossible by enforcing that only frozen (immutable) or copied objects cross Ractor boundaries. This eliminates a class of concurrency bugs that can lead to privilege escalation or state corruption. CWE-362: Race Condition.
+
+### Pattern Matching for Structured Input Validation
+
+Ruby 3.0 introduced `case/in` pattern matching, enabling expressive validation of complex data structures.
+
+```ruby
+# VULNERABLE: Manual hash access without validation
+def process_webhook(payload)
+  event = payload['event']
+  user_id = payload['data']['user_id']
+  # NoMethodError if structure is unexpected, potential crash
+  handle_event(event, user_id)
+end
+
+# SECURE: Pattern matching validates structure and extracts values
+def process_webhook(payload)
+  case payload
+  in { 'event' => String => event, 'data' => { 'user_id' => Integer => user_id } }
+    handle_event(event, user_id)
+  in { 'event' => String => event }
+    handle_event_without_user(event)
+  else
+    raise ArgumentError, "Invalid webhook payload structure"
+  end
+end
+```
+
+**Security implication:** Pattern matching validates both structure and types in a single expression, reducing the chance of processing malformed input that could lead to unexpected behavior or crashes. It makes data validation explicit and exhaustive.
+
+---
+
+## Ruby 3.1
+
+### Data Class for Immutable Value Objects
+
+The `Data` class (Ruby 3.1.1+) creates simple immutable value objects, ideal for security-sensitive data that should not be modified after creation.
+
+```ruby
+# VULNERABLE: Struct is mutable by default
+Token = Struct.new(:value, :expires_at, :scope)
+token = Token.new('abc123', Time.now + 3600, 'read')
+token.scope = 'admin'  # Attacker modifies scope after creation!
+
+# SECURE: Data class creates immutable value objects
+Token = Data.define(:value, :expires_at, :scope)
+token = Token.new(value: 'abc123', expires_at: Time.now + 3600, scope: 'read')
+token.scope = 'admin'  # => NoMethodError: undefined method 'scope=' — immutable!
+
+# SECURE: Use Data for security configuration
+SecurityConfig = Data.define(:algorithm, :key_size, :iterations)
+config = SecurityConfig.new(algorithm: 'argon2id', key_size: 256, iterations: 3)
+# config is frozen and cannot be tampered with
+```
+
+**Security implication:** Immutable value objects prevent tampering with security-critical data after initialization. Unlike Struct (which has setters) or OpenStruct (which allows arbitrary attributes), Data objects cannot be modified. Use Data for tokens, credentials, security configs, and audit records.
+
+### YAML.load Restricted by Default (Psych 4.0)
+
+Starting with Ruby 3.1 (Psych 4.0), `YAML.load` restricts which classes can be instantiated by default. However, `YAML.safe_load` remains the recommended approach as it communicates intent clearly and provides defense in depth.
+
+```ruby
+# Always use safe_load for untrusted input, even on Ruby 3.1+
+config = YAML.safe_load(untrusted_yaml, permitted_classes: [Date, Time])
+```
+
+---
+
+## Ruby 3.2
+
+### Regexp.timeout for ReDoS Protection
+
+Ruby 3.2 introduced `Regexp.timeout` to prevent Regular Expression Denial of Service (ReDoS) attacks where crafted input causes catastrophic backtracking.
+
+```ruby
+# VULNERABLE: Regex without timeout (CWE-1333)
+# Input like "aaaaaaaaaaaaaaaaaaaaaaaaaaa!" causes exponential backtracking
+def validate_email(input)
+  input.match?(/^([a-zA-Z0-9]+\.)*[a-zA-Z0-9]+@[a-zA-Z0-9]+(\.[a-zA-Z]+)+$/)
+end
+
+# SECURE: Set a global regex timeout (Ruby 3.2+)
+Regexp.timeout = 1.0  # 1 second timeout for all regexps
+
+# SECURE: Set per-regex timeout
+pattern = Regexp.new(
+  '^([a-zA-Z0-9]+\.)*[a-zA-Z0-9]+@[a-zA-Z0-9]+(\.[a-zA-Z]+)+$',
+  timeout: 0.5
+)
+
+begin
+  input.match?(pattern)
+rescue Regexp::TimeoutError
+  false  # Treat timeout as validation failure
+end
+
+# SECURE: Use atomic groups or possessive quantifiers to prevent backtracking
+def validate_email(input)
+  # Simplified non-backtracking pattern
+  input.match?(/\A[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\z/)
+end
+```
+
+**Security implication:** ReDoS is a denial-of-service attack that exploits vulnerable regex patterns. `Regexp.timeout` provides a safety net, but the best defense is writing non-backtracking patterns. Set a global timeout as defense in depth. CWE-1333: Inefficient Regular Expression Complexity.
+
+### Anonymous Method Forwarding
+
+Anonymous `*` and `**` forwarding reduces the risk of accidentally exposing or logging sensitive parameters.
+
+```ruby
+# VULNERABLE: Named splat can leak sensitive params in logs/errors
+def authenticate(username, password, **options)
+  log("Auth attempt: #{options.inspect}")  # Might leak sensitive data
+  do_auth(username, password, **options)
+end
+
+# SECURE: Anonymous forwarding — no local variable to leak
+def authenticate(username, password, **)
+  do_auth(username, password, **)
+end
+```
+
+**Security implication:** Anonymous forwarding prevents accidental exposure of forwarded arguments in logs, error messages, or debugging output. This is a minor but useful defense against information leakage.
+
+---
+
+## Ruby 3.3
+
+### YJIT Performance and Security Implications
+
+Ruby 3.3 made YJIT (Yet Another JIT compiler) production-ready with significant performance improvements. JIT compilation has security implications that must be considered.
+
+```ruby
+# Enable YJIT: RUBY_YJIT_ENABLE=1 ruby app.rb
+# Or: ruby --yjit app.rb
+# YJIT is safe for production — respects W^X memory protection
+```
+
+**Security implication:** YJIT follows W^X (Write XOR Execute) memory protection, mitigating JIT spraying attacks. Performance gains also reduce the impact of algorithmic complexity DoS attacks.
+
+### Range#overlap? for Secure Range Validation
+
+Ruby 3.3 added `Range#overlap?` for checking if two ranges intersect, useful for time-based access control and resource scheduling.
+
+```ruby
+# VULNERABLE: Manual range overlap check is error-prone
+def time_slot_available?(requested_start, requested_end, bookings)
+  bookings.none? do |booking|
+    # Easy to get boundary conditions wrong
+    requested_start < booking.end_time && requested_end > booking.start_time
+  end
+end
+
+# SECURE: Use Range#overlap? for correct boundary handling (Ruby 3.3+)
+def time_slot_available?(requested_range, bookings)
+  bookings.none? do |booking|
+    requested_range.overlap?(booking.start_time..booking.end_time)
+  end
+end
+```
+
+**Security implication:** Incorrect range comparisons in access control (time-based permissions, IP ranges, date validity) can create authorization bypasses. `Range#overlap?` provides a well-tested, correct implementation that handles edge cases.
+
+---
+
+## Detection Patterns for Auditing Ruby Security
+
+| Pattern | Regex | Severity | Checkpoint ID |
+|---------|-------|----------|---------------|
+| eval() code injection | `\beval\s*\(` | error | SA-RB-01 |
+| instance_eval code injection | `\binstance_eval\s*[\(\s]` | error | SA-RB-01b |
+| send() method injection | `\.send\s*\(` | warning | SA-RB-02 |
+| system() command injection | `\bsystem\s*\(` | warning | SA-RB-03 |
+| exec() command injection | `\bexec\s*\(` | warning | SA-RB-03b |
+| Marshal.load deserialization | `Marshal\.load\s*\(` | error | SA-RB-04 |
+| YAML.load (unsafe) | `YAML\.load\b(?!_file)` | error | SA-RB-05 |
+| ERB.new with variable | `ERB\.new\s*\(` | warning | SA-RB-06 |
+| find_by_sql injection | `find_by_sql\s*\(` | error | SA-RB-07 |
+| html_safe XSS bypass | `\.html_safe\b` | warning | SA-RB-08 |
+| raw() XSS bypass | `\braw\s*\(` | warning | SA-RB-08b |
+| permit! mass assignment | `\.permit!\b` | error | SA-RB-09 |
+| Kernel.open pipe injection | `\bKernel\.open\s*\(` | error | SA-RB-10 |
+| Digest::MD5 weak crypto | `Digest::MD5` | warning | SA-RB-12 |
+| Digest::SHA1 weak crypto | `Digest::SHA1` | warning | SA-RB-13 |
+| send_file path traversal | `send_file\s*\(` | warning | SA-RB-14 |
+
+## Version Adoption Security Checklist
+
+| Ruby Version | Feature | Security Benefit | Audit Action |
+|-------------|---------|------------------|--------------|
+| 3.0 | Ractor | Eliminates shared mutable state | Use for concurrent security-critical operations |
+| 3.0 | Pattern matching | Structured input validation | Replace manual hash traversal for webhook/API payloads |
+| 3.1 | Data class | Immutable value objects | Use for tokens, credentials, security configs |
+| 3.1 | Psych 4.0 | YAML.load restricted by default | Still use safe_load explicitly for clarity |
+| 3.2 | Regexp.timeout | ReDoS protection | Set global timeout, audit regex patterns |
+| 3.2 | Anonymous forwarding | Prevents parameter leakage | Use for auth/security method wrappers |
+| 3.3 | YJIT (production) | DoS resilience via performance | Enable in production for compute-heavy apps |
+| 3.3 | Range#overlap? | Correct range comparisons | Use for time-based access control |
+
+- [ ] Upgrade to Ruby 3.2+ and set `Regexp.timeout` globally
+- [ ] Replace all `YAML.load` with `YAML.safe_load`
+- [ ] Audit all `eval`, `instance_eval`, `class_eval`, `send` calls
+- [ ] Replace `Marshal.load` on untrusted data with JSON
+- [ ] Ensure shell commands use array form of `system`/`exec`
+- [ ] Audit all `html_safe` and `raw()` in views
+- [ ] Verify strong parameters in all controllers (no `permit!`)
+- [ ] Replace `Kernel.open` with `File.read` or `Net::HTTP`
+- [ ] Replace MD5/SHA1 with SHA-256+ or bcrypt
+
+## Related References
+
+- `owasp-top10.md` -- OWASP Top 10 mapping
+- `cwe-top25.md` -- CWE Top 25 mapping
+- `input-validation.md` -- Input validation patterns
+- `php-security-features.md` -- PHP security reference (similar structure)
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Ruby language security reference for security-audit skill |

--- a/skills/security-audit/references/rust-security-features.md
+++ b/skills/security-audit/references/rust-security-features.md
@@ -273,7 +273,14 @@ async fn get_user_sqlx_safe(pool: &PgPool, username: &str) -> Result<User, sqlx:
 
 **Security implication:** ORM raw query methods bypass injection protection. Always use query builders or explicit bind parameters.
 
-**Detection regex:** `sql_query\s*\(\s*format!\s*\(|query(_as)?\s*\(\s*&format!\s*\(`
+**Detection:** the inline forms (`sql_query(format!(...))`, `query_as(&format!(...))`) are caught by the regex below. The more common shape — a `let` binding that builds the query string, then gets passed into `query_as(&query)` — needs a two-pass check: first list files that use `format!(...)` against a `SELECT/INSERT/UPDATE/DELETE` literal, then verify those same files pass the resulting variable into a raw-SQL method.
+
+```bash
+# Pass 1: find format! calls that look like SQL.
+grep -rnP 'format!\s*\([^)]*\b(SELECT|INSERT|UPDATE|DELETE)\b' --include='*.rs' .
+# Pass 2: for each hit, check whether the variable reaches a raw-SQL entry point.
+grep -rnP '\b(sql_query|query|query_as|query_scalar|execute)\s*\(\s*&[A-Za-z_]' --include='*.rs' .
+```
 
 ### 8. Command Injection via std::process::Command (CWE-78)
 

--- a/skills/security-audit/references/rust-security-features.md
+++ b/skills/security-audit/references/rust-security-features.md
@@ -1,0 +1,591 @@
+# Rust Security Features by Version
+
+Modern Rust editions introduce language features that directly improve security when used correctly. While Rust's ownership system prevents many memory safety issues at compile time, `unsafe` blocks, logic bugs, and ecosystem pitfalls still create real vulnerabilities. This reference documents security-relevant patterns from Rust Edition 2021 through Edition 2024.
+
+## Core Rust Security Patterns
+
+### 1. Unsafe Block Audit Patterns (CWE-119, CWE-787)
+
+`unsafe` blocks opt out of Rust's safety guarantees. Every `unsafe` block is a potential source of memory corruption, undefined behavior, and security vulnerabilities.
+
+```rust
+// VULNERABLE: Unnecessary unsafe for performance shortcut
+unsafe fn get_unchecked_item(data: &[u8], index: usize) -> u8 {
+    *data.get_unchecked(index) // No bounds check — buffer over-read
+}
+
+// VULNERABLE: Unsafe transmute between incompatible types
+unsafe fn force_cast(input: u64) -> &'static str {
+    std::mem::transmute(input) // Undefined behavior — invalid pointer
+}
+
+// VULNERABLE: Dereferencing raw pointer without validation
+unsafe fn read_raw(ptr: *const u8) -> u8 {
+    *ptr // May be null, dangling, or misaligned
+}
+
+// SECURE: Use safe alternatives
+fn get_item(data: &[u8], index: usize) -> Option<u8> {
+    data.get(index).copied() // Returns None if out of bounds
+}
+
+// SECURE: When unsafe is truly needed, document invariants
+/// # Safety
+/// `ptr` must be non-null, properly aligned, and point to an initialized `u8`.
+/// The caller must ensure the pointer is valid for the lifetime of this call.
+unsafe fn read_raw_documented(ptr: *const u8) -> u8 {
+    debug_assert!(!ptr.is_null());
+    *ptr
+}
+```
+
+**Security implication:** Every `unsafe` block is a potential vulnerability. Audit for: null pointer derefs, buffer overflows, data races, invalid type transmutes, and violation of aliasing rules. Minimize `unsafe` surface area.
+
+**Detection regex:** `unsafe\s*\{|unsafe\s+fn\s|unsafe\s+impl\s`
+
+### 2. FFI Boundary Issues (CWE-119, CWE-476)
+
+Foreign Function Interface (FFI) calls cross the safety boundary. Null pointers, lifetime mismanagement, and missing error handling at FFI boundaries cause vulnerabilities.
+
+```rust
+// VULNERABLE: No null check on FFI pointer
+extern "C" {
+    fn get_data() -> *const c_char;
+}
+
+fn read_external_data() -> String {
+    unsafe {
+        let ptr = get_data();
+        // ptr may be null — undefined behavior
+        CStr::from_ptr(ptr).to_string_lossy().into_owned()
+    }
+}
+
+// VULNERABLE: Exposing Rust-owned memory to C without lifetime management
+#[no_mangle]
+pub extern "C" fn get_string() -> *const c_char {
+    let s = CString::new("hello").unwrap();
+    s.as_ptr() // s is dropped here — dangling pointer returned to C!
+}
+
+// SECURE: Null check and proper error handling
+fn read_external_data_safe() -> Result<String, Box<dyn std::error::Error>> {
+    unsafe {
+        let ptr = get_data();
+        if ptr.is_null() {
+            return Err("null pointer from FFI".into());
+        }
+        Ok(CStr::from_ptr(ptr).to_string_lossy().into_owned())
+    }
+}
+
+// SECURE: Use into_raw to transfer ownership to C
+#[no_mangle]
+pub extern "C" fn get_string_safe() -> *mut c_char {
+    let s = CString::new("hello").unwrap();
+    s.into_raw() // Ownership transferred — caller must free with free_string()
+}
+
+#[no_mangle]
+pub extern "C" fn free_string(ptr: *mut c_char) {
+    if !ptr.is_null() {
+        unsafe { drop(CString::from_raw(ptr)); }
+    }
+}
+```
+
+**Security implication:** FFI boundaries are the primary source of memory safety bugs in Rust. All C/FFI pointers must be validated for null, alignment, and lifetime correctness.
+
+**Detection regex:** `extern\s+"C"\s*\{|#\[no_mangle\]`
+
+### 3. panic! in Library Code — Denial of Service (CWE-248)
+
+`panic!` in library code causes unwinding that can crash the entire application. In servers, a panic in a handler can take down the process.
+
+```rust
+// VULNERABLE: panic! in library code
+pub fn parse_config(input: &str) -> Config {
+    let parts: Vec<&str> = input.split(':').collect();
+    Config {
+        host: parts[0].to_string(), // Panics if input is empty
+        port: parts[1].parse().unwrap(), // Panics if not a number
+    }
+}
+
+// SECURE: Return Result instead of panicking
+pub fn parse_config_safe(input: &str) -> Result<Config, ConfigError> {
+    let parts: Vec<&str> = input.split(':').collect();
+    if parts.len() < 2 {
+        return Err(ConfigError::InvalidFormat);
+    }
+    let port = parts[1].parse::<u16>()
+        .map_err(|_| ConfigError::InvalidPort)?;
+    Ok(Config {
+        host: parts[0].to_string(),
+        port,
+    })
+}
+```
+
+**Security implication:** Panics in libraries or request handlers enable denial-of-service. Library code should return `Result` or `Option`, never `panic!`. Use `catch_unwind` at service boundaries as a safety net.
+
+**Detection regex:** `panic!\s*\(|todo!\s*\(|unimplemented!\s*\(`
+
+### 4. .unwrap() / .expect() in Production Paths (CWE-248)
+
+`.unwrap()` and `.expect()` panic on `None`/`Err`, crashing the application. In production code paths, they create denial-of-service vectors.
+
+```rust
+// VULNERABLE: unwrap in request handler
+async fn handle_request(req: Request) -> Response {
+    let body: serde_json::Value = serde_json::from_str(&req.body()).unwrap(); // Panics on invalid JSON
+    let user_id = body["user_id"].as_str().unwrap(); // Panics if missing or not string
+    let user = db.get_user(user_id).await.unwrap(); // Panics on DB error
+    Response::ok(user)
+}
+
+// SECURE: Proper error handling with ? operator
+async fn handle_request_safe(req: Request) -> Result<Response, AppError> {
+    let body: serde_json::Value = serde_json::from_str(&req.body())
+        .map_err(|_| AppError::BadRequest("invalid JSON"))?;
+    let user_id = body["user_id"].as_str()
+        .ok_or(AppError::BadRequest("missing user_id"))?;
+    let user = db.get_user(user_id).await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    Ok(Response::ok(user))
+}
+```
+
+**Security implication:** Every `.unwrap()` in a production code path is a potential DoS vector. Use `?`, `unwrap_or`, `unwrap_or_default`, or `match` instead.
+
+**Detection regex:** `\.unwrap\(\)|\.expect\(\s*"`
+
+### 5. Integer Overflow: Debug vs Release Behavior (CWE-190)
+
+Rust panics on integer overflow in debug mode but **silently wraps** in release mode. This behavioral difference can hide bugs during development that become exploitable in production.
+
+```rust
+// VULNERABLE: Overflow behavior differs between debug and release
+fn calculate_allocation_size(count: u32, size: u32) -> u32 {
+    count * size // Panics in debug, wraps in release!
+    // If count=65536 and size=65536, release result is 0 (wraps)
+}
+
+// VULNERABLE: Overflow in security-relevant bounds check
+fn is_within_bounds(offset: u32, length: u32) -> bool {
+    offset + length <= MAX_SIZE // In release: wraps to small value, check passes
+}
+
+// SECURE: Use checked arithmetic
+fn calculate_allocation_size_safe(count: u32, size: u32) -> Option<u32> {
+    count.checked_mul(size) // Returns None on overflow
+}
+
+// SECURE: Use saturating arithmetic where appropriate
+fn add_with_limit(a: u32, b: u32) -> u32 {
+    a.saturating_add(b) // Returns u32::MAX on overflow instead of wrapping
+}
+```
+
+**Security implication:** Silent overflow in release builds can bypass bounds checks, cause undersized allocations, or corrupt financial calculations. Use `checked_*`, `saturating_*`, or `overflowing_*` methods.
+
+**Detection regex:** Best detected via `clippy::arithmetic_side_effects` lint. No reliable simple regex.
+
+### 6. Use-After-Free via Raw Pointers in Unsafe (CWE-416)
+
+Raw pointers in `unsafe` blocks bypass the borrow checker, allowing use-after-free vulnerabilities.
+
+```rust
+// VULNERABLE: Use-after-free with raw pointers
+fn use_after_free() {
+    let ptr: *const String;
+    {
+        let s = String::from("secret data");
+        ptr = &s as *const String;
+    } // s is dropped here
+    unsafe {
+        println!("{}", *ptr); // Use-after-free: reading freed memory
+    }
+}
+
+// VULNERABLE: Raw pointer from vector that may reallocate
+fn dangling_from_vec() {
+    let mut v = vec![1, 2, 3];
+    let ptr = v.as_ptr();
+    v.push(4); // May reallocate, invalidating ptr
+    unsafe {
+        println!("{}", *ptr); // Potential use-after-free
+    }
+}
+
+// SECURE: Use references with proper lifetimes
+fn safe_access(data: &[i32]) -> Option<&i32> {
+    data.first() // Borrow checker ensures data outlives the reference
+}
+
+// SECURE: Pin for self-referential structures
+use std::pin::Pin;
+fn pinned_data(data: Pin<&String>) -> &str {
+    data.as_str() // Data cannot be moved while pinned
+}
+```
+
+**Security implication:** Use-after-free can lead to information disclosure, code execution, or crashes. Avoid raw pointers when safe alternatives exist.
+
+**Detection regex:** `as\s+\*const\s|as\s+\*mut\s|\*const\s+\w+\s*;|\*mut\s+\w+\s*;`
+
+### 7. SQL Injection in Diesel/sqlx (CWE-89)
+
+While Diesel's query builder is injection-safe, raw SQL methods (`sql_query`, `query_as` with string interpolation) bypass this protection.
+
+```rust
+// VULNERABLE: Raw SQL with string formatting in Diesel
+use diesel::sql_query;
+
+fn get_user(conn: &mut PgConnection, username: &str) -> QueryResult<Vec<User>> {
+    sql_query(format!("SELECT * FROM users WHERE name = '{}'", username))
+        .load(conn) // SQL injection!
+}
+
+// VULNERABLE: sqlx raw query with format!
+async fn get_user_sqlx(pool: &PgPool, username: &str) -> Result<Vec<User>, sqlx::Error> {
+    let query = format!("SELECT * FROM users WHERE name = '{}'", username);
+    sqlx::query_as::<_, User>(&query)
+        .fetch_all(pool)
+        .await
+}
+
+// SECURE: Diesel query builder (injection-safe by design)
+fn get_user_safe(conn: &mut PgConnection, name: &str) -> QueryResult<User> {
+    users::table
+        .filter(users::name.eq(name)) // Parameterized automatically
+        .first(conn)
+}
+
+// SECURE: sqlx with bind parameters
+async fn get_user_sqlx_safe(pool: &PgPool, username: &str) -> Result<User, sqlx::Error> {
+    sqlx::query_as::<_, User>("SELECT * FROM users WHERE name = $1")
+        .bind(username) // Parameterized
+        .fetch_one(pool)
+        .await
+}
+```
+
+**Security implication:** ORM raw query methods bypass injection protection. Always use query builders or explicit bind parameters.
+
+**Detection regex:** `sql_query\s*\(\s*format!\s*\(|query(_as)?\s*\(\s*&format!\s*\(`
+
+### 8. Command Injection via std::process::Command (CWE-78)
+
+Using shell invocation with user input enables command injection, similar to Go's `exec.Command("sh", "-c", ...)`.
+
+```rust
+// VULNERABLE: Shell invocation with user input
+use std::process::Command;
+
+fn process_file(filename: &str) -> std::io::Result<Vec<u8>> {
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(format!("cat {}", filename)) // Shell injection: filename = "; rm -rf /"
+        .output()?;
+    Ok(output.stdout)
+}
+
+// SECURE: Direct execution without shell
+fn process_file_safe(filename: &str) -> std::io::Result<Vec<u8>> {
+    let output = Command::new("cat")
+        .arg(filename) // Passed as single argument, no shell interpretation
+        .output()?;
+    Ok(output.stdout)
+}
+
+// SECURE: Validate input before execution
+fn process_file_validated(filename: &str) -> Result<Vec<u8>, AppError> {
+    let re = regex::Regex::new(r"^[a-zA-Z0-9._-]+$").unwrap();
+    if !re.is_match(filename) {
+        return Err(AppError::InvalidInput("invalid filename"));
+    }
+    let path = Path::new("/safe/dir").join(filename);
+    let output = Command::new("cat")
+        .arg(&path)
+        .output()?;
+    Ok(output.stdout)
+}
+```
+
+**Security implication:** Shell invocation via `sh -c` or `bash -c` interprets metacharacters. Pass arguments directly to `Command::new` and avoid shell wrappers.
+
+**Detection regex:** `Command::new\s*\(\s*"(sh|bash|cmd|powershell)"`
+
+### 9. Path Traversal (CWE-22)
+
+Path joining in Rust does not sanitize `..` components. An absolute path argument to `.join()` replaces the base entirely.
+
+```rust
+// VULNERABLE: Path::join with user input
+fn serve_file(base: &Path, user_input: &str) -> std::io::Result<Vec<u8>> {
+    let path = base.join(user_input);
+    // If user_input is "../../etc/passwd", path escapes base
+    // If user_input is "/etc/passwd" (absolute), base is REPLACED entirely
+    std::fs::read(path)
+}
+
+// SECURE: Canonicalize and validate
+fn serve_file_safe(base: &Path, user_input: &str) -> Result<Vec<u8>, AppError> {
+    let base = base.canonicalize()?;
+    let requested = base.join(user_input).canonicalize()?;
+    if !requested.starts_with(&base) {
+        return Err(AppError::Forbidden);
+    }
+    Ok(std::fs::read(requested)?)
+}
+```
+
+**Security implication:** Path traversal exposes sensitive files. Always canonicalize and verify the resolved path stays within the base directory.
+
+**Detection regex:** `Path::new\s*\(.*\)\.join\s*\(|\.join\s*\(\s*&?(req|input|param|query|user)`
+
+### 10. Serde Deserialization Pitfalls (CWE-502)
+
+Deserializing untrusted data with `serde` can cause denial of service (deeply nested structures, huge allocations) or logic bugs (missing fields silently defaulted).
+
+```rust
+// VULNERABLE: Deserialize untrusted input without limits
+#[derive(Deserialize)]
+struct UserRequest {
+    name: String,         // Unbounded string — attacker sends 1GB name
+    tags: Vec<String>,    // Unbounded vector — millions of elements
+    metadata: HashMap<String, Value>, // Unbounded map — memory exhaustion
+}
+
+fn handle(body: &[u8]) -> Result<UserRequest, serde_json::Error> {
+    serde_json::from_slice(body) // No size limits
+}
+
+// VULNERABLE: Default values hide missing security-critical fields
+#[derive(Deserialize)]
+struct AuthRequest {
+    username: String,
+    #[serde(default)]
+    require_mfa: bool, // Defaults to false if omitted — MFA bypass!
+}
+
+// SECURE: Bounded deserialization with validation
+use validator::Validate;
+
+#[derive(Deserialize, Validate)]
+struct UserRequestSafe {
+    #[validate(length(min = 1, max = 255))]
+    name: String,
+    #[validate(length(max = 50))]
+    #[serde(default)]
+    tags: Vec<String>,
+}
+
+fn handle_safe(body: &[u8]) -> Result<UserRequestSafe, AppError> {
+    if body.len() > 1_048_576 { // 1MB limit
+        return Err(AppError::PayloadTooLarge);
+    }
+    let req: UserRequestSafe = serde_json::from_slice(body)?;
+    req.validate()?;
+    Ok(req)
+}
+```
+
+**Security implication:** Unbounded deserialization enables memory exhaustion DoS. Default values on security-critical fields can bypass authentication or authorization. Always validate after deserialization and set size limits.
+
+**Detection regex:** `serde_json::from_str\s*\(|serde_json::from_slice\s*\(|serde_json::from_reader\s*\(`
+
+### 11. Timing Side-Channel in Comparisons (CWE-208)
+
+Standard equality comparison (`==`) for secrets (tokens, MACs, hashes) leaks timing information that allows attackers to guess values byte-by-byte.
+
+```rust
+// VULNERABLE: Standard comparison leaks timing information
+fn verify_token(provided: &str, expected: &str) -> bool {
+    provided == expected // Short-circuits on first different byte
+}
+
+fn verify_hmac(provided: &[u8], expected: &[u8]) -> bool {
+    provided == expected // Timing leak reveals which bytes match
+}
+
+// SECURE: Constant-time comparison
+use constant_time_eq::constant_time_eq;
+
+fn verify_token_safe(provided: &[u8], expected: &[u8]) -> bool {
+    constant_time_eq(provided, expected) // Same time regardless of which bytes differ
+}
+
+// SECURE: Using ring or subtle crate
+use subtle::ConstantTimeEq;
+
+fn verify_hmac_safe(provided: &[u8], expected: &[u8]) -> bool {
+    provided.ct_eq(expected).into()
+}
+```
+
+**Security implication:** Timing attacks against token/HMAC comparison can recover secrets with repeated network requests. Always use constant-time comparison for security-sensitive values.
+
+**Detection regex:** `==\s*(token|secret|hmac|hash|key|password|mac|signature|api_key|auth)`
+
+### 12. Memory Leaks via mem::forget or Rc Cycles (CWE-401)
+
+`mem::forget` prevents destructors from running, leaking resources. `Rc`/`Arc` reference cycles cause unbounded memory growth.
+
+```rust
+// VULNERABLE: mem::forget leaks sensitive data
+use std::mem;
+
+fn process_secret(secret: String) {
+    // ... use secret ...
+    mem::forget(secret); // Destructor never runs — secret stays in memory
+    // Sensitive data persists in memory indefinitely
+}
+
+// VULNERABLE: Rc cycle causes memory leak
+use std::rc::Rc;
+use std::cell::RefCell;
+
+struct Node {
+    next: Option<Rc<RefCell<Node>>>,
+}
+
+fn create_cycle() {
+    let a = Rc::new(RefCell::new(Node { next: None }));
+    let b = Rc::new(RefCell::new(Node { next: Some(a.clone()) }));
+    a.borrow_mut().next = Some(b.clone()); // Cycle: a -> b -> a
+    // Neither a nor b will ever be freed — memory leak
+}
+
+// SECURE: Use Weak references to break cycles
+use std::rc::Weak;
+
+struct SafeNode {
+    next: Option<Rc<RefCell<SafeNode>>>,
+    parent: Option<Weak<RefCell<SafeNode>>>, // Weak breaks the cycle
+}
+
+// SECURE: Zeroize sensitive data before drop
+use zeroize::Zeroize;
+
+fn process_secret_safe(mut secret: String) {
+    // ... use secret ...
+    secret.zeroize(); // Overwrites memory with zeros before drop
+}
+```
+
+**Security implication:** `mem::forget` prevents cleanup of sensitive data and resources. Reference cycles cause unbounded memory growth (DoS). Use `Weak` for back-references and `zeroize` for sensitive data.
+
+**Detection regex:** `mem::forget\s*\(|ManuallyDrop::new\s*\(`
+
+## Rust Edition 2021+ Security Features
+
+### Disjoint Capture in Closures
+
+Edition 2021 changed closures to capture only the fields they use, not the entire struct. This reduces unintended data exposure in closures.
+
+```rust
+// Before Edition 2021: entire struct captured
+struct Session {
+    token: String,
+    debug_info: String,
+}
+
+fn log_debug(session: &Session) {
+    let logger = || {
+        // Before 2021: captures all of `session`, including `token`
+        // After 2021: captures only `session.debug_info`
+        println!("{}", session.debug_info);
+    };
+    logger();
+}
+```
+
+**Security implication:** Disjoint capture reduces accidental exposure of sensitive fields when closures are passed to logging, serialization, or error handling functions.
+
+### Default Cargo Features and Dependency Auditing
+
+```toml
+# SECURE: Audit dependencies and minimize features
+[dependencies]
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+# Use rustls instead of openssl to reduce native dependency surface
+
+# Run: cargo audit
+# Run: cargo deny check
+```
+
+**Security implication:** Default features can pull in unnecessary native dependencies that increase attack surface. Use `default-features = false` and explicitly list needed features.
+
+## Rust Edition 2024+ Security Features
+
+### Unsafe Extern Blocks
+
+Edition 2024 requires `unsafe` on `extern` blocks, making FFI boundaries more visible in code review.
+
+```rust
+// Edition 2024: extern blocks require unsafe keyword
+unsafe extern "C" {
+    fn external_function(ptr: *const u8) -> i32;
+}
+```
+
+**Security implication:** Explicit `unsafe` on extern blocks ensures FFI calls are not overlooked during security audits.
+
+### Lifetime Elision Improvements
+
+Edition 2024 refines lifetime elision rules, reducing the need for explicit lifetimes while maintaining safety guarantees.
+
+**Security implication:** Fewer explicit lifetimes means fewer opportunities for lifetime annotation errors that could lead to dangling references.
+
+## Detection Patterns for Auditing Rust Security Features
+
+| Pattern | Regex | Severity | Checkpoint ID |
+|---------|-------|----------|---------------|
+| `unsafe` block/fn/impl | `unsafe\s*\{\|unsafe\s+fn\s\|unsafe\s+impl\s` | warning | SA-RS-01 |
+| FFI boundary | `extern\s+"C"\s*\{\|#\[no_mangle\]` | warning | SA-RS-02 |
+| `panic!` in library code | `panic!\s*\(\|todo!\s*\(\|unimplemented!\s*\(` | warning | SA-RS-03 |
+| `.unwrap()` / `.expect()` | `\.unwrap\(\)\|\.expect\(\s*"` | warning | SA-RS-04 |
+| Raw pointer cast | `as\s+\*const\s\|as\s+\*mut\s` | warning | SA-RS-05 |
+| SQL with format! | `sql_query\s*\(\s*format!\|query.*&format!` | error | SA-RS-06 |
+| Shell command injection | `Command::new\s*\(\s*"(sh\|bash\|cmd)"` | error | SA-RS-07 |
+| Path traversal via join | `\.join\s*\(.*req\|input\|param\|query\|user` | warning | SA-RS-08 |
+| Unbounded deserialization | `serde_json::from_(str\|slice\|reader)\s*\(` | warning | SA-RS-09 |
+| Timing-unsafe comparison | `==\s*(token\|secret\|hmac\|hash\|key\|password)` | error | SA-RS-10 |
+| `mem::forget` usage | `mem::forget\s*\(\|ManuallyDrop::new\s*\(` | warning | SA-RS-11 |
+| Hardcoded credentials | `(password\|secret\|api_key\|token)\s*[:=]\s*"[^"]{8,}"` | error | SA-RS-12 |
+| `transmute` usage | `std::mem::transmute\|mem::transmute` | error | SA-RS-13 |
+| Missing `#[must_use]` on Result | Custom lint — use `clippy::must_use_candidate` | warning | SA-RS-14 |
+| Unbounded allocation | `Vec::with_capacity\s*\(\s*(req\|input\|user)` | warning | SA-RS-15 |
+
+## Version Adoption Security Checklist
+
+- [ ] Run `cargo clippy -- -W clippy::all -W clippy::pedantic` in CI
+- [ ] Run `cargo audit` to check dependencies for known vulnerabilities
+- [ ] Run `cargo deny check` for license and vulnerability compliance
+- [ ] Audit all `unsafe` blocks — document safety invariants with `// Safety:` comments
+- [ ] Audit all FFI boundaries for null checks and lifetime correctness
+- [ ] Replace `.unwrap()` / `.expect()` in production code paths with proper error handling
+- [ ] Verify no `panic!` / `todo!` / `unimplemented!` in library code
+- [ ] Use `checked_*` arithmetic for security-relevant calculations
+- [ ] Use constant-time comparison for tokens, MACs, and hashes
+- [ ] Set payload size limits before `serde` deserialization
+- [ ] Use `zeroize` crate for sensitive data cleanup
+- [ ] Minimize dependency features with `default-features = false`
+- [ ] Use `rustls` instead of `openssl` bindings where possible
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `cwe-top25.md` — CWE Top 25 mapping
+- `input-validation.md` — Input validation patterns
+- `path-traversal-prevention.md` — Path traversal prevention
+- `cryptography-guide.md` — Cryptographic best practices
+- `supply-chain-security.md` — Dependency auditing
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Multi-language security references expansion |


### PR DESCRIPTION
## Summary

Tier 2 ecosystem PR — Go, Rust, and Ruby. Five new standalone reference guides (~3,080 lines total):

- **`go-security-features.md`**: generics, context cancellation, http.Server timeouts, SQL null handling
- **`gin-security.md`**: middleware chain, CORS, session handling, Bind() validation, rate limiting
- **`rust-security-features.md`**: safe-Rust idioms, unsafe boundaries, serde deny_unknown_fields, Arc/Mutex, zeroize
- **`ruby-security-features.md`**: Ruby 3.x — RBS/Sorbet, Ractor isolation, pattern matching, Process.exec
- **`rails-security.md`**: Rails 7 — CSRF rotation, strong_params, ActiveRecord safety, encrypted credentials, ActionText XSS

Each guide has vulnerable vs secure examples and detection regex hints.

## Provenance

Imported from [evandervecht/security-audit-skill](https://github.com/evandervecht/security-audit-skill). Dual-licensed MIT + CC-BY-SA-4.0. Fork-specific `SA-GO-*` / `SA-GIN-*` / `SA-RS-*` / `SA-RB-*` / `SA-RAILS-*` checkpoint IDs stripped.

Attribution: [E van der Vecht](mailto:evandervecht@schubergphilis.com).

## Test plan

- [ ] CI green
- [ ] References render in GitHub preview