### PR TITLE
feat(references): add Android and iOS mobile SDK security guides

### DIFF
--- a/skills/security-audit/references/android-sdk-security.md
+++ b/skills/security-audit/references/android-sdk-security.md
@@ -33,8 +33,13 @@ Activities declared with `android:exported="true"` are accessible to any applica
 </activity>
 ```
 
-**Detection regex:** `android:exported\s*=\s*"true"`
-**Severity:** error
+**Detection guidance:** a plain `android:exported="true"` regex flags both the vulnerable AND the secure example above (the secure one is exported but protected by `android:permission`). Narrow it to "exported without `android:permission` or `intent-filter`", which requires a structural check. XML-aware tooling like `xmlstarlet sel` is the right answer:
+
+```bash
+xmlstarlet sel -t -m '//activity[@android:exported="true"][not(@android:permission)][not(intent-filter)]' \
+  -v '@android:name' -n AndroidManifest.xml 2>/dev/null
+```
+**Severity:** error (for exported-without-protection); info (for bare regex matches — review required)
 
 ### Implicit Intent Data Leakage
 
@@ -52,7 +57,7 @@ intent.putExtra("auth_token", token)
 startActivity(intent)
 ```
 
-**Detection regex:** `new\s+Intent\s*\(\s*"[^"]+"\s*\)[\s\S]{0,120}putExtra\s*\(\s*"(auth|token|session|password|secret|key|credential)`
+**Detection regex (Java + Kotlin — `new` is optional):** `(new\s+)?Intent\s*\(\s*"[^"]+"\s*\)[\s\S]{0,120}putExtra\s*\(\s*"(auth|token|session|password|secret|key|credential)` — run with `grep -rP` across `.java` and `.kt` files.
 **Severity:** warning
 
 ### Exported Broadcast Receivers Without Permissions
@@ -68,7 +73,7 @@ registerReceiver(receiver, IntentFilter("com.example.PAYMENT_COMPLETE"),
     "com.example.PAYMENT_PERMISSION", null)
 ```
 
-**Detection regex:** `registerReceiver\s*\(\s*\w+\s*,\s*\w+\s*\)\s*$`
+**Detection regex (two-argument form only — permission-protected calls take 3+ args):** `registerReceiver\s*\(\s*[^,]+,\s*[^,)]+\)` — run with `grep -rP` across `.java` and `.kt`. The permission-protected overload has a third `String broadcastPermission` argument, so this pattern skips it.
 **Severity:** warning
 
 ## ContentProvider Vulnerabilities
@@ -223,7 +228,19 @@ class WebViewActivity : AppCompatActivity() {
 }
 ```
 
-**Detection regex:** `addJavascriptInterface\s*\(`
+**Detection guidance:** `addJavascriptInterface(…)` itself is not a vulnerability on modern `minSdk`. Flag two specific shapes instead: (1) `addJavascriptInterface(` in a project whose `minSdk` is below 17, and (2) an interface class whose public methods are missing the `@JavascriptInterface` annotation:
+
+```bash
+# (1) Find addJavascriptInterface usage and require the caller to verify minSdk.
+grep -rnE 'addJavascriptInterface\s*\(' --include='*.java' --include='*.kt' . \
+  | while read -r line; do echo "review minSdk: $line"; done
+
+# (2) Detect interface classes where any public method lacks the annotation.
+# Heuristic: a class passed to addJavascriptInterface whose next 20 lines
+# show a public/fun member without a preceding @JavascriptInterface line.
+# Best run through an AST-aware tool (ktlint custom rule, PSI in Android Studio).
+```
+**Severity:** info (regex match only — requires manual minSdk + annotation review)
 **Severity:** error
 
 ### WebView File Access

--- a/skills/security-audit/references/android-sdk-security.md
+++ b/skills/security-audit/references/android-sdk-security.md
@@ -1,0 +1,719 @@
+# Android SDK Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for Android applications. Covers manifest vulnerabilities, component exposure, insecure storage, WebView risks, network configuration, and cryptographic weaknesses.
+
+## Component Exposure
+
+### Exported Activities Without Intent Filters
+
+Activities declared with `android:exported="true"` are accessible to any application on the device. Without proper intent-filter restrictions or permission requirements, malicious apps can launch these activities directly, potentially bypassing authentication flows or accessing sensitive screens.
+
+```xml
+<!-- VULNERABLE: Activity exported without restrictions -->
+<activity
+    android:name=".AdminActivity"
+    android:exported="true">
+</activity>
+
+<!-- SECURE: Activity protected with custom permission -->
+<activity
+    android:name=".AdminActivity"
+    android:exported="true"
+    android:permission="com.example.ADMIN_PERMISSION">
+    <intent-filter>
+        <action android:name="com.example.ACTION_ADMIN" />
+        <category android:name="android.intent.category.DEFAULT" />
+    </intent-filter>
+</activity>
+
+<!-- SECURE: Activity not exported (default when no intent-filter) -->
+<activity
+    android:name=".AdminActivity"
+    android:exported="false">
+</activity>
+```
+
+**Detection regex:** `android:exported\s*=\s*"true"`
+**Severity:** error
+
+### Implicit Intent Data Leakage
+
+Using implicit intents to pass sensitive data allows any app with a matching intent filter to intercept the information. Always use explicit intents when transmitting sensitive data.
+
+```kotlin
+// VULNERABLE: Implicit intent leaking sensitive data
+val intent = Intent("com.example.SHARE_DATA")
+intent.putExtra("auth_token", token)
+startActivity(intent)
+
+// SECURE: Explicit intent targeting specific component
+val intent = Intent(this, DataReceiverActivity::class.java)
+intent.putExtra("auth_token", token)
+startActivity(intent)
+```
+
+**Detection regex:** `new\s+Intent\s*\(\s*"[^"]+"\s*\)[\s\S]{0,120}putExtra\s*\(\s*"(auth|token|session|password|secret|key|credential)`
+**Severity:** warning
+
+### Exported Broadcast Receivers Without Permissions
+
+Broadcast receivers exported without permission restrictions allow any app to send them broadcasts, triggering unintended actions or injecting malicious data.
+
+```kotlin
+// VULNERABLE: Dynamically registering receiver without permission
+registerReceiver(receiver, IntentFilter("com.example.PAYMENT_COMPLETE"))
+
+// SECURE: Register with permission requirement
+registerReceiver(receiver, IntentFilter("com.example.PAYMENT_COMPLETE"),
+    "com.example.PAYMENT_PERMISSION", null)
+```
+
+**Detection regex:** `registerReceiver\s*\(\s*\w+\s*,\s*\w+\s*\)\s*$`
+**Severity:** warning
+
+## ContentProvider Vulnerabilities
+
+### SQL Injection via ContentProvider query()
+
+ContentProviders that build SQL queries by concatenating user-supplied `selection` arguments are vulnerable to SQL injection. Always use parameterized `selectionArgs` to safely pass values.
+
+```java
+// VULNERABLE: SQL injection in ContentProvider query
+@Override
+public Cursor query(Uri uri, String[] projection, String selection,
+                    String[] selectionArgs, String sortOrder) {
+    String userId = uri.getLastPathSegment();
+    // Direct concatenation allows SQL injection
+    String rawQuery = "SELECT * FROM users WHERE id = " + userId;
+    return db.rawQuery(rawQuery, null);
+}
+
+// SECURE: Parameterized query with selectionArgs
+@Override
+public Cursor query(Uri uri, String[] projection, String selection,
+                    String[] selectionArgs, String sortOrder) {
+    String userId = uri.getLastPathSegment();
+    return db.query("users", projection, "id = ?",
+                    new String[]{userId}, null, null, sortOrder);
+}
+```
+
+```kotlin
+// VULNERABLE: Raw query concatenation in Kotlin ContentProvider
+override fun query(
+    uri: Uri, projection: Array<String>?, selection: String?,
+    selectionArgs: Array<String>?, sortOrder: String?
+): Cursor? {
+    val id = uri.lastPathSegment
+    return db.rawQuery("SELECT * FROM items WHERE id = $id", null)
+}
+
+// SECURE: Parameterized query
+override fun query(
+    uri: Uri, projection: Array<String>?, selection: String?,
+    selectionArgs: Array<String>?, sortOrder: String?
+): Cursor? {
+    val id = uri.lastPathSegment
+    return db.query("items", projection, "id = ?",
+                    arrayOf(id), null, null, sortOrder)
+}
+```
+
+**Detection regex:** `rawQuery\s*\(\s*"[^"]*\+\s*\w+|rawQuery\s*\(\s*"[^"]*\$\{?`
+**Severity:** error
+
+### Path Traversal in ContentProvider openFile
+
+ContentProviders that expose files via `openFile()` without validating the URI path component are vulnerable to path traversal attacks via `../` sequences.
+
+```java
+// VULNERABLE: No path validation in openFile
+File file = new File(getContext().getFilesDir(), uri.getLastPathSegment());
+return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY);
+
+// SECURE: Validate canonical path to prevent traversal
+File baseDir = getContext().getFilesDir();
+File file = new File(baseDir, uri.getLastPathSegment());
+if (!file.getCanonicalPath().startsWith(baseDir.getCanonicalPath())) {
+    throw new SecurityException("Path traversal detected");
+}
+```
+
+**Detection regex:** `openFile\s*\(\s*Uri\s+\w+[\s\S]{0,200}getLastPathSegment\s*\(\s*\)(?![\s\S]{0,200}getCanonicalPath)`
+**Severity:** error
+
+## WebView Security
+
+### JavaScript Interface on API < 17
+
+Before Android API level 17, `addJavascriptInterface()` allowed JavaScript to invoke any public method on the injected Java object via reflection, leading to arbitrary code execution. On API 17+, only methods annotated with `@JavascriptInterface` are accessible.
+
+```java
+// VULNERABLE: addJavascriptInterface without API level check
+public class WebViewActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        WebView webView = new WebView(this);
+        webView.getSettings().setJavaScriptEnabled(true);
+        webView.addJavascriptInterface(new WebAppInterface(), "Android");
+        webView.loadUrl("https://example.com");
+    }
+
+    // All public methods exposed on API < 17
+    public class WebAppInterface {
+        public String getToken() {
+            return AuthManager.getAuthToken();
+        }
+    }
+}
+
+// SECURE: Check API level and use @JavascriptInterface annotation
+public class WebViewActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        WebView webView = new WebView(this);
+        webView.getSettings().setJavaScriptEnabled(true);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            webView.addJavascriptInterface(new SecureInterface(), "Android");
+        }
+        webView.loadUrl("https://example.com");
+    }
+
+    public class SecureInterface {
+        @JavascriptInterface
+        public String getPublicData() {
+            return "safe-public-data";
+        }
+    }
+}
+```
+
+```kotlin
+// VULNERABLE: JavaScript interface with untrusted content
+class WebViewActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val webView = WebView(this)
+        webView.settings.javaScriptEnabled = true
+        webView.addJavascriptInterface(AppBridge(), "app")
+        // Loading untrusted URL with JS interface exposed
+        webView.loadUrl(intent.getStringExtra("url") ?: "")
+    }
+}
+
+// SECURE: Restrict to trusted origins, validate URLs
+class WebViewActivity : AppCompatActivity() {
+    private val allowedHosts = setOf("app.example.com", "cdn.example.com")
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val webView = WebView(this)
+        webView.settings.javaScriptEnabled = true
+
+        val url = intent.getStringExtra("url") ?: return
+        val host = Uri.parse(url).host
+        if (host in allowedHosts) {
+            webView.addJavascriptInterface(AppBridge(), "app")
+            webView.loadUrl(url)
+        }
+    }
+}
+```
+
+**Detection regex:** `addJavascriptInterface\s*\(`
+**Severity:** error
+
+### WebView File Access
+
+Enabling `setAllowFileAccess(true)` allows JavaScript in the WebView to read device files. Combined with untrusted content, this creates a data exfiltration vector.
+
+```kotlin
+// VULNERABLE: File access enabled with JavaScript
+webView.settings.apply {
+    javaScriptEnabled = true
+    allowFileAccess = true
+    allowUniversalAccessFromFileURLs = true
+}
+
+// SECURE: Disable file access
+webView.settings.apply {
+    javaScriptEnabled = true
+    allowFileAccess = false
+    allowFileAccessFromFileURLs = false
+    allowUniversalAccessFromFileURLs = false
+}
+```
+
+**Detection regex:** `setAllowFileAccess\s*\(\s*true\s*\)|allowFileAccess\s*=\s*true`
+**Severity:** error
+
+## Insecure Data Storage
+
+### SharedPreferences Without Encryption
+
+Storing sensitive data (passwords, tokens, API keys) in standard `SharedPreferences` exposes them to extraction on rooted devices or via backup access. `MODE_WORLD_READABLE` (deprecated) makes data accessible to all apps on the device.
+
+```kotlin
+// VULNERABLE: Storing token in plain SharedPreferences
+fun saveAuthToken(context: Context, token: String) {
+    val prefs = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
+    prefs.edit().putString("access_token", token).apply()
+}
+
+// VULNERABLE: MODE_WORLD_READABLE (deprecated but still seen)
+val prefs = getSharedPreferences("config", Context.MODE_WORLD_READABLE)
+prefs.edit().putString("password", userPassword).apply()
+
+// SECURE: Use EncryptedSharedPreferences from AndroidX Security
+fun saveAuthToken(context: Context, token: String) {
+    val masterKey = MasterKey.Builder(context)
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .build()
+
+    val prefs = EncryptedSharedPreferences.create(
+        context,
+        "secure_auth",
+        masterKey,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+    prefs.edit().putString("access_token", token).apply()
+}
+```
+
+```java
+// VULNERABLE: Storing password in SharedPreferences
+SharedPreferences prefs = getSharedPreferences("user", MODE_PRIVATE);
+prefs.edit().putString("password", password).apply();
+
+// SECURE: Use EncryptedSharedPreferences
+MasterKey masterKey = new MasterKey.Builder(context)
+    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+    .build();
+
+SharedPreferences prefs = EncryptedSharedPreferences.create(
+    context, "secure_user", masterKey,
+    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+);
+prefs.edit().putString("password", password).apply();
+```
+
+**Detection regex:** `getSharedPreferences\s*\([^)]*\)\s*[\s\S]{0,80}(putString|edit\(\))[\s\S]{0,80}(password|token|secret|key|credential|session)|MODE_WORLD_READABLE`
+**Severity:** error
+
+### SQLite Databases Without Encryption
+
+Unencrypted SQLite databases allow extraction on rooted devices. Use SQLCipher or Room with an encrypted `SupportFactory`.
+
+**Detection regex:** `SQLiteOpenHelper|openOrCreateDatabase\s*\(`
+**Severity:** warning
+
+## Network Security Configuration
+
+### Cleartext Traffic Allowed
+
+Allowing cleartext (HTTP) traffic exposes data to man-in-the-middle attacks. Android 9+ blocks cleartext by default, but apps can override this via `NetworkSecurityConfig` or manifest attributes.
+
+```xml
+<!-- VULNERABLE: Cleartext traffic allowed globally -->
+<application
+    android:usesCleartextTraffic="true"
+    android:networkSecurityConfig="@xml/network_security_config">
+</application>
+
+<!-- network_security_config.xml - VULNERABLE -->
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>
+
+<!-- network_security_config.xml - SECURE -->
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+    <!-- Exception only for local development -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">10.0.2.2</domain>
+    </domain-config>
+</network-security-config>
+```
+
+**Detection regex:** `usesCleartextTraffic\s*=\s*"true"|cleartextTrafficPermitted\s*=\s*"true"`
+**Severity:** error
+
+### Missing Certificate Pinning
+
+Without certificate pinning, any trusted-CA-signed certificate is accepted. Use `<pin-set>` in `network_security_config.xml` or OkHttp `CertificatePinner` for production APIs.
+
+**Detection regex:** `(pin-set|CertificatePinner)`
+**Severity:** warning
+
+## Manifest Security Flags
+
+### Debug Mode Enabled
+
+A release build with `android:debuggable="true"` allows attackers to attach debuggers, inspect memory, and bypass security controls.
+
+```xml
+<!-- VULNERABLE: Debuggable in manifest (should never be in release) -->
+<application
+    android:debuggable="true"
+    android:label="@string/app_name">
+</application>
+
+<!-- SECURE: Remove debuggable flag (defaults to false for release builds) -->
+<application
+    android:label="@string/app_name">
+</application>
+```
+
+```groovy
+// VULNERABLE: Debuggable enabled in release build type
+android {
+    buildTypes {
+        release {
+            debuggable true
+            minifyEnabled true
+        }
+    }
+}
+
+// SECURE: Debuggable false for release (this is the default)
+android {
+    buildTypes {
+        release {
+            debuggable false
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),
+                'proguard-rules.pro'
+        }
+    }
+}
+```
+
+**Detection regex:** `android:debuggable\s*=\s*"true"|debuggable\s+true`
+**Severity:** error
+
+### Backup Enabled Without Restrictions
+
+`android:allowBackup="true"` (default) lets `adb backup` extract app data including tokens and databases. Set `android:allowBackup="false"` or use `fullBackupContent`/`dataExtractionRules` to exclude sensitive files.
+
+**Detection regex:** `android:allowBackup\s*=\s*"true"`
+**Severity:** warning
+
+## Cryptographic Weaknesses
+
+### Insecure Random Number Generation
+
+Using `java.util.Random` for security-sensitive operations (token generation, nonce creation, key derivation) produces predictable output. The seed can be guessed, and the sequence is deterministic.
+
+```java
+// VULNERABLE: java.util.Random for token generation
+import java.util.Random;
+
+public class TokenGenerator {
+    public String generateToken() {
+        Random random = new Random();
+        byte[] token = new byte[32];
+        random.nextBytes(token);
+        return Base64.encodeToString(token, Base64.NO_WRAP);
+    }
+}
+
+// SECURE: SecureRandom for cryptographic randomness
+import java.security.SecureRandom;
+
+public class TokenGenerator {
+    public String generateToken() {
+        SecureRandom random = new SecureRandom();
+        byte[] token = new byte[32];
+        random.nextBytes(token);
+        return Base64.encodeToString(token, Base64.NO_WRAP);
+    }
+}
+```
+
+```kotlin
+// VULNERABLE: kotlin.random.Random for session ID
+fun generateSessionId(): String {
+    val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+    return (1..32).map { chars[kotlin.random.Random.nextInt(chars.length)] }
+        .joinToString("")
+}
+
+// SECURE: SecureRandom for session ID
+fun generateSessionId(): String {
+    val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+    val secureRandom = java.security.SecureRandom()
+    return (1..32).map { chars[secureRandom.nextInt(chars.length)] }
+        .joinToString("")
+}
+```
+
+**Detection regex:** `new\s+Random\s*\(|java\.util\.Random|kotlin\.random\.Random`
+**Severity:** error
+
+### Hardcoded Encryption Keys
+
+Hardcoded keys in source code are trivially extractable via decompilation. Keys should be stored in the Android Keystore or derived at runtime from user credentials.
+
+```kotlin
+// VULNERABLE: Hardcoded AES key
+object CryptoHelper {
+    private val SECRET_KEY = "MyS3cr3tK3y12345".toByteArray()
+
+    fun encrypt(data: String): ByteArray {
+        val keySpec = SecretKeySpec(SECRET_KEY, "AES")
+        val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec)
+        return cipher.doFinal(data.toByteArray())
+    }
+}
+
+// SECURE: Use Android Keystore
+object CryptoHelper {
+    private const val KEY_ALIAS = "app_encryption_key"
+
+    private fun getOrCreateKey(): SecretKey {
+        val keyStore = KeyStore.getInstance("AndroidKeyStore")
+        keyStore.load(null)
+
+        keyStore.getKey(KEY_ALIAS, null)?.let { return it as SecretKey }
+
+        val keyGen = KeyGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore"
+        )
+        keyGen.init(
+            KeyGenParameterSpec.Builder(
+                KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+            )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setKeySize(256)
+            .build()
+        )
+        return keyGen.generateKey()
+    }
+
+    fun encrypt(data: String): ByteArray {
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey())
+        return cipher.doFinal(data.toByteArray())
+    }
+}
+```
+
+```java
+// VULNERABLE: Hardcoded key bytes
+private static final byte[] KEY = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+    0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10};
+
+// SECURE: Derive key from Android Keystore
+KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
+keyStore.load(null);
+SecretKey key = (SecretKey) keyStore.getKey("my_key_alias", null);
+```
+
+**Detection regex:** `SecretKeySpec\s*\(\s*"[^"]+"\s*\.toByteArray|private\s+(static\s+)?final\s+byte\[\]\s+\w*(KEY|key|Key|SECRET|secret|Secret)\s*=`
+**Severity:** error
+
+### Weak Cipher Configuration
+
+DES, RC4, and AES/ECB are weak. Use `AES/GCM/NoPadding` for authenticated encryption.
+
+**Detection regex:** `Cipher\.getInstance\s*\(\s*"(DES|RC4|AES/ECB|Blowfish)`
+**Severity:** error
+
+## Root Detection
+
+### Missing or Weak Root Detection
+
+Apps handling sensitive data (banking, healthcare, enterprise) should detect rooted devices and respond appropriately. Weak or missing detection allows operation in compromised environments.
+
+```kotlin
+// VULNERABLE: No root detection at all
+
+// BASIC (easily bypassed): Simple file check
+fun isRooted(): Boolean {
+    val paths = arrayOf("/system/app/Superuser.apk", "/sbin/su", "/system/bin/su")
+    return paths.any { File(it).exists() }
+}
+
+// SECURE: Multi-layered root detection with SafetyNet/Play Integrity
+class RootDetector(private val context: Context) {
+
+    fun checkDeviceIntegrity(callback: (Boolean) -> Unit) {
+        // 1. File system checks
+        if (checkRootBinaries()) {
+            callback(false)
+            return
+        }
+
+        // 2. Build property checks
+        if (checkBuildTags()) {
+            callback(false)
+            return
+        }
+
+        // 3. Google Play Integrity API (server-verified)
+        val integrityManager = IntegrityManagerFactory.create(context)
+        val request = IntegrityTokenRequest.builder()
+            .setNonce(generateNonce())
+            .build()
+
+        integrityManager.requestIntegrityToken(request)
+            .addOnSuccessListener { response ->
+                // Verify token on your server, not client-side
+                verifyTokenOnServer(response.token(), callback)
+            }
+            .addOnFailureListener {
+                callback(false)
+            }
+    }
+
+    private fun checkRootBinaries(): Boolean {
+        val paths = arrayOf(
+            "/system/app/Superuser.apk",
+            "/sbin/su", "/system/bin/su", "/system/xbin/su",
+            "/data/local/xbin/su", "/data/local/bin/su",
+            "/system/sd/xbin/su", "/system/bin/failsafe/su",
+            "/data/local/su"
+        )
+        return paths.any { File(it).exists() }
+    }
+
+    private fun checkBuildTags(): Boolean {
+        val tags = Build.TAGS
+        return tags != null && tags.contains("test-keys")
+    }
+}
+```
+
+**Detection regex:** `(SafetyNet|PlayIntegrity|IntegrityManager|isRooted|checkRoot|rootDetect)`
+**Severity:** warning
+
+## Logging and Debug Output
+
+### Sensitive Data in Logs
+
+Using `Log.d()`, `Log.v()`, or `Log.i()` with sensitive data in production builds exposes information via `logcat`. Any app with `READ_LOGS` permission (or ADB access) can read these logs.
+
+```kotlin
+// VULNERABLE: Logging sensitive data
+Log.d("Auth", "User token: $authToken")
+Log.i("Payment", "Card number: $cardNumber")
+Log.v("API", "Request body: $requestJson")
+
+// SECURE: Use Timber with a release tree that strips verbose/debug
+class ReleaseTree : Timber.Tree() {
+    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+        if (priority < Log.WARN) return // Strip DEBUG and VERBOSE in release
+        // Send to crash reporting service instead
+        CrashReporter.log(priority, tag, message)
+    }
+}
+
+// In Application.onCreate():
+if (BuildConfig.DEBUG) {
+    Timber.plant(Timber.DebugTree())
+} else {
+    Timber.plant(ReleaseTree())
+}
+```
+
+```java
+// VULNERABLE: Logging credentials
+Log.d("Login", "Password: " + password);
+Log.i("API", "Bearer " + token);
+
+// SECURE: Use ProGuard/R8 to strip Log calls in release
+// proguard-rules.pro:
+// -assumenosideeffects class android.util.Log {
+//     public static int d(...);
+//     public static int v(...);
+// }
+```
+
+**Detection regex:** `Log\.(d|v|i)\s*\(\s*"[^"]*"\s*,\s*[^)]*?(password|token|secret|key|credential|card|ssn|session)`
+**Severity:** warning
+
+## Gradle Build Security
+
+### Dependency Vulnerabilities
+
+Outdated dependencies introduce known CVEs. Use dependency verification (`gradle/verification-metadata.xml`) and keep versions current.
+
+**Detection regex:** `(implementation|api|compile)\s+['"][^'"]+:[0-9]+\.[0-9]+`
+**Severity:** warning
+
+### Signing Configuration with Hardcoded Credentials
+
+Keystore passwords in `build.gradle` are extractable. Load from environment variables or `local.properties` (excluded from VCS).
+
+```groovy
+// VULNERABLE: Hardcoded signing config
+storePassword "mysecretpassword"
+keyPassword "mykeypassword"
+
+// SECURE: Environment variables
+storePassword System.getenv("KEYSTORE_PASSWORD") ?: ""
+keyPassword System.getenv("KEY_PASSWORD") ?: ""
+```
+
+**Detection regex:** `storePassword\s+["'][^"']+["']|keyPassword\s+["'][^"']+["']`
+**Severity:** error
+
+## Tapjacking and Overlay Attacks
+
+### Missing Overlay Protection
+
+Without `filterTouchesWhenObscured`, overlay apps can trick users into unintended actions. Add `android:filterTouchesWhenObscured="true"` on sensitive views or check `FLAG_WINDOW_IS_OBSCURED` in `onTouchEvent`.
+
+**Detection regex:** `filterTouchesWhenObscured\s*=\s*"?true"?`
+**Severity:** warning
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| Exported components without protection | Critical | Immediate | Low |
+| SQL injection in ContentProvider | Critical | Immediate | Medium |
+| WebView JavaScript interface exposure | Critical | Immediate | Medium |
+| Hardcoded encryption keys | Critical | Immediate | Medium |
+| Debug mode in release build | Critical | Immediate | Low |
+| Cleartext traffic allowed | High | 1 week | Low |
+| SharedPreferences without encryption | High | 1 week | Medium |
+| Insecure random for tokens | High | 1 week | Low |
+| Missing root detection | Medium | 1 month | High |
+| Sensitive data in logs | Medium | 1 week | Low |
+| allowBackup without exclusions | Medium | 1 week | Low |
+| Missing certificate pinning | Medium | 1 month | Medium |
+| Missing overlay protection | Low | 1 month | Low |
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `cryptography-guide.md` — Cryptographic best practices
+- `api-security.md` — API security patterns
+- `authentication-patterns.md` — Authentication best practices
+- `ios-sdk-security.md` — iOS security patterns (companion reference)
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Mobile SDK security coverage |

--- a/skills/security-audit/references/ios-sdk-security.md
+++ b/skills/security-audit/references/ios-sdk-security.md
@@ -37,7 +37,7 @@ let query: [String: Any] = [
 SecItemAdd(query as CFDictionary, nil)
 ```
 
-**Detection regex:** `kSecAttrAccessibleAlways[^T]|kSecAttrAccessibleAlways\b(?!ThisDeviceOnly)`
+**Detection regex (PCRE):** `kSecAttrAccessibleAlways(ThisDeviceOnly)?\b` — run with `grep -rnP`. Both `kSecAttrAccessibleAlways` and `kSecAttrAccessibleAlwaysThisDeviceOnly` are insecure because both keep the Keychain item accessible while the device is locked; the earlier pattern excluded the `…ThisDeviceOnly` variant that the VULNERABLE examples above show is also vulnerable.
 **Severity:** error
 
 ### Missing Keychain Access Control
@@ -175,8 +175,18 @@ func copyTemporarySensitiveData(_ data: String) {
     )
 }
 
-// SECURE: For iOS 15+, mark as sensitive
-func copyWithSensitiveFlag(_ data: String) {
+// SECURE: Narrow the blast radius. There is no single "mark as
+// sensitive" API on UIPasteboard — instead combine:
+//   .localOnly        — don't propagate to other devices via Universal Clipboard
+//   .expirationDate   — clear after N seconds
+//   …and declare the type explicitly via UIPasteboard.typeListString /
+//   UIPasteboard.typeAutomatic so the system Pasteboard suggestions
+//   (iOS 14+) can drop the item from the "recent items" UI when
+//   appropriate.
+// For a password-field-like flow, use a UITextField with
+// `isSecureTextEntry = true` and avoid writing to the pasteboard at
+// all; the keyboard's native "Strong Password" integration is safer.
+func copyWithShortLifetime(_ data: String) {
     let item = [UIPasteboard.typeAutomatic: data]
     UIPasteboard.general.setItems(
         [item],
@@ -378,16 +388,10 @@ class JailbreakDetector {
 
 ### Insecure Random Number Generation
 
-`arc4random` and `arc4random_uniform` use a non-cryptographic PRNG. For security tokens, nonces, and key material, use `SecRandomCopyBytes`.
+The classically-insecure libc `random()`, `rand()`, and `srand()` are predictable and must not be used for security tokens. On Apple platforms `arc4random` and `arc4random_uniform` are actually backed by a CSPRNG (since they were rewritten in the 2010s to call into the kernel), so in practice they are cryptographically suitable — the failure mode to audit for here is `random()` / `rand()` / `srand()` with security-sensitive values. `SecRandomCopyBytes` remains the documented, API-stable way to request CSPRNG bytes.
 
 ```swift
-// VULNERABLE: arc4random for security token
-func generateToken() -> String {
-    let bytes = (0..<32).map { _ in UInt8(arc4random_uniform(256)) }
-    return Data(bytes).base64EncodedString()
-}
-
-// VULNERABLE: Using random() for session ID
+// VULNERABLE: libc random() / rand() for session ID — predictable PRNG.
 func generateSessionId() -> String {
     return String(format: "%08x%08x", random(), random())
 }
@@ -403,7 +407,7 @@ func generateToken() -> String {
 }
 ```
 
-**Detection regex:** `arc4random\s*\(|arc4random_uniform\s*\([\s\S]{0,80}(token|key|secret|session|nonce|salt|iv)`
+**Detection regex (PCRE — target the classically-insecure libc PRNG, not arc4random which is CSPRNG on Apple):** `\b(random|rand|srand)\s*\([\s\S]{0,80}(token|key|secret|session|nonce|salt|iv)` — run with `grep -rnP` across `.swift`, `.m`, `.mm`. Match on `arc4random_uniform(…secret…)` is informational only: the function is suitable for cryptographic use on Apple platforms.
 **Severity:** error
 
 ### Weak Hashing Algorithms

--- a/skills/security-audit/references/ios-sdk-security.md
+++ b/skills/security-audit/references/ios-sdk-security.md
@@ -1,0 +1,539 @@
+# iOS SDK Security Patterns
+
+Security patterns, common misconfigurations, and detection regexes for iOS applications. Covers Keychain misuse, App Transport Security, WebView risks, pasteboard leakage, insecure storage, URL scheme vulnerabilities, and cryptographic weaknesses.
+
+## Keychain Security
+
+### Insecure Keychain Accessibility
+
+Using `kSecAttrAccessibleAlways` (deprecated in iOS 12) makes Keychain items accessible even when the device is locked, defeating the purpose of encrypted storage. Items are also available during device backups.
+
+```swift
+// VULNERABLE: kSecAttrAccessibleAlways — data accessible when device locked
+let query: [String: Any] = [
+    kSecClass as String: kSecClassGenericPassword,
+    kSecAttrAccount as String: "auth_token",
+    kSecValueData as String: tokenData,
+    kSecAttrAccessible as String: kSecAttrAccessibleAlways
+]
+SecItemAdd(query as CFDictionary, nil)
+
+// VULNERABLE: kSecAttrAccessibleAlwaysThisDeviceOnly — still accessible when locked
+let query: [String: Any] = [
+    kSecClass as String: kSecClassGenericPassword,
+    kSecAttrAccount as String: "auth_token",
+    kSecValueData as String: tokenData,
+    kSecAttrAccessible as String: kSecAttrAccessibleAlwaysThisDeviceOnly
+]
+SecItemAdd(query as CFDictionary, nil)
+
+// SECURE: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+let query: [String: Any] = [
+    kSecClass as String: kSecClassGenericPassword,
+    kSecAttrAccount as String: "auth_token",
+    kSecValueData as String: tokenData,
+    kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+]
+SecItemAdd(query as CFDictionary, nil)
+```
+
+**Detection regex:** `kSecAttrAccessibleAlways[^T]|kSecAttrAccessibleAlways\b(?!ThisDeviceOnly)`
+**Severity:** error
+
+### Missing Keychain Access Control
+
+High-value secrets should require user presence via `SecAccessControlCreateWithFlags` with `.biometryCurrentSet` or passcode constraints. Use `kSecAttrAccessControl` in the Keychain query.
+
+**Detection regex:** `SecItemAdd\s*\((?![\s\S]{0,300}kSecAttrAccessControl)`
+**Severity:** warning
+
+## App Transport Security (ATS)
+
+### NSAllowsArbitraryLoads
+
+Disabling ATS globally with `NSAllowsArbitraryLoads = YES` allows all HTTP connections, exposing the app to man-in-the-middle attacks. Apple requires justification for this setting during App Store review.
+
+```xml
+<!-- VULNERABLE: ATS disabled globally in Info.plist -->
+<key>NSAppTransportSecurity</key>
+<dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+</dict>
+
+<!-- SECURE: ATS enabled with per-domain exceptions only -->
+<key>NSAppTransportSecurity</key>
+<dict>
+    <key>NSExceptionDomains</key>
+    <dict>
+        <key>legacy-api.example.com</key>
+        <dict>
+            <key>NSExceptionAllowsInsecureHTTPLoads</key>
+            <true/>
+            <key>NSExceptionMinimumTLSVersion</key>
+            <string>TLSv1.2</string>
+        </dict>
+    </dict>
+</dict>
+```
+
+```swift
+// Code-level: Verify ATS is not disabled programmatically
+// Check Info.plist at build time using a build phase script:
+// if grep -q "NSAllowsArbitraryLoads.*true" "$INFOPLIST_FILE"; then
+//     echo "error: NSAllowsArbitraryLoads must not be YES in release"
+//     exit 1
+// fi
+```
+
+**Detection regex:** `NSAllowsArbitraryLoads\s*</key>\s*<true\s*/?>|NSAllowsArbitraryLoads.*<true|NSAllowsArbitraryLoads\s*=\s*(YES|true)`
+**Severity:** error
+
+### Per-Domain ATS Exceptions Without Justification
+
+Per-domain exceptions should be narrow, documented, and include `NSExceptionMinimumTLSVersion`. Wildcard exceptions are a red flag.
+
+**Detection regex:** `NSExceptionAllowsInsecureHTTPLoads\s*</key>\s*<true`
+**Severity:** warning
+
+## WebView Security
+
+### UIWebView Usage (Deprecated)
+
+`UIWebView` is deprecated since iOS 12 and rejected by App Store since April 2020. It has known security issues including JavaScript-to-native bridge vulnerabilities and no content process isolation.
+
+```swift
+// VULNERABLE: UIWebView usage (deprecated)
+import UIKit
+
+class LegacyWebViewController: UIViewController {
+    let webView = UIWebView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.addSubview(webView)
+        webView.loadRequest(URLRequest(url: URL(string: "https://example.com")!))
+    }
+}
+
+// SECURE: Use WKWebView with proper configuration
+import WebKit
+
+class ModernWebViewController: UIViewController {
+    lazy var webView: WKWebView = {
+        let config = WKWebViewConfiguration()
+        config.preferences.javaScriptEnabled = true
+        config.defaultWebpagePreferences.allowsContentJavaScript = true
+        let wv = WKWebView(frame: .zero, configuration: config)
+        wv.navigationDelegate = self
+        return wv
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.addSubview(webView)
+        webView.load(URLRequest(url: URL(string: "https://example.com")!))
+    }
+}
+```
+
+**Detection regex:** `UIWebView`
+**Severity:** error
+
+### WKWebView with Untrusted Content
+
+Even with `WKWebView`, validate URLs against an allowlist and implement `WKNavigationDelegate` to restrict navigation to trusted origins.
+
+**Detection regex:** `WKWebView[\s\S]{0,200}load\s*\(\s*URLRequest[\s\S]{0,100}(userURL|launchURL|deepLink|externalURL|untrusted)`
+**Severity:** warning
+
+## Pasteboard Security
+
+### Sensitive Data on General Pasteboard
+
+Data copied to the system `UIPasteboard.general` is accessible to all apps. On iOS 14+, users see a notification, but on older versions data is silently shared.
+
+```swift
+// VULNERABLE: Copying sensitive data to general pasteboard
+func copyToken() {
+    UIPasteboard.general.string = authToken
+}
+
+func copyPassword() {
+    UIPasteboard.general.string = password
+}
+
+// SECURE: Use a named pasteboard with expiration
+func copyTemporarySensitiveData(_ data: String) {
+    let pasteboard = UIPasteboard.withUniqueName()
+    pasteboard.setItems(
+        [[UIPasteboard.typeAutomatic: data]],
+        options: [
+            .localOnly: true,
+            .expirationDate: Date().addingTimeInterval(60) // Expires in 60 seconds
+        ]
+    )
+}
+
+// SECURE: For iOS 15+, mark as sensitive
+func copyWithSensitiveFlag(_ data: String) {
+    let item = [UIPasteboard.typeAutomatic: data]
+    UIPasteboard.general.setItems(
+        [item],
+        options: [.localOnly: true, .expirationDate: Date().addingTimeInterval(120)]
+    )
+}
+```
+
+**Detection regex:** `UIPasteboard\.general\.(string|strings|items|setString|setValue|setItems)\s*=?\s*[\s\S]{0,60}(token|password|secret|key|credential|session|auth)`
+**Severity:** warning
+
+## Insecure Data Storage
+
+### NSUserDefaults for Sensitive Data
+
+`NSUserDefaults` / `UserDefaults` stores data in an unencrypted plist file in the app sandbox. On jailbroken devices or via backup extraction, this data is trivially readable.
+
+```swift
+// VULNERABLE: Storing tokens in UserDefaults
+func saveSession(token: String, refreshToken: String) {
+    UserDefaults.standard.set(token, forKey: "auth_token")
+    UserDefaults.standard.set(refreshToken, forKey: "refresh_token")
+}
+
+// VULNERABLE: Storing password in UserDefaults
+UserDefaults.standard.set(password, forKey: "user_password")
+
+// SECURE: Use Keychain for sensitive data
+func saveSession(token: String) {
+    let query: [String: Any] = [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrAccount as String: "auth_token",
+        kSecValueData as String: token.data(using: .utf8)!,
+        kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+    ]
+    SecItemDelete(query as CFDictionary) // Remove old entry
+    SecItemAdd(query as CFDictionary, nil)
+}
+```
+
+**Detection regex:** `UserDefaults\.(standard\.)?set\s*\([^,]+,\s*forKey:\s*"(token|password|secret|key|credential|session|auth|refresh|api_key)|NSUserDefaults.*set(Object|Value).*forKey.*@"(token|password|secret|key|credential|session|auth)`
+**Severity:** error
+
+### Core Data Without Encryption
+
+Core Data uses unencrypted SQLite by default. For sensitive models, set `NSPersistentStoreFileProtectionKey` to `FileProtectionType.complete`.
+
+**Detection regex:** `NSPersistentContainer\s*\(name:|NSPersistentStoreDescription\s*\(\s*\)`
+**Severity:** warning
+
+## URL Scheme Vulnerabilities
+
+### Custom URL Scheme Without Validation
+
+Custom URL schemes (e.g., `myapp://`) can be invoked by any app or website. Without validating the source and parameters, attackers can trigger actions or inject data.
+
+```swift
+// VULNERABLE: No validation of URL scheme parameters
+func application(_ app: UIApplication, open url: URL,
+                 options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
+    if url.scheme == "myapp" {
+        let token = url.queryParameters["token"]
+        AuthManager.shared.setToken(token!) // Blindly trusting URL param
+        return true
+    }
+    return false
+}
+
+// SECURE: Validate source application and parameters
+func application(_ app: UIApplication, open url: URL,
+                 options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
+    guard url.scheme == "myapp" else { return false }
+
+    // Check source application
+    let sourceApp = options[.sourceApplication] as? String ?? ""
+    let allowedApps = ["com.example.trustedapp", "com.apple.SafariViewService"]
+    guard allowedApps.contains(sourceApp) else {
+        Logger.warning("URL scheme invoked from untrusted app: \(sourceApp)")
+        return false
+    }
+
+    // Validate and sanitize parameters
+    guard let host = url.host, host == "auth" else { return false }
+    guard let token = url.queryParameters["token"],
+          token.count <= 256,
+          token.range(of: #"^[a-zA-Z0-9\-_]+$"#, options: .regularExpression) != nil else {
+        return false
+    }
+
+    AuthManager.shared.setToken(token)
+    return true
+}
+```
+
+**Detection regex:** `application\s*\(\s*_\s+app.*open\s+url:\s*URL|openURL:\s*\(NSURL\s*\*\)`
+**Severity:** warning
+
+### Universal Link Bypass
+
+Custom URL schemes can be hijacked. Use Universal Links (Associated Domains) for authentication callbacks, which provide server-verified deep linking.
+
+**Detection regex:** `CFBundleURLSchemes|CFBundleURLTypes`
+**Severity:** warning
+
+## Jailbreak Detection
+
+### Missing or Weak Jailbreak Detection
+
+Apps processing sensitive data should detect jailbroken devices. Simple file-existence checks are easily bypassed by hooking frameworks like Frida or Substrate.
+
+```swift
+// BASIC (easily bypassed): Simple file check
+func isJailbroken() -> Bool {
+    let paths = [
+        "/Applications/Cydia.app",
+        "/Library/MobileSubstrate/MobileSubstrate.dylib",
+        "/bin/bash", "/usr/sbin/sshd", "/etc/apt",
+        "/private/var/lib/apt/"
+    ]
+    return paths.contains { FileManager.default.fileExists(atPath: $0) }
+}
+
+// SECURE: Multi-layered detection with runtime checks
+class JailbreakDetector {
+    static func isCompromised() -> Bool {
+        // 1. File system checks
+        if checkSuspiciousFiles() { return true }
+
+        // 2. Sandbox integrity check
+        if checkSandboxViolation() { return true }
+
+        // 3. Dynamic library injection check
+        if checkDyldInjection() { return true }
+
+        // 4. Fork check (sandbox should prevent fork)
+        if checkForkAvailability() { return true }
+
+        return false
+    }
+
+    private static func checkSuspiciousFiles() -> Bool {
+        let paths = [
+            "/Applications/Cydia.app",
+            "/Library/MobileSubstrate/MobileSubstrate.dylib",
+            "/bin/bash", "/usr/sbin/sshd", "/etc/apt",
+            "/usr/bin/ssh", "/private/var/lib/apt/",
+            "/private/var/lib/cydia", "/private/var/stash"
+        ]
+        for path in paths {
+            if FileManager.default.fileExists(atPath: path) { return true }
+            // Also try to open — hook might hide from fileExists
+            if let _ = fopen(path, "r") { return true }
+        }
+        return false
+    }
+
+    private static func checkSandboxViolation() -> Bool {
+        let testPath = "/private/jb_test_\(UUID().uuidString)"
+        do {
+            try "test".write(toFile: testPath, atomically: true, encoding: .utf8)
+            try FileManager.default.removeItem(atPath: testPath)
+            return true // Should not be able to write outside sandbox
+        } catch {
+            return false
+        }
+    }
+
+    private static func checkDyldInjection() -> Bool {
+        let count = _dyld_image_count()
+        for i in 0..<count {
+            guard let name = _dyld_get_image_name(i) else { continue }
+            let imageName = String(cString: name)
+            if imageName.contains("MobileSubstrate") ||
+               imageName.contains("cycript") ||
+               imageName.contains("frida") ||
+               imageName.contains("SSLKillSwitch") {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func checkForkAvailability() -> Bool {
+        let pid = fork()
+        if pid >= 0 {
+            // fork succeeded — jailbroken (sandbox should block this)
+            if pid > 0 { kill(pid, SIGTERM) }
+            return true
+        }
+        return false
+    }
+}
+```
+
+**Detection regex:** `(isJailbroken|jailbreakDetect|checkJailbreak|JailbreakDetector|Cydia\.app)`
+**Severity:** warning
+
+## Cryptographic Weaknesses
+
+### Insecure Random Number Generation
+
+`arc4random` and `arc4random_uniform` use a non-cryptographic PRNG. For security tokens, nonces, and key material, use `SecRandomCopyBytes`.
+
+```swift
+// VULNERABLE: arc4random for security token
+func generateToken() -> String {
+    let bytes = (0..<32).map { _ in UInt8(arc4random_uniform(256)) }
+    return Data(bytes).base64EncodedString()
+}
+
+// VULNERABLE: Using random() for session ID
+func generateSessionId() -> String {
+    return String(format: "%08x%08x", random(), random())
+}
+
+// SECURE: SecRandomCopyBytes for cryptographic randomness
+func generateToken() -> String {
+    var bytes = [UInt8](repeating: 0, count: 32)
+    let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+    guard status == errSecSuccess else {
+        fatalError("Failed to generate random bytes")
+    }
+    return Data(bytes).base64EncodedString()
+}
+```
+
+**Detection regex:** `arc4random\s*\(|arc4random_uniform\s*\([\s\S]{0,80}(token|key|secret|session|nonce|salt|iv)`
+**Severity:** error
+
+### Weak Hashing Algorithms
+
+Using MD5 or SHA-1 for integrity checks or password hashing provides inadequate collision resistance.
+
+```swift
+// VULNERABLE: MD5 for integrity
+import CommonCrypto
+func md5Hash(_ input: String) -> String {
+    let data = Data(input.utf8)
+    var digest = [UInt8](repeating: 0, count: Int(CC_MD5_DIGEST_LENGTH))
+    data.withUnsafeBytes { CC_MD5($0.baseAddress, CC_LONG(data.count), &digest) }
+    return digest.map { String(format: "%02x", $0) }.joined()
+}
+
+// SECURE: SHA-256 using CryptoKit
+import CryptoKit
+func sha256Hash(_ input: String) -> String {
+    let digest = SHA256.hash(data: Data(input.utf8))
+    return digest.map { String(format: "%02x", $0) }.joined()
+}
+```
+
+**Detection regex:** `CC_MD5\s*\(|CC_SHA1\s*\(|CC_MD5_DIGEST_LENGTH|kCCHmacAlgMD5`
+**Severity:** warning
+
+## Binary Protections
+
+### Missing PIE (Position Independent Executable)
+
+Non-PIE binaries load at a fixed address, making them vulnerable to return-oriented programming (ROP) attacks. Modern Xcode enables PIE by default, but legacy or custom build settings may disable it.
+
+```
+# Check binary for PIE flag:
+# otool -hv MyApp | grep PIE
+# If "PIE" is absent, the binary is not position-independent.
+
+# In Xcode build settings, ensure:
+# Generate Position-Dependent Code = No
+# Other Linker Flags includes -pie (usually automatic)
+```
+
+```swift
+// Xcode project.pbxproj — VULNERABLE: PIE disabled
+// GCC_GENERATE_POSITION_DEPENDENT_CODE = YES;
+
+// SECURE: Default Xcode setting
+// GCC_GENERATE_POSITION_DEPENDENT_CODE = NO;
+```
+
+**Detection regex:** `GCC_GENERATE_POSITION_DEPENDENT_CODE\s*=\s*YES`
+**Severity:** error
+
+### Missing ARC (Automatic Reference Counting)
+
+Non-ARC code is prone to use-after-free and double-free. Ensure `CLANG_ENABLE_OBJC_ARC = YES` in build settings.
+
+**Detection regex:** `CLANG_ENABLE_OBJC_ARC\s*=\s*NO|\[(\w+)\s+release\]|\[(\w+)\s+autorelease\]`
+**Severity:** error
+
+## Logging and Debug Output
+
+### NSLog with Sensitive Data
+
+`NSLog` output persists in the device console log and can be read by other apps (on older iOS) or via device management profiles. Use `os_log` with appropriate privacy levels instead.
+
+```swift
+// VULNERABLE: NSLog/print with sensitive data
+NSLog("Auth token: %@", authToken)
+print("User password: \(password)")
+debugPrint("API key: \(apiKey)")
+
+// SECURE: os_log with private annotation
+import os.log
+
+let logger = Logger(subsystem: "com.example.app", category: "auth")
+logger.debug("Auth completed for user: \(userID, privacy: .public)")
+logger.debug("Token: \(authToken, privacy: .private)")
+// In release: private values redacted as <private>
+```
+
+**Detection regex:** `NSLog\s*\(\s*@?"[^"]*%([@dfs])[^"]*"\s*,\s*[^)]*?(password|token|secret|key|credential|session|auth)|print\s*\(\s*"[^"]*\\?\(\s*(password|token|secret|key|credential|session|auth)`
+**Severity:** warning
+
+## Third-Party SDK Security
+
+### Embedded Frameworks Without Verification
+
+Verify binary framework integrity with checksums (`shasum -a 256`) and enable Library Validation in Hardened Runtime settings.
+
+**Detection regex:** `\.framework|\.xcframework`
+**Severity:** warning
+
+## Screenshot and Background Snapshot Protection
+
+### Sensitive Screens Captured in App Switcher
+
+iOS captures screenshots when backgrounding. Add a blur overlay on `willResignActiveNotification` and remove it on `didBecomeActiveNotification` to protect sensitive screens.
+
+**Detection regex:** `willResignActiveNotification[\s\S]{0,200}(blur|hide|overlay|mask|obscure)|applicationWillResignActive[\s\S]{0,200}(blur|hide|overlay)`
+**Severity:** warning
+
+## Remediation Priority
+
+| Finding | Severity | Remediation Timeline | Effort |
+|---------|----------|---------------------|--------|
+| kSecAttrAccessibleAlways usage | Critical | Immediate | Low |
+| NSAllowsArbitraryLoads = YES | Critical | Immediate | Low |
+| UIWebView usage | Critical | Immediate | High |
+| Sensitive data in UserDefaults | Critical | Immediate | Medium |
+| Missing PIE / ARC disabled | Critical | Immediate | Medium |
+| Insecure random for tokens | High | 1 week | Low |
+| Custom URL scheme without validation | High | 1 week | Medium |
+| Pasteboard leaking sensitive data | Medium | 1 week | Low |
+| Missing jailbreak detection | Medium | 1 month | High |
+| NSLog with sensitive data | Medium | 1 week | Low |
+| Missing screenshot protection | Low | 1 month | Medium |
+| Missing Keychain access control | Low | 1 month | Medium |
+
+## Related References
+
+- `owasp-top10.md` — OWASP Top 10 mapping
+- `cryptography-guide.md` — Cryptographic best practices
+- `api-security.md` — API security patterns
+- `authentication-patterns.md` — Authentication best practices
+- `android-sdk-security.md` — Android security patterns (companion reference)
+
+## Changelog
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-03-31 | Initial release | Mobile SDK security coverage |


### PR DESCRIPTION
## Summary

Tier 2 ecosystem PR — Mobile. Two new standalone reference guides (~1,258 lines total):

- **`android-sdk-security.md`**: component exposure, exported activities, WebView JS bridges, SharedPreferences insecure storage, cleartext traffic, custom TrustManager weaknesses, debuggable manifests
- **`ios-sdk-security.md`**: ATS bypass, Keychain usage, URL scheme hijacking, WKWebView config, Data Protection classes, ATS exemptions

Each guide has vulnerable vs secure examples (Kotlin / Swift / XML manifest) and detection regex hints.

## Provenance

Imported from [evandervecht/security-audit-skill](https://github.com/evandervecht/security-audit-skill). Dual-licensed MIT + CC-BY-SA-4.0. Fork-specific `SA-ANDROID-*` / `SA-IOS-*` checkpoint IDs stripped.

Attribution: [E van der Vecht](mailto:evandervecht@schubergphilis.com).

## Test plan

- [ ] CI green
- [ ] References render in GitHub preview