### PR TITLE
feat(scanner): multi-language audit dispatcher + 309 checkpoints (113 → 422)

### DIFF
--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -56,43 +56,41 @@ $stmt->execute([$id]);
 echo htmlspecialchars($input, ENT_QUOTES | ENT_HTML5, 'UTF-8');
 ```
 
-**API keys (encrypt at rest):**
+**API keys, passwords, randomness:**
 ```php
-$nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
-$encrypted = 'enc:' . base64_encode($nonce . sodium_crypto_secretbox($apiKey, $nonce, $key));
+$n = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+$enc = 'enc:' . base64_encode($n . sodium_crypto_secretbox($apiKey, $n, $key));
+password_hash($pw, PASSWORD_ARGON2ID);
+bin2hex(random_bytes(32));   // never mt_rand/rand
 ```
 
-**Password hashing + randomness:**
-```php
-$hash  = password_hash($password, PASSWORD_ARGON2ID);
-$token = bin2hex(random_bytes(32));   // never mt_rand/rand
-```
-
-Scanners (semgrep/opengrep, trivy, gitleaks): see `references/automated-scanning.md`.
+Automated scanners: `references/automated-scanning.md`.
 
 ## Security Checklist
 
-- [ ] `semgrep` (or `opengrep`), `trivy fs --severity HIGH,CRITICAL`, `gitleaks detect` clean
-- [ ] bcrypt/Argon2 passwords, CSRF tokens on state changes, TLS 1.2+
-- [ ] Input validated server-side; parameterized SQL; XML entities off (LIBXML_NONET)
+- [ ] `semgrep`/`opengrep`, `trivy fs --severity HIGH,CRITICAL`, `gitleaks` clean
+- [ ] bcrypt/Argon2 passwords, CSRF on state changes, TLS 1.2+
+- [ ] Server-side input validation; parameterized SQL; XML entities off
 - [ ] Output encoding + CSP; no unserialize() on user input
-- [ ] API keys encrypted (sodium_crypto_secretbox); exception messages sanitized
-- [ ] Secrets out of VCS; audit logging enabled
-- [ ] File uploads validated, renamed, outside web root
-- [ ] Headers: HSTS, X-Content-Type-Options; dependencies scanned
+- [ ] API keys encrypted; exception messages sanitized
+- [ ] Secrets out of VCS; audit logging on
+- [ ] Uploads validated, renamed, outside web root
+- [ ] Headers HSTS + X-Content-Type-Options; dependencies scanned
 
 ## GitHub Actions Security
 
 - **NEVER** interpolate `${{ inputs.* }}` / `${{ github.event.* }}` in `run:` — use `env:`
-- Dependency triage: upgrade > override > dismiss with rationale
-- See `references/gha-security.md`
+- Dependency triage: upgrade > override > dismiss. Full patterns: `references/gha-security.md`.
 
 ## Verification
 
 ```bash
-./scripts/security-audit.sh /path/to/project    # PHP
-./scripts/github-security-audit.sh owner/repo   # GitHub
+./scripts/security-audit-dispatcher.sh /path/to/project  # auto-detect stack
+./scripts/security-audit.sh /path/to/project             # PHP-only
+./scripts/github-security-audit.sh owner/repo            # GH repo
 ```
+
+Dispatcher detects the stack from indicator files and runs matching `scripts/scanners/*.sh` (17 ecosystems; see `references/` index).
 
 ---
 

--- a/skills/security-audit/checkpoints.yaml
+++ b/skills/security-audit/checkpoints.yaml
@@ -1382,3 +1382,2534 @@ llm_reviews:
       Report specific injection vectors and their remediation.
     severity: error
     desc: "Review GitHub Actions for injection vectors, permission scope, and secret exposure"
+
+  # === Imported from evandervecht/security-audit-skill fork (2026-04-19) ===
+  # Per-language, per-framework, cloud, mobile, and IaC checkpoints.
+  # Authored by E van der Vecht (MIT + CC-BY-SA-4.0 dual-licensed).
+  # Consumed by scripts/security-audit-dispatcher.sh and scripts/scanners/*.sh.
+
+  # === SECURITY DOCUMENTATION ===
+  # === SECRETS NOT IN VCS ===
+  # === COMPOSER AUDIT IN CI ===
+  # === XXE PREVENTION ===
+  # Use command type to avoid false positives from glob fallback to config files
+  # === SQL INJECTION PREVENTION ===
+  # === XSS PREVENTION ===
+  # Use command type to avoid false positives from glob fallback to config files
+  # === DEPENDABOT FOR SECURITY ===
+  # === DESERIALIZATION PREVENTION ===
+  # === INSECURE PASSWORD HASHING ===
+  # === COMMAND INJECTION ===
+  # === INSECURE RANDOMNESS ===
+  # === INFORMATION DISCLOSURE ===
+  # === FILE UPLOAD SAFETY ===
+  # === COOKIE SECURITY ===
+  # === OPEN REDIRECT ===
+  # === SECURITY HEADERS ===
+  # === CODE INJECTION (CWE-94) ===
+  # === IDOR (CWE-639) ===
+  # === SECRET SCANNING ===
+  # === SUPPLY CHAIN ===
+  # === TYPE JUGGLING (CWE-843) ===
+  # === PHAR DESERIALIZATION (CWE-502) ===
+  # === SSTI (CWE-1336) ===
+  # === EMAIL HEADER INJECTION (CWE-93) ===
+  # === LDAP INJECTION (CWE-90) ===
+  # === INSECURE TOKEN GENERATION (CWE-330) ===
+  # === LOG INJECTION / CRLF (CWE-117) ===
+  # === SESSION FIXATION (CWE-384) ===
+  # === HOST HEADER POISONING (CWE-644) ===
+  # === MASS ASSIGNMENT (CWE-915) ===
+  # === SAST TOOLING ===
+  # === DEPENDENCY SCANNING ===
+  # === GITLEAKS IN CI ===
+  # === PATH TRAVERSAL PREVENTION (CWE-22) ===
+  # === SEMGREP IN CI ===
+  # === SECURITY POLICY ===
+  # === INFRASTRUCTURE-AS-CODE SECURITY ===
+  - id: SA-IAC-01
+    type: command
+    target: "! grep -rqP '^USER\\s+root' Dockerfile* 2>/dev/null || ! grep -rqP '^USER\\s' Dockerfile* 2>/dev/null"
+    severity: warning
+    desc: "Dockerfile should not run as root - add a USER directive with a non-root user"
+
+
+  - id: SA-IAC-02
+    type: command
+    target: "! grep -rqE '(COPY|ADD).*\\.env' Dockerfile* 2>/dev/null"
+    severity: error
+    desc: "Dockerfile must not copy .env files into image layers (secrets leak)"
+
+
+  - id: SA-IAC-03
+    type: command
+    target: "! grep -rqE 'ARG.*(PASSWORD|SECRET|TOKEN|API_KEY)' Dockerfile* 2>/dev/null"
+    severity: error
+    desc: "Dockerfile ARG must not contain secrets (visible in image history)"
+
+
+  - id: SA-IAC-04
+    type: command
+    target: "! grep -rqE '^FROM\\s+\\w+\\s*$' Dockerfile* 2>/dev/null"
+    severity: warning
+    desc: "Dockerfile base images should be pinned to specific tags or digests, not latest"
+
+
+  - id: SA-IAC-05
+    type: command
+    target: "! grep -rqE 'privileged:\\s*true' docker-compose*.yml 2>/dev/null"
+    severity: error
+    desc: "Docker Compose must not use privileged mode (container escape risk)"
+
+
+  - id: SA-IAC-06
+    type: command
+    target: "! grep -rqE '/var/run/docker\\.sock' docker-compose*.yml 2>/dev/null"
+    severity: error
+    desc: "Docker Compose must not mount Docker socket (container escape risk)"
+
+
+  - id: SA-IAC-07
+    type: command
+    target: "! grep -rqE 'runAsUser:\\s*0' k8s/ kubernetes/ deploy/ manifests/ charts/ 2>/dev/null"
+    severity: error
+    desc: "Kubernetes pods must not run as root (runAsUser: 0)"
+
+
+  - id: SA-IAC-08
+    type: command
+    target: "! grep -rqE 'hostNetwork:\\s*true' k8s/ kubernetes/ deploy/ manifests/ charts/ 2>/dev/null"
+    severity: error
+    desc: "Kubernetes pods should not use host networking"
+
+
+  - id: SA-IAC-09
+    type: command
+    target: "! grep -rqE 'cidr_blocks.*0\\.0\\.0\\.0/0' *.tf **/*.tf 2>/dev/null"
+    severity: warning
+    desc: "Terraform security groups should not allow unrestricted ingress (0.0.0.0/0)"
+
+
+  - id: SA-IAC-10
+    type: command
+    target: "! grep -rqE 'acl.*public' *.tf **/*.tf 2>/dev/null"
+    severity: warning
+    desc: "Terraform S3 buckets should not use public ACLs"
+
+
+  # === FRONTEND/CLIENT-SIDE SECURITY ===
+  - id: SA-FE-01
+    type: not_contains
+    target: "**/*.js"
+    pattern: ".innerHTML ="
+    severity: warning
+    desc: "Direct innerHTML assignment may enable DOM-based XSS - use textContent or sanitize"
+
+
+  - id: SA-FE-02
+    type: not_contains
+    target: "**/*.js"
+    pattern: "document.write("
+    severity: warning
+    desc: "document.write() may enable DOM-based XSS - use DOM manipulation methods"
+
+
+  - id: SA-FE-03
+    type: command
+    target: "! grep -rqE 'eval\\s*\\(' --include='*.js' --include='*.ts' . 2>/dev/null"
+    severity: warning
+    desc: "eval() in JavaScript enables code injection - use safer alternatives"
+
+
+  - id: SA-FE-04
+    type: command
+    target: "! grep -rqE 'localStorage\\.(set|get)Item.*(token|password|secret|key|credential|session)' --include='*.js' --include='*.ts' . 2>/dev/null"
+    severity: error
+    desc: "Sensitive data (tokens, passwords, secrets) must not be stored in localStorage"
+
+
+  - id: SA-FE-05
+    type: command
+    target: "! grep -rqE 'Access-Control-Allow-Origin.*\\*' --include='*.php' --include='*.js' --include='*.conf' --include='*.yaml' --include='*.yml' . 2>/dev/null"
+    severity: warning
+    desc: "CORS wildcard (*) origin should be avoided - use specific allowed origins"
+
+
+  - id: SA-FE-06
+    type: command
+    target: "! grep -rqE 'new Function\\s*\\(' --include='*.js' --include='*.ts' . 2>/dev/null"
+    severity: warning
+    desc: "new Function() enables dynamic code execution - use safer alternatives"
+
+
+  # === AI/LLM AGENT SECURITY ===
+  - id: SA-AI-01
+    type: command
+    target: "! grep -rqE '(api_key|apiKey|API_KEY|secret|password|token)\\s*[:=]\\s*[\"'\\''](sk-|AKIA|ghp_|ghs_)' SKILL.md AGENTS.md CLAUDE.md .claude/ 2>/dev/null"
+    severity: error
+    desc: "AI agent config files must not contain hardcoded API keys or secrets"
+
+
+  - id: SA-AI-02
+    type: command
+    target: "! grep -rqE 'dangerouslyDisableSandbox|--no-verify|--force' SKILL.md AGENTS.md CLAUDE.md .claude/ 2>/dev/null"
+    severity: error
+    desc: "AI agent configs must not disable safety mechanisms (sandbox, hooks, verification)"
+
+
+  - id: SA-AI-03
+    type: command
+    target: "! grep -rqE 'Bash\\(\\*\\)|allowed-tools:.*Bash\\b[^(]' SKILL.md skills/*/SKILL.md 2>/dev/null"
+    severity: warning
+    desc: "AI skills should not grant unrestricted Bash access - scope to specific commands"
+
+
+  - id: SA-AI-04
+    type: command
+    target: "! grep -rqE '\"version\"\\s*:\\s*\"latest\"' .claude/mcp*.json mcp.json 2>/dev/null"
+    severity: warning
+    desc: "MCP server versions should be pinned, not 'latest' (supply chain risk)"
+
+
+  # === JAVASCRIPT/TYPESCRIPT SECURITY ===
+  - id: SA-JS-01
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "eval\\("
+    severity: error
+    desc: "eval() usage detected - potential code injection"
+
+
+  - id: SA-JS-02
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "\\.innerHTML\\s*="
+    severity: error
+    desc: "innerHTML assignment detected - potential DOM XSS"
+
+
+  - id: SA-JS-03
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "document\\.write\\("
+    severity: error
+    desc: "document.write() usage detected - potential DOM XSS"
+
+
+  - id: SA-JS-04
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "addEventListener\\(.message"
+    severity: warning
+    desc: "postMessage handler detected - verify origin validation"
+
+
+  - id: SA-JS-05
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "Math\\.random\\(\\)"
+    severity: warning
+    desc: "Math.random() is not cryptographically secure - use crypto.getRandomValues()"
+
+
+  - id: SA-JS-06
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "__proto__"
+    severity: error
+    desc: "__proto__ access detected - potential prototype pollution"
+
+
+  - id: SA-JS-07
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "new\\s+Function\\("
+    severity: error
+    desc: "Function constructor detected - equivalent to eval()"
+
+
+  - id: SA-JS-08
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "setTimeout\\(\\s*['\"`]"
+    severity: error
+    desc: "setTimeout with string argument - implicit eval()"
+
+
+  - id: SA-JS-09
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "\\.outerHTML\\s*="
+    severity: error
+    desc: "outerHTML assignment detected - potential DOM XSS"
+
+
+  - id: SA-JS-10
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "\\bdebugger\\b"
+    severity: warning
+    desc: "debugger statement detected - must not ship to production"
+
+
+  - id: SA-JS-11
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "require\\(.serialize-javascript"
+    severity: warning
+    desc: "serialize-javascript outputs executable JS - ensure output is never eval'd"
+
+
+  - id: SA-JS-12
+    type: regex
+    target: "**/*.{ts,tsx}"
+    pattern: ":\\s*any\\b"
+    severity: warning
+    desc: "TypeScript 'any' type disables type checking - use 'unknown' for untrusted input"
+
+
+  - id: SA-JS-13
+    type: regex
+    target: "**/*.{ts,tsx}"
+    pattern: "as\\s+unknown\\s+as"
+    severity: error
+    desc: "Double type assertion bypasses TypeScript safety - use runtime validation"
+
+
+  - id: SA-JS-14
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "import\\([^)]*\\$\\{"
+    severity: error
+    desc: "Dynamic import with template variable - potential module injection"
+
+
+  - id: SA-JS-15
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "setInterval\\(\\s*['\"`]"
+    severity: error
+    desc: "setInterval with string argument - implicit eval()"
+
+
+  - id: SA-JS-17
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "postMessage\\([^,]+,\\s*['\"]\\*['\"]"
+    severity: error
+    desc: "postMessage with wildcard origin - data exposed to any frame"
+
+
+  # === NODE.JS SERVER-SIDE SECURITY (Phase 3) ===
+  - id: SA-NODE-01
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "child_process.*exec\\("
+    severity: error
+    desc: "child_process.exec() with potential command injection — use execFile or spawn instead"
+
+
+  - id: SA-NODE-02
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "fs\\.(readFile|writeFile|readdir|unlink).*req\\.(query|params|body)"
+    severity: error
+    desc: "fs operation with user input — validate and restrict paths with path.resolve + startsWith"
+
+
+  - id: SA-NODE-03
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "require\\s*\\(\\s*['\"]vm2?['\"]\\s*\\)"
+    severity: error
+    desc: "vm/vm2 module is not a security boundary — use OS-level isolation for untrusted code"
+
+
+  - id: SA-NODE-04
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "Buffer\\.(allocUnsafe|allocUnsafeSlow)\\s*\\("
+    severity: warning
+    desc: "Buffer.allocUnsafe returns uninitialized memory — use Buffer.alloc unless fully overwritten"
+
+
+  - id: SA-NODE-05
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "require\\s*\\(\\s*[^'\"\\s].*[+`]"
+    severity: error
+    desc: "Dynamic require() with variable path — use an allowlist of permitted modules"
+
+
+  - id: SA-NODE-06
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "(hashSync|compareSync|pbkdf2Sync|scryptSync)\\s*\\("
+    severity: warning
+    desc: "Synchronous crypto in request handler blocks event loop — use async variant"
+
+
+  - id: SA-NODE-07
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "res\\.(setHeader|writeHead)\\s*\\([^)]*req\\.(query|params|body|headers)"
+    severity: error
+    desc: "User input in HTTP response header — risk of CRLF injection"
+
+
+  - id: SA-NODE-08
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "Math\\.random\\s*\\("
+    severity: warning
+    desc: "Math.random() is not cryptographically secure — use crypto.randomUUID() or crypto.randomBytes()"
+
+
+  - id: SA-NODE-09
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "http\\.createServer\\s*\\("
+    severity: warning
+    desc: "http.createServer — verify headersTimeout, requestTimeout, and body size limits are set"
+
+
+  - id: SA-NODE-10
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "Object\\.assign\\s*\\([^,]+,\\s*req\\.(body|query|params)"
+    severity: error
+    desc: "Object.assign with user input — risk of prototype pollution"
+
+
+  - id: SA-NODE-11
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "\\beval\\s*\\("
+    severity: error
+    desc: "eval() executes arbitrary code — use safe alternatives"
+
+
+  - id: SA-NODE-12
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "createHash\\s*\\(\\s*['\"]md5['\"]"
+    severity: warning
+    desc: "MD5 is cryptographically broken — use SHA-256 or stronger"
+
+
+  - id: SA-NODE-13
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "createHash\\s*\\(\\s*['\"]sha1['\"]"
+    severity: warning
+    desc: "SHA-1 is cryptographically weak — use SHA-256 or stronger"
+
+
+  - id: SA-NODE-14
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "new\\s+Function\\s*\\("
+    severity: error
+    desc: "new Function() is equivalent to eval — use safe alternatives"
+
+
+  - id: SA-NODE-15
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "fetch\\s*\\(\\s*req\\.(query|params|body)"
+    severity: error
+    desc: "fetch with user-supplied URL — risk of SSRF, validate and restrict URLs"
+
+
+  # === PYTHON SECURITY CHECKS (Phase 4) ===
+  - id: SA-PY-01
+    type: regex
+    target: "**/*.py"
+    pattern: "pickle\\.(loads|load)\\("
+    severity: error
+    desc: "Insecure deserialization via pickle"
+
+
+  - id: SA-PY-02
+    type: regex
+    target: "**/*.py"
+    pattern: "eval\\("
+    severity: error
+    desc: "Code injection via eval()"
+
+
+  - id: SA-PY-03
+    type: regex
+    target: "**/*.py"
+    pattern: "exec\\("
+    severity: error
+    desc: "Code injection via exec()"
+
+
+  - id: SA-PY-04
+    type: regex
+    target: "**/*.py"
+    pattern: "subprocess\\.\\w+\\(.*shell\\s*=\\s*True"
+    severity: error
+    desc: "Command injection via subprocess with shell=True"
+
+
+  - id: SA-PY-05
+    type: regex
+    target: "**/*.py"
+    pattern: "os\\.system\\("
+    severity: error
+    desc: "Command injection via os.system()"
+
+
+  - id: SA-PY-06
+    type: regex
+    target: "**/*.py"
+    pattern: "yaml\\.load\\("
+    severity: error
+    desc: "Unsafe YAML loading — use yaml.safe_load() instead"
+
+
+  - id: SA-PY-07
+    type: regex
+    target: "**/*.py"
+    pattern: "execute\\(f\""
+    severity: error
+    desc: "SQL injection via f-string in query"
+
+
+  - id: SA-PY-08
+    type: regex
+    target: "**/*.py"
+    pattern: "execute\\(.*\\.format\\("
+    severity: error
+    desc: "SQL injection via .format() in query"
+
+
+  - id: SA-PY-09
+    type: regex
+    target: "**/*.py"
+    pattern: "hashlib\\.md5\\("
+    severity: warning
+    desc: "Weak hash algorithm MD5 — use SHA-256+ or argon2 for passwords"
+
+
+  - id: SA-PY-10
+    type: regex
+    target: "**/*.py"
+    pattern: "hashlib\\.sha1\\("
+    severity: warning
+    desc: "Weak hash algorithm SHA1 — use SHA-256+ for integrity checks"
+
+
+  - id: SA-PY-11
+    type: regex
+    target: "**/*.py"
+    pattern: "tempfile\\.mktemp\\("
+    severity: error
+    desc: "Deprecated tempfile.mktemp() has race condition — use mkstemp()"
+
+
+  - id: SA-PY-12
+    type: regex
+    target: "**/*.py"
+    pattern: "__import__\\("
+    severity: warning
+    desc: "Dynamic import via __import__() — validate module names against a whitelist"
+
+
+  - id: SA-PY-13
+    type: regex
+    target: "**/*.py"
+    pattern: "xml\\.etree\\.ElementTree"
+    severity: warning
+    desc: "Standard library XML parser — use defusedxml to prevent XXE attacks"
+
+
+  - id: SA-PY-14
+    type: regex
+    target: "**/*.py"
+    pattern: "Template\\s*\\(.*\\w+.*\\)"
+    severity: warning
+    desc: "Jinja2/Mako Template with variable input — risk of SSTI"
+
+
+  - id: SA-PY-15
+    type: regex
+    target: "**/*.py"
+    pattern: "os\\.popen\\("
+    severity: error
+    desc: "Command injection via os.popen()"
+
+
+  - id: SA-PY-16
+    type: regex
+    target: "**/*.py"
+    pattern: "compile\\(.*,.*,"
+    severity: warning
+    desc: "compile() with dynamic input — risk of code injection"
+
+
+  - id: SA-PY-17
+    type: regex
+    target: "**/*.py"
+    pattern: "shelve\\.open\\("
+    severity: warning
+    desc: "shelve uses pickle internally — insecure deserialization risk"
+
+
+  - id: SA-PY-18
+    type: regex
+    target: "**/*.py"
+    pattern: "marshal\\.loads\\("
+    severity: warning
+    desc: "Insecure deserialization via marshal"
+
+
+  # === RUBY SECURITY CHECKS (Phase 4) ===
+  - id: SA-RB-01
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\beval\\s*\\("
+    severity: error
+    desc: "eval() usage — potential code injection"
+
+
+  - id: SA-RB-02
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\.send\\s*\\("
+    severity: warning
+    desc: "send() with dynamic method — potential method injection"
+
+
+  - id: SA-RB-03
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\bsystem\\s*\\("
+    severity: warning
+    desc: "system() call — verify no user input in command string"
+
+
+  - id: SA-RB-04
+    type: regex
+    target: "**/*.rb"
+    pattern: "Marshal\\.load\\s*\\("
+    severity: error
+    desc: "Marshal.load — insecure deserialization of untrusted data"
+
+
+  - id: SA-RB-05
+    type: regex
+    target: "**/*.rb"
+    pattern: "YAML\\.load\\s*\\("
+    severity: error
+    desc: "YAML.load without safe_load — insecure deserialization risk"
+
+
+  - id: SA-RB-06
+    type: regex
+    target: "**/*.rb"
+    pattern: "ERB\\.new\\s*\\("
+    severity: warning
+    desc: "ERB.new — audit for template injection with user input"
+
+
+  - id: SA-RB-07
+    type: regex
+    target: "**/*.rb"
+    pattern: "find_by_sql\\s*\\("
+    severity: error
+    desc: "find_by_sql — risk of SQL injection with string interpolation"
+
+
+  - id: SA-RB-08
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\.html_safe\\b"
+    severity: warning
+    desc: "html_safe bypasses Rails XSS escaping — audit for user input"
+
+
+  - id: SA-RB-09
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\braw\\s*\\("
+    severity: warning
+    desc: "raw() bypasses Rails XSS escaping — audit for user input"
+
+
+  - id: SA-RB-10
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\bKernel\\.open\\s*\\("
+    severity: error
+    desc: "Kernel.open — pipe injection and SSRF risk with user input"
+
+
+  - id: SA-RB-11
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\.permit!\\b"
+    severity: error
+    desc: "permit! allows all params — mass assignment vulnerability"
+
+
+  - id: SA-RB-12
+    type: regex
+    target: "**/*.rb"
+    pattern: "Digest::MD5"
+    severity: warning
+    desc: "MD5 is cryptographically broken — use SHA-256 or bcrypt"
+
+
+  - id: SA-RB-13
+    type: regex
+    target: "**/*.rb"
+    pattern: "Digest::SHA1"
+    severity: warning
+    desc: "SHA-1 is cryptographically weak — use SHA-256 or stronger"
+
+
+  - id: SA-RB-14
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\bexec\\s*\\("
+    severity: warning
+    desc: "exec() call — verify no user input in command string"
+
+
+  - id: SA-RB-15
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\bopen\\s*\\(\\s*[\"']\\|"
+    severity: error
+    desc: "open() with pipe prefix — direct command execution"
+
+
+  # === JAVA SECURITY CHECKS (Phase 2) ===
+  - id: SA-JAVA-01
+    type: regex
+    target: "**/*.java"
+    pattern: "new\\s+ObjectInputStream\\s*\\("
+    severity: error
+    desc: "ObjectInputStream deserialization — risk of RCE via gadget chains"
+
+
+  - id: SA-JAVA-02
+    type: regex
+    target: "**/*.java"
+    pattern: "new\\s+XMLDecoder\\s*\\("
+    severity: error
+    desc: "XMLDecoder deserialization — enables arbitrary code execution"
+
+
+  - id: SA-JAVA-03
+    type: regex
+    target: "**/*.java"
+    pattern: "InitialContext\\s*\\(\\s*\\)[\\s\\S]{0,100}\\.lookup\\s*\\("
+    severity: error
+    desc: "JNDI lookup — risk of remote class loading (Log4Shell pattern)"
+
+
+  - id: SA-JAVA-04
+    type: regex
+    target: "**/*.java"
+    pattern: "Class\\.forName\\s*\\("
+    severity: warning
+    desc: "Reflection via Class.forName — risk of arbitrary class instantiation"
+
+
+  - id: SA-JAVA-05
+    type: regex
+    target: "**/*.java"
+    pattern: "(createStatement|executeQuery|executeUpdate)\\s*\\([^)]*\\+"
+    severity: error
+    desc: "JDBC string concatenation — SQL injection risk, use PreparedStatement"
+
+
+  - id: SA-JAVA-06
+    type: regex
+    target: "**/*.java"
+    pattern: "DocumentBuilderFactory\\.newInstance\\s*\\("
+    severity: warning
+    desc: "XML parsing without explicit XXE protection — disable external entities"
+
+
+  - id: SA-JAVA-07
+    type: regex
+    target: "**/*.java"
+    pattern: "Runtime\\.getRuntime\\s*\\(\\s*\\)\\.exec\\s*\\("
+    severity: error
+    desc: "Runtime.exec — command injection risk, use ProcessBuilder with array args"
+
+
+  - id: SA-JAVA-08
+    type: regex
+    target: "**/*.java"
+    pattern: "getInstance\\s*\\(\\s*\"(MD5|SHA-1)\"\\s*\\)"
+    severity: warning
+    desc: "Weak hash algorithm (MD5/SHA-1) — use SHA-256 or stronger"
+
+
+  - id: SA-JAVA-09
+    type: regex
+    target: "**/*.java"
+    pattern: "new\\s+Random\\s*\\("
+    severity: warning
+    desc: "java.util.Random is predictable — use SecureRandom for security operations"
+
+
+  - id: SA-JAVA-10
+    type: regex
+    target: "**/*.java"
+    pattern: "Cipher\\.getInstance\\s*\\(\\s*\"(DES|.*ECB)"
+    severity: error
+    desc: "Weak cipher (DES/ECB) — use AES-GCM for authenticated encryption"
+
+
+  - id: SA-JAVA-11
+    type: regex
+    target: "**/*.java"
+    pattern: "(openConnection|openStream)\\s*\\(\\s*\\)"
+    severity: warning
+    desc: "URL.openConnection/openStream — SSRF risk, validate and restrict URLs"
+
+
+  - id: SA-JAVA-12
+    type: regex
+    target: "**/*.java"
+    pattern: "new\\s+File\\s*\\(\\s*[^)]*\\+\\s*(request|req|param|input|args)"
+    severity: warning
+    desc: "File path from user input — path traversal risk, validate canonical path"
+
+
+  # === C# SECURITY CHECKS (Phase 2) ===
+  - id: SA-CS-01
+    type: regex
+    target: "**/*.cs"
+    pattern: "new\\s+BinaryFormatter\\s*\\("
+    severity: error
+    desc: "BinaryFormatter deserialization — RCE risk, use System.Text.Json"
+
+
+  - id: SA-CS-02
+    type: regex
+    target: "**/*.cs"
+    pattern: "new\\s+NetDataContractSerializer\\s*\\("
+    severity: error
+    desc: "NetDataContractSerializer — insecure deserialization with type embedding"
+
+
+  - id: SA-CS-03
+    type: regex
+    target: "**/*.cs"
+    pattern: "FromSqlRaw\\s*\\(\\s*\\$"
+    severity: error
+    desc: "FromSqlRaw with interpolation — SQL injection, use FromSqlInterpolated"
+
+
+  - id: SA-CS-04
+    type: regex
+    target: "**/*.cs"
+    pattern: "new\\s+XmlDocument\\s*\\("
+    severity: warning
+    desc: "XmlDocument — set XmlResolver=null and disable DTD processing"
+
+
+  - id: SA-CS-05
+    type: regex
+    target: "**/*.cs"
+    pattern: "Process\\.Start\\s*\\("
+    severity: warning
+    desc: "Process.Start — command injection risk, set UseShellExecute=false"
+
+
+  - id: SA-CS-06
+    type: regex
+    target: "**/*.cs"
+    pattern: "MD5\\.Create\\s*\\("
+    severity: warning
+    desc: "MD5 is cryptographically broken — use SHA256 or stronger"
+
+
+  - id: SA-CS-07
+    type: regex
+    target: "**/*.cs"
+    pattern: "SHA1\\.Create\\s*\\("
+    severity: warning
+    desc: "SHA-1 is cryptographically weak — use SHA256 or stronger"
+
+
+  - id: SA-CS-08
+    type: regex
+    target: "**/*.cs"
+    pattern: "new\\s+Random\\s*\\("
+    severity: warning
+    desc: "System.Random is predictable — use RandomNumberGenerator for security"
+
+
+  - id: SA-CS-09
+    type: regex
+    target: "**/*.cs"
+    pattern: "DESCryptoServiceProvider"
+    severity: error
+    desc: "DES is broken (56-bit key) — use AES-GCM"
+
+
+  - id: SA-CS-10
+    type: regex
+    target: "**/*.cs"
+    pattern: "AllowAnyOrigin\\s*\\("
+    severity: error
+    desc: "CORS AllowAnyOrigin — use explicit origin allowlist"
+
+
+  - id: SA-CS-11
+    type: regex
+    target: "**/*.cs"
+    pattern: "DirectorySearcher\\s*\\(\\s*\\$"
+    severity: error
+    desc: "LDAP injection via DirectorySearcher with interpolation"
+
+
+  - id: SA-CS-12
+    type: regex
+    target: "**/*.cs"
+    pattern: "UseShellExecute\\s*=\\s*true"
+    severity: warning
+    desc: "UseShellExecute=true passes args through shell — set to false"
+
+
+  # === GO SECURITY CHECKS ===
+  - id: SA-GO-01
+    type: regex
+    target: "**/*.go"
+    pattern: "unsafe\\.(Pointer|Sizeof|Slice|String|Offsetof|Alignof)"
+    severity: warning
+    desc: "unsafe package usage — bypasses Go memory safety, audit required"
+
+
+  - id: SA-GO-02
+    type: regex
+    target: "**/*.go"
+    pattern: "\"text/template\""
+    severity: error
+    desc: "text/template does not escape HTML — use html/template for web output"
+
+
+  - id: SA-GO-03
+    type: regex
+    target: "**/*.go"
+    pattern: "(Sprintf|\"\\s*\\+).*(SELECT|INSERT|UPDATE|DELETE|select|insert|update|delete)"
+    severity: error
+    desc: "SQL string concatenation — use parameterized queries"
+
+
+  - id: SA-GO-04
+    type: regex
+    target: "**/*.go"
+    pattern: "exec\\.Command\\s*\\(\\s*\"(sh|bash|cmd|powershell)\""
+    severity: error
+    desc: "Shell invocation via exec.Command — risk of command injection"
+
+
+  - id: SA-GO-05
+    type: regex
+    target: "**/*.go"
+    pattern: "filepath\\.Join\\s*\\(.*\\b(r\\.|req\\.|request\\.|URL)"
+    severity: warning
+    desc: "filepath.Join with user input — validate resolved path stays within base"
+
+
+  - id: SA-GO-06
+    type: regex
+    target: "**/*.go"
+    pattern: "InsecureSkipVerify\\s*:\\s*true"
+    severity: error
+    desc: "TLS certificate verification disabled — enables MITM attacks"
+
+
+  - id: SA-GO-07
+    type: regex
+    target: "**/*.go"
+    pattern: "\"math/rand\""
+    severity: warning
+    desc: "math/rand is not cryptographically secure — use crypto/rand for secrets"
+
+
+  - id: SA-GO-08
+    type: regex
+    target: "**/*.go"
+    pattern: "http\\.(Get|Post|Head)\\s*\\(.*\\b(r\\.|req\\.|request\\.|URL)"
+    severity: error
+    desc: "HTTP request with user-controlled URL — SSRF risk"
+
+
+  - id: SA-GO-09
+    type: regex
+    target: "**/*.go"
+    pattern: "log\\.(Print|Fatal|Panic)(f|ln)?\\s*\\("
+    severity: warning
+    desc: "Unstructured logging — use log/slog for security event logging"
+
+
+  - id: SA-GO-10
+    type: regex
+    target: "**/*.go"
+    pattern: "Header\\(\\)\\.Set\\s*\\(.*\\b(r\\.|req\\.)"
+    severity: warning
+    desc: "HTTP header set with request data — risk of header injection"
+
+
+  - id: SA-GO-11
+    type: regex
+    target: "**/*.go"
+    pattern: "VersionTLS1[01]\\b"
+    severity: error
+    desc: "TLS 1.0/1.1 is insecure — use TLS 1.2 or higher"
+
+
+  - id: SA-GO-12
+    type: regex
+    target: "**/*.go"
+    pattern: "(password|secret|apiKey|token)\\s*[:=]\\s*\"[^\"]{8,}\""
+    severity: error
+    desc: "Potential hardcoded credential — use environment variables or secret manager"
+
+
+  # === RUST SECURITY CHECKS ===
+  - id: SA-RS-01
+    type: regex
+    target: "**/*.rs"
+    pattern: "unsafe\\s*\\{|unsafe\\s+fn\\s|unsafe\\s+impl\\s"
+    severity: warning
+    desc: "unsafe block/fn/impl — bypasses Rust safety guarantees, audit required"
+
+
+  - id: SA-RS-02
+    type: regex
+    target: "**/*.rs"
+    pattern: "extern\\s+\"C\"\\s*\\{|#\\[no_mangle\\]"
+    severity: warning
+    desc: "FFI boundary — audit for null pointers, lifetime issues, and error handling"
+
+
+  - id: SA-RS-03
+    type: regex
+    target: "**/*.rs"
+    pattern: "panic!\\s*\\(|todo!\\s*\\(|unimplemented!\\s*\\("
+    severity: warning
+    desc: "panic!/todo!/unimplemented! in code — can cause DoS via unwinding"
+
+
+  - id: SA-RS-04
+    type: regex
+    target: "**/*.rs"
+    pattern: "\\.unwrap\\(\\)|\\.expect\\(\\s*\""
+    severity: warning
+    desc: ".unwrap()/.expect() can panic — use ? or match in production paths"
+
+
+  - id: SA-RS-05
+    type: regex
+    target: "**/*.rs"
+    pattern: "as\\s+\\*const\\s|as\\s+\\*mut\\s"
+    severity: warning
+    desc: "Raw pointer cast — potential use-after-free or null deref in unsafe code"
+
+
+  - id: SA-RS-06
+    type: regex
+    target: "**/*.rs"
+    pattern: "sql_query\\s*\\(\\s*format!|query.*&format!"
+    severity: error
+    desc: "SQL query with format! string — use parameterized queries"
+
+
+  - id: SA-RS-07
+    type: regex
+    target: "**/*.rs"
+    pattern: "Command::new\\s*\\(\\s*\"(sh|bash|cmd|powershell)\""
+    severity: error
+    desc: "Shell invocation via Command::new — risk of command injection"
+
+
+  - id: SA-RS-08
+    type: regex
+    target: "**/*.rs"
+    pattern: "\\.join\\s*\\(.*\\b(req|input|param|query|user)"
+    severity: warning
+    desc: "Path join with user input — validate resolved path stays within base"
+
+
+  - id: SA-RS-09
+    type: regex
+    target: "**/*.rs"
+    pattern: "serde_json::from_(str|slice|reader)\\s*\\("
+    severity: warning
+    desc: "Deserialization of potentially untrusted data — enforce size limits"
+
+
+  - id: SA-RS-10
+    type: regex
+    target: "**/*.rs"
+    pattern: "==\\s*(token|secret|hmac|hash|key|password|mac|signature)"
+    severity: error
+    desc: "Non-constant-time comparison of secret — use constant_time_eq"
+
+
+  - id: SA-RS-11
+    type: regex
+    target: "**/*.rs"
+    pattern: "mem::forget\\s*\\(|ManuallyDrop::new\\s*\\("
+    severity: warning
+    desc: "mem::forget/ManuallyDrop prevents cleanup — sensitive data may persist"
+
+
+  - id: SA-RS-12
+    type: regex
+    target: "**/*.rs"
+    pattern: "(password|secret|api_key|token)\\s*[:=]\\s*\"[^\"]{8,}\""
+    severity: error
+    desc: "Potential hardcoded credential — use environment variables or secret manager"
+
+
+  # === VUE.JS SECURITY CHECKS ===
+  - id: SA-VUE-01
+    type: regex
+    target: "**/*.{vue,js,ts}"
+    pattern: "v-html\\s*="
+    severity: warning
+    desc: "v-html directive — potential XSS if used with user input"
+
+
+  - id: SA-VUE-02
+    type: regex
+    target: "**/*.{vue,js,ts}"
+    pattern: "Vue\\.compile\\s*\\("
+    severity: error
+    desc: "Vue.compile() with dynamic input — potential template injection"
+
+
+  - id: SA-VUE-03
+    type: regex
+    target: "**/*.{vue,js,ts}"
+    pattern: ":(href|src)\\s*=\\s*\"[^\"]*[a-zA-Z]"
+    severity: warning
+    desc: "v-bind:href/src with variable — validate URL protocol to prevent javascript: XSS"
+
+
+  - id: SA-VUE-04
+    type: regex
+    target: "**/*.{vue,js,ts}"
+    pattern: "beforeEnter\\s*:|beforeEach\\s*\\("
+    severity: warning
+    desc: "Client-side route guard — ensure server-side authorization exists"
+
+
+  - id: SA-VUE-05
+    type: regex
+    target: "**/*.{vue,js,ts}"
+    pattern: "(computed|watch|methods)\\s*:\\s*\\{[^}]*eval\\s*\\("
+    severity: error
+    desc: "eval() in Vue reactivity hook — potential code injection"
+
+
+  - id: SA-VUE-06
+    type: regex
+    target: "**/*.{vue,js,ts}"
+    pattern: "(defineStore|new\\s+Vuex\\.Store)\\s*\\([^)]*\\{[\\s\\S]*?(token|secret|password|apiKey|api_key|ssn|creditCard)"
+    severity: error
+    desc: "Sensitive data in Vuex/Pinia store — exposed via DevTools"
+
+
+  - id: SA-VUE-07
+    type: regex
+    target: "**/*.{vue,js,ts}"
+    pattern: "(asyncData|serverPrefetch|fetch)\\s*\\([^)]*\\)\\s*\\{[\\s\\S]*?(secret|internal|private|apiKey|connectionString)"
+    severity: error
+    desc: "SSR hydration may leak server-only data to client HTML"
+
+
+  - id: SA-VUE-08
+    type: regex
+    target: "**/*.{vue,js,ts}"
+    pattern: "Vue\\.mixin\\s*\\(|app\\.mixin\\s*\\("
+    severity: warning
+    desc: "Global mixin — applies to every component, audit for side effects"
+
+
+  # === ANGULAR SECURITY CHECKS ===
+  - id: SA-ANG-01
+    type: regex
+    target: "**/*.{ts,html}"
+    pattern: "bypassSecurityTrust(Html|Script|Url|ResourceUrl)\\s*\\("
+    severity: error
+    desc: "bypassSecurityTrust* disables Angular sanitization — audit for user input"
+
+
+  - id: SA-ANG-02
+    type: regex
+    target: "**/*.{ts,html}"
+    pattern: "compiler\\.compileModuleAndAllComponentsAsync|Component\\(\\s*\\{\\s*template\\s*:"
+    severity: error
+    desc: "Dynamic template compilation — potential template injection"
+
+
+  - id: SA-ANG-03
+    type: regex
+    target: "**/*.{ts,html}"
+    pattern: "@Pipe[\\s\\S]*?bypassSecurityTrust"
+    severity: error
+    desc: "Pipe with bypassSecurityTrust — reusable sanitization bypass"
+
+
+  - id: SA-ANG-04
+    type: regex
+    target: "**/*.{ts,html}"
+    pattern: "\\[innerHTML\\]\\s*="
+    severity: warning
+    desc: "innerHTML binding — verify input is sanitized before binding"
+
+
+  - id: SA-ANG-05
+    type: regex
+    target: "**/*.{ts,html}"
+    pattern: "canActivate|CanActivate|canLoad|CanLoad"
+    severity: warning
+    desc: "Client-side route guard — ensure server-side authorization exists"
+
+
+  - id: SA-ANG-06
+    type: regex
+    target: "**/*.{ts,html}"
+    pattern: "HttpInterceptor[\\s\\S]*?intercept\\s*\\("
+    severity: warning
+    desc: "HTTP interceptor — verify tokens are only sent to trusted origins"
+
+
+  - id: SA-ANG-07
+    type: regex
+    target: "**/*.{ts,html}"
+    pattern: "eval\\s*\\([^)]*\\)|new\\s+Function\\s*\\("
+    severity: error
+    desc: "eval/new Function in Angular code — potential code injection"
+
+
+  - id: SA-ANG-08
+    type: regex
+    target: "**/*.{ts,html}"
+    pattern: "ngZone\\.run\\s*\\([\\s\\S]*?(password|token|secret|creditCard|ssn|apiKey)"
+    severity: warning
+    desc: "Sensitive data in Zone.js context — may persist in memory"
+
+
+  # === REACT SECURITY CHECKS ===
+  - id: SA-REACT-01
+    type: regex
+    target: "**/*.{jsx,tsx}"
+    pattern: "dangerouslySetInnerHTML"
+    severity: warning
+    desc: "dangerouslySetInnerHTML usage — potential XSS"
+
+
+  - id: SA-REACT-02
+    type: regex
+    target: "**/*.{jsx,tsx}"
+    pattern: "\\{\\s*\\.\\.\\.(?:user|props|data|input|params|query)"
+    severity: warning
+    desc: "Spreading user-controlled object as JSX props — may inject dangerouslySetInnerHTML"
+
+
+  - id: SA-REACT-03
+    type: regex
+    target: "**/*.{jsx,tsx}"
+    pattern: "href\\s*=\\s*\\{(?!['\"](https?:|mailto:|/)[^}])"
+    severity: warning
+    desc: "Dynamic href from variable — potential javascript: protocol XSS"
+
+
+  - id: SA-REACT-04
+    type: regex
+    target: "**/*.{jsx,tsx}"
+    pattern: "'use client'[\\s\\S]*?\\b(password|secret|token|ssn|creditCard|hash)\\b"
+    severity: warning
+    desc: "Client component may receive sensitive data as props — data visible in browser"
+
+
+  - id: SA-REACT-05
+    type: regex
+    target: "**/*.{jsx,tsx}"
+    pattern: "\\beval\\s*\\(|new\\s+Function\\s*\\("
+    severity: error
+    desc: "eval() or Function constructor — code injection risk"
+
+
+  - id: SA-REACT-06
+    type: regex
+    target: "**/*.{jsx,tsx}"
+    pattern: "useState\\s*\\(\\s*\\{[^}]*(token|secret|password|refreshToken|cvv|ssn|creditCard)"
+    severity: warning
+    desc: "Sensitive data in React state — visible in DevTools"
+
+
+  - id: SA-REACT-07
+    type: regex
+    target: "**/*.{jsx,tsx}"
+    pattern: "useEffect\\s*\\(\\s*\\(\\)\\s*=>\\s*\\{[^}]*fetch\\s*\\([^)]*\\)\\.then"
+    severity: warning
+    desc: "useEffect fetch without visible auth — verify credentials are included"
+
+
+  - id: SA-REACT-08
+    type: regex
+    target: "**/*.{jsx,tsx}"
+    pattern: "key\\s*=\\s*\\{[^}]*(index|idx|i)\\s*\\}"
+    severity: info
+    desc: "Array index as React key — may cause state leaks between list items"
+
+
+  # === NEXT.JS SECURITY CHECKS ===
+  - id: SA-NEXT-01
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx}"
+    pattern: "'use server'[\\s\\S]*?export\\s+async\\s+function\\s+\\w+"
+    severity: warning
+    desc: "Server Action — verify auth/authorization check inside function body"
+
+
+  - id: SA-NEXT-02
+    type: regex
+    target: "**/*.{js,ts}"
+    pattern: "export\\s+async\\s+function\\s+(GET|POST|PUT|DELETE|PATCH)\\s*\\("
+    severity: warning
+    desc: "Next.js API route handler — verify authentication is enforced"
+
+
+  - id: SA-NEXT-03
+    type: regex
+    target: "**/*.env*"
+    pattern: "NEXT_PUBLIC_[A-Z_]*(SECRET|KEY|PASSWORD|TOKEN|CREDENTIAL|PRIVATE|DATABASE)"
+    severity: error
+    desc: "NEXT_PUBLIC_ env var with secret-like name — exposed to client bundle"
+
+
+  - id: SA-NEXT-04
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx}"
+    pattern: "(getServerSideProps|getStaticProps)[\\s\\S]*?return\\s*\\{\\s*props:"
+    severity: warning
+    desc: "getServerSideProps/getStaticProps return — verify no sensitive fields in props"
+
+
+  - id: SA-NEXT-05
+    type: regex
+    target: "**/next.config.{js,mjs,ts}"
+    pattern: "hostname:\\s*['\"]?\\*{1,2}['\"]?"
+    severity: error
+    desc: "Wildcard hostname in next/image config — SSRF risk via image optimization"
+
+
+  - id: SA-NEXT-06
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx}"
+    pattern: "Response\\.redirect\\s*\\([^)]*searchParams|redirect\\s*\\(\\s*(?:req|request)"
+    severity: warning
+    desc: "Redirect with user-controlled destination — potential open redirect"
+
+
+  - id: SA-NEXT-07
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx}"
+    pattern: "JSON\\.stringify\\s*\\([^)]*(config|secret|user|session|token|key|credential)"
+    severity: warning
+    desc: "JSON.stringify of potentially sensitive object — may leak in RSC payload"
+
+
+  - id: SA-NEXT-08
+    type: regex
+    target: "**/*.{js,ts}"
+    pattern: "export\\s+async\\s+function\\s+POST\\s*\\([^)]*\\)\\s*\\{[^}]*(?:cookie|session|auth)"
+    severity: warning
+    desc: "POST handler with cookie/session auth — verify CSRF protection"
+
+
+  # === NUXT SECURITY CHECKS ===
+  - id: SA-NUXT-01
+    type: regex
+    target: "server/**/*.{js,ts}"
+    pattern: "defineEventHandler\\s*\\(\\s*async\\s*\\(\\s*event\\s*\\)"
+    severity: warning
+    desc: "Nitro server handler — verify authentication middleware is applied"
+
+
+  - id: SA-NUXT-02
+    type: regex
+    target: "**/*.{vue,js,ts}"
+    pattern: "useFetch\\s*\\(\\s*['\"][^'\"]*admin|useAsyncData\\s*\\(\\s*['\"][^'\"]*secret"
+    severity: warning
+    desc: "useFetch/useAsyncData fetching sensitive endpoint — data exposed in hydration payload"
+
+
+  - id: SA-NUXT-03
+    type: regex
+    target: "**/nuxt.config.{js,ts}"
+    pattern: "runtimeConfig[\\s\\S]*?public\\s*:\\s*\\{[^}]*(secret|password|token|key|credential|private|database)"
+    severity: error
+    desc: "Secret in runtimeConfig.public — exposed to client"
+
+
+  - id: SA-NUXT-04
+    type: regex
+    target: "**/*.vue"
+    pattern: "v-html\\s*="
+    severity: warning
+    desc: "v-html directive — potential XSS, especially dangerous in SSR context"
+
+
+  - id: SA-NUXT-05
+    type: regex
+    target: "server/**/*.{js,ts}"
+    pattern: "exec\\s*\\(|execSync\\s*\\(|\\$queryRawUnsafe\\s*\\("
+    severity: error
+    desc: "Shell exec or raw SQL in Nitro handler — injection risk"
+
+
+  - id: SA-NUXT-06
+    type: regex
+    target: "plugins/**/*.{js,ts}"
+    pattern: "defineNuxtPlugin\\s*\\(\\s*(?:async\\s*)?\\(\\s*nuxtApp\\s*\\)\\s*=>"
+    severity: info
+    desc: "Nuxt plugin without enforce/dependsOn — verify execution order for security plugins"
+
+
+  # === SPRING SECURITY CHECKS ===
+  - id: SA-SPRING-01
+    type: regex
+    target: "**/*.java"
+    pattern: "requestMatchers\\s*\\(\\s*\"\\/(api|admin)\\/\\*\\*\"\\s*\\)\\s*\\.\\s*permitAll\\s*\\(\\s*\\)"
+    severity: error
+    desc: "Spring Security permitAll overreach — verify scope is intentionally broad"
+
+
+  - id: SA-SPRING-02
+    type: regex
+    target: "**/*.java"
+    pattern: "parseExpression\\s*\\(\\s*[a-zA-Z_]\\w*\\s*\\)"
+    severity: error
+    desc: "SpEL expression parsed from untrusted input — injection risk"
+
+
+  - id: SA-SPRING-03
+    type: regex
+    target: "**/*.java"
+    pattern: "include\\s*:\\s*[\"']?\\*[\"']?|exposure\\.include\\s*=\\s*\\*"
+    severity: error
+    desc: "Spring Boot actuator wildcard exposure — secrets and heap dumps accessible"
+
+
+  - id: SA-SPRING-04
+    type: regex
+    target: "**/*.java"
+    pattern: "csrf\\s*\\(\\s*(?:csrf|c)\\s*->\\s*(?:csrf|c)\\.disable\\s*\\(\\s*\\)\\s*\\)|\\.csrf\\(\\)\\.disable\\(\\)"
+    severity: warning
+    desc: "CSRF protection disabled — verify endpoint is stateless (JWT/Bearer)"
+
+
+  - id: SA-SPRING-05
+    type: regex
+    target: "**/*.java"
+    pattern: "@PreAuthorize\\s*\\("
+    severity: warning
+    desc: "@PreAuthorize found — verify @EnableMethodSecurity is declared on a @Configuration class"
+
+
+  - id: SA-SPRING-06
+    type: regex
+    target: "**/*.java"
+    pattern: "return\\s+(?:request|param|input|query|\\w+)\\s*;"
+    severity: warning
+    desc: "Controller return value may be user-controlled — Thymeleaf SSTI risk"
+
+
+  - id: SA-SPRING-07
+    type: regex
+    target: "**/*.java"
+    pattern: "@ModelAttribute\\s+(?!.*Dto|.*Request|.*Form|.*Command)\\w+\\s+\\w+"
+    severity: warning
+    desc: "@ModelAttribute binds to entity directly — mass assignment risk"
+
+
+  - id: SA-SPRING-08
+    type: regex
+    target: "**/*.java"
+    pattern: "enableDefaultTyping\\s*\\(|activateDefaultTyping\\s*\\("
+    severity: error
+    desc: "Jackson default typing enabled — deserialization gadget chain risk"
+
+
+  # === .NET SECURITY CHECKS ===
+  - id: SA-DOTNET-01
+    type: regex
+    target: "**/*.cs"
+    pattern: "UseAuthentication\\s*\\(\\s*\\)[\\s\\S]{0,200}UseRouting\\s*\\(\\s*\\)|MapControllers\\s*\\(\\s*\\)[\\s\\S]{0,200}UseAuthentication\\s*\\(\\s*\\)|UseAuthorization\\s*\\(\\s*\\)[\\s\\S]{0,200}UseAuthentication\\s*\\(\\s*\\)"
+    severity: error
+    desc: "ASP.NET Core middleware ordering wrong — auth must come before routing/endpoints"
+
+
+  - id: SA-DOTNET-02
+    type: regex
+    target: "**/*.cs"
+    pattern: "FromSqlRaw\\s*\\(\\s*\\$\"|FromSqlRaw\\s*\\(\\s*\"[^\"]*\"\\s*\\+|ExecuteSqlRaw\\s*\\(\\s*\\$\"|ExecuteSqlRaw\\s*\\(\\s*\"[^\"]*\"\\s*\\+"
+    severity: error
+    desc: "Entity Framework raw SQL with string interpolation/concatenation — SQL injection"
+
+
+  - id: SA-DOTNET-03
+    type: regex
+    target: "**/*.cs"
+    pattern: "\\[AllowAnonymous\\]\\s*(?:\\r?\\n\\s*)*(?:public\\s+class|\\[(?:ApiController|Route)\\])"
+    severity: error
+    desc: "[AllowAnonymous] on controller class — all actions are publicly accessible"
+
+
+  - id: SA-DOTNET-04
+    type: regex
+    target: "**/*.cs"
+    pattern: "Html\\.Raw\\s*\\((?!.*Sanitiz)|@\\(\\s*\\(MarkupString\\)\\s*\\w+"
+    severity: error
+    desc: "Razor Html.Raw or MarkupString with unsanitized input — XSS risk"
+
+
+  - id: SA-DOTNET-05
+    type: regex
+    target: "**/*.cs"
+    pattern: "AllowAnyOrigin\\s*\\(\\s*\\)|SetIsOriginAllowed\\s*\\(\\s*_?\\s*=>\\s*true\\s*\\)"
+    severity: error
+    desc: "CORS policy allows any origin — credential theft via cross-origin requests"
+
+
+  - id: SA-DOTNET-06
+    type: regex
+    target: "**/*.cs"
+    pattern: "IgnoreAntiforgeryTokenAttribute\\s*\\(\\s*\\)|IgnoreAntiforgeryToken\\]"
+    severity: warning
+    desc: "Anti-forgery token validation disabled — CSRF risk"
+
+
+  - id: SA-DOTNET-07
+    type: regex
+    target: "**/*.cs"
+    pattern: "DisableAutomaticKeyGeneration\\s*\\(\\s*\\)"
+    severity: warning
+    desc: "Data Protection automatic key generation disabled — keys will expire without rotation"
+
+
+  - id: SA-DOTNET-08
+    type: regex
+    target: "**/*.cs"
+    pattern: "class\\s+\\w+Hub\\s*:\\s*Hub\\b"
+    severity: warning
+    desc: "SignalR hub found — verify [Authorize] attribute is applied"
+
+
+  # === BLAZOR SECURITY CHECKS ===
+  - id: SA-BLAZOR-01
+    type: regex
+    target: "**/*.{razor,cs}"
+    pattern: "Http\\.\\w+Async\\s*\\(\\s*\"[^\"]*(?:admin|secret|internal|private|manage)"
+    severity: error
+    desc: "Blazor WASM calling sensitive API — verify server-side [Authorize] enforcement"
+
+
+  - id: SA-BLAZOR-02
+    type: regex
+    target: "**/*.{razor,cs}"
+    pattern: "(?:private|protected|public)\\s+string\\s+(?:creditCard|cvv|ssn|password|secret|token|apiKey)\\s*="
+    severity: warning
+    desc: "Sensitive data stored in Blazor component state — exposure via circuit or prerender"
+
+
+  - id: SA-BLAZOR-03
+    type: regex
+    target: "**/*.{razor,cs}"
+    pattern: "InvokeVoidAsync\\s*\\(\\s*\"eval\"|InvokeAsync\\s*\\(\\s*\"eval\""
+    severity: error
+    desc: "JS interop calling eval — injection risk from untrusted input"
+
+
+  - id: SA-BLAZOR-04
+    type: regex
+    target: "**/*.{razor,cs}"
+    pattern: "\\[Authorize\\][\\s\\S]{0,200}prerender\\s*:\\s*true"
+    severity: warning
+    desc: "[Authorize] with prerender enabled — auth state may not be available during prerender"
+
+
+  - id: SA-BLAZOR-05
+    type: regex
+    target: "**/*.{razor,cs}"
+    pattern: "OnInitializedAsync[\\s\\S]{0,300}(?:Sensitive|Secret|Private|Confidential|GetCredentials|GetTokens)"
+    severity: warning
+    desc: "Sensitive data loaded in OnInitializedAsync — may leak via prerendering"
+
+
+  # === DJANGO SECURITY ===
+  - id: SA-DJANGO-01
+    type: regex
+    target: "**/*.py"
+    pattern: "\\.raw\\s*\\(\\s*f[\"']|\\.raw\\s*\\(\\s*[\"'].*%s.*[\"']\\s*%|\\.extra\\s*\\(|cursor\\.execute\\s*\\(\\s*f[\"']|cursor\\.execute\\s*\\(\\s*[\"'].*%s.*[\"']\\s*%"
+    severity: error
+    desc: "Django ORM injection via raw(), extra(), or cursor.execute() with string interpolation"
+
+
+  - id: SA-DJANGO-02
+    type: regex
+    target: "**/*.py"
+    pattern: "@csrf_exempt|csrf_exempt\\s*\\(|decorators\\.csrf\\s+import\\s+csrf_exempt"
+    severity: error
+    desc: "CSRF protection disabled via @csrf_exempt decorator"
+
+
+  - id: SA-DJANGO-03
+    type: regex
+    target: "**/*.py"
+    pattern: "DEBUG\\s*=\\s*True"
+    severity: error
+    desc: "Django DEBUG=True — exposes tracebacks, SQL queries, and settings in production"
+
+
+  - id: SA-DJANGO-04
+    type: regex
+    target: "**/*.py"
+    pattern: "mark_safe\\s*\\(|\\.safestring\\s+import|safestring\\.mark_safe"
+    severity: error
+    desc: "XSS risk via mark_safe() — bypasses Django auto-escaping"
+
+
+  - id: SA-DJANGO-05
+    type: regex
+    target: "**/*.py"
+    pattern: "SECRET_KEY\\s*=\\s*[\"'][^\"']{8,}[\"']"
+    severity: error
+    desc: "Django SECRET_KEY hardcoded in source — enables session/token forgery if leaked"
+
+
+  - id: SA-DJANGO-06
+    type: regex
+    target: "**/*.py"
+    pattern: "PickleSerializer|SESSION_SERIALIZER.*[Pp]ickle"
+    severity: error
+    desc: "Pickle session serializer — enables RCE if SECRET_KEY is compromised"
+
+
+  - id: SA-DJANGO-07
+    type: regex
+    target: "**/*.py"
+    pattern: "path\\s*\\(\\s*[\"']admin/[\"']|url\\s*\\(\\s*r?\\s*[\"'].*admin/"
+    severity: warning
+    desc: "Django admin on default /admin/ URL — consider obscuring path and adding IP restrictions"
+
+
+  - id: SA-DJANGO-08
+    type: regex
+    target: "**/*.py"
+    pattern: "FileField\\s*\\(\\s*upload_to\\s*=\\s*[\"'][^\"']*[\"'](?:\\s*\\)|\\s*,\\s*\\))|request\\.FILES\\["
+    severity: warning
+    desc: "File upload without visible validation — verify size, type, and filename sanitization"
+
+
+  # === FLASK SECURITY ===
+  - id: SA-FLASK-01
+    type: regex
+    target: "**/*.py"
+    pattern: "render_template_string\\s*\\("
+    severity: error
+    desc: "Flask render_template_string() — potential SSTI if user input reaches template"
+
+
+  - id: SA-FLASK-02
+    type: regex
+    target: "**/*.py"
+    pattern: "request\\.args\\s*\\[|request\\.args\\.get\\s*\\(|request\\.form\\s*\\[|request\\.form\\.get\\s*\\(|request\\.values"
+    severity: warning
+    desc: "Flask request parameter access — verify input is validated before use"
+
+
+  - id: SA-FLASK-03
+    type: regex
+    target: "**/*.py"
+    pattern: "send_file\\s*\\(\\s*f[\"']|send_file\\s*\\(\\s*.*request\\.|send_file\\s*\\(\\s*os\\.path\\.join"
+    severity: error
+    desc: "Flask send_file() with dynamic path — potential path traversal"
+
+
+  - id: SA-FLASK-04
+    type: regex
+    target: "**/*.py"
+    pattern: "app\\.run\\s*\\(.*debug\\s*=\\s*True|\\.config\\s*\\[\\s*[\"']DEBUG[\"']\\s*\\]\\s*=\\s*True|FLASK_DEBUG\\s*=\\s*1"
+    severity: error
+    desc: "Flask debug=True — Werkzeug debugger enables arbitrary code execution"
+
+
+  - id: SA-FLASK-05
+    type: regex
+    target: "**/*.py"
+    pattern: "secret_key\\s*=\\s*[\"'][^\"']{1,30}[\"']|app\\.config\\s*\\[\\s*[\"']SECRET_KEY[\"']\\s*\\]\\s*=\\s*[\"']"
+    severity: error
+    desc: "Flask SECRET_KEY hardcoded or weak — enables session cookie forgery"
+
+
+  - id: SA-FLASK-06
+    type: regex
+    target: "**/*.py"
+    pattern: "db\\.session\\.execute\\s*\\(\\s*f[\"']|db\\.session\\.execute\\s*\\(\\s*[\"'].*%s.*[\"']\\s*%|db\\.engine\\.execute\\s*\\(\\s*f[\"']|\\.execute\\s*\\(\\s*f[\"']SELECT|\\.execute\\s*\\(\\s*f[\"']INSERT|\\.execute\\s*\\(\\s*f[\"']UPDATE|\\.execute\\s*\\(\\s*f[\"']DELETE"
+    severity: error
+    desc: "SQLAlchemy raw query with string interpolation — SQL injection risk"
+
+
+  # === FASTAPI SECURITY ===
+  - id: SA-FASTAPI-01
+    type: regex
+    target: "**/*.py"
+    pattern: "@app\\.(get|post|put|patch|delete)\\("
+    severity: warning
+    desc: "FastAPI endpoint without Depends() — verify authentication is not missing"
+
+
+  - id: SA-FASTAPI-02
+    type: regex
+    target: "**/*.py"
+    pattern: "def\\s+\\w+\\s*\\([^)]*:\\s*dict\\s*[,\\)]|:\\s*Any\\s*[,\\)=]|extra\\s*=\\s*[\"']allow[\"']"
+    severity: warning
+    desc: "Pydantic validation bypass via dict/Any type or extra='allow'"
+
+
+  - id: SA-FASTAPI-03
+    type: regex
+    target: "**/*.py"
+    pattern: "allow_origins\\s*=\\s*\\[\\s*[\"']\\*[\"']\\s*\\]|CORSMiddleware.*allow_origins.*\\*"
+    severity: error
+    desc: "FastAPI CORS wildcard origin — allows any domain to make cross-origin requests"
+
+
+  - id: SA-FASTAPI-04
+    type: regex
+    target: "**/*.py"
+    pattern: "response\\.headers\\s*\\[.*\\]\\s*=\\s*f[\"']|response\\.headers\\s*\\[.*\\]\\s*=.*request\\.|.headers\\s*\\[\\s*[\"']Set-Cookie[\"']\\s*\\]\\s*="
+    severity: warning
+    desc: "Response header set from user input — potential header injection"
+
+
+  - id: SA-FASTAPI-05
+    type: regex
+    target: "**/*.py"
+    pattern: "UploadFile.*filename|file\\.filename|shutil\\.copyfileobj\\s*\\(\\s*file"
+    severity: warning
+    desc: "FastAPI file upload — verify size limit, type validation, and filename sanitization"
+
+
+  - id: SA-FASTAPI-06
+    type: regex
+    target: "**/*.py"
+    pattern: "algorithms\\s*=\\s*\\[.*none.*\\]|jwt\\.decode\\s*\\(\\s*token\\s*,\\s*[^,]+\\s*\\)\\s*$|ACCESS_TOKEN_EXPIRE.*(?:525600|86400|43200)"
+    severity: error
+    desc: "OAuth2/JWT implementation issue — algorithm confusion, missing validation, or excessive expiry"
+
+
+  # === GIN (GO) SECURITY CHECKS ===
+  - id: SA-GIN-01
+    type: regex
+    target: "**/*.go"
+    pattern: "\\.Use\\(auth[A-Za-z]*\\("
+    severity: error
+    desc: "Auth middleware may be registered after routes — verify ordering"
+
+
+  - id: SA-GIN-02
+    type: regex
+    target: "**/*.go"
+    pattern: "c\\.(Bind|ShouldBind|ShouldBindJSON|BindJSON|ShouldBindQuery)\\s*\\("
+    severity: warning
+    desc: "Gin binding function — verify struct does not contain sensitive fields (mass assignment)"
+
+
+  - id: SA-GIN-03
+    type: regex
+    target: "**/*.go"
+    pattern: "template\\.HTML\\s*\\(|c\\.Data\\s*\\([^)]*\"text/html|c\\.Writer\\.WriteString\\s*\\("
+    severity: error
+    desc: "Raw HTML output bypassing template auto-escaping — potential XSS"
+
+
+  - id: SA-GIN-04
+    type: regex
+    target: "**/*.go"
+    pattern: "AllowAllOrigins\\s*:\\s*true|AllowOrigins\\s*:\\s*\\[\\s*\"\\*\"\\s*\\]|AllowOriginFunc\\s*:.*return\\s+true"
+    severity: error
+    desc: "CORS misconfiguration — wildcard or permissive origin policy"
+
+
+  - id: SA-GIN-05
+    type: regex
+    target: "**/*.go"
+    pattern: "c\\.(File|FileAttachment)\\s*\\([^)]*c\\.(Param|Query|PostForm)\\s*\\("
+    severity: error
+    desc: "User-controlled path in c.File/c.FileAttachment — path traversal risk"
+
+
+  - id: SA-GIN-06
+    type: regex
+    target: "**/*.go"
+    pattern: "gin\\.New\\s*\\(\\s*\\)"
+    severity: warning
+    desc: "gin.New() without default middleware — verify Recovery() is registered first"
+
+
+  # === RAILS SECURITY CHECKS ===
+  - id: SA-RAILS-01
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\.permit!|params\\[:[a-z_]+\\]\\.permit\\([^)]*(?:role|admin|superuser|permission)"
+    severity: error
+    desc: "Mass assignment — permit! or permitting sensitive fields"
+
+
+  - id: SA-RAILS-02
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\.html_safe|raw\\s*\\(|<%=="
+    severity: error
+    desc: "html_safe/raw/<%== bypasses Rails auto-escaping — XSS risk"
+
+
+  - id: SA-RAILS-03
+    type: regex
+    target: "**/*.rb"
+    pattern: "find_by_sql\\s*\\(.*#\\{|\\.where\\s*\\(.*#\\{|\\.order\\s*\\(\\s*params"
+    severity: error
+    desc: "String interpolation in SQL query — SQL injection risk"
+
+
+  - id: SA-RAILS-04
+    type: regex
+    target: "**/*.rb"
+    pattern: "skip_before_action\\s*:verify_authenticity_token|protect_from_forgery\\s+with:\\s*:null_session"
+    severity: error
+    desc: "CSRF protection disabled or misconfigured"
+
+
+  - id: SA-RAILS-05
+    type: regex
+    target: "**/*.rb"
+    pattern: "send_file\\s*.*params\\[|send_data\\s*.*filename:\\s*params\\["
+    severity: error
+    desc: "User-controlled path in send_file/send_data — path traversal risk"
+
+
+  - id: SA-RAILS-06
+    type: regex
+    target: "**/*.rb"
+    pattern: "render\\s+inline:\\s*.*params\\[|render\\s+inline:\\s*.*#\\{"
+    severity: error
+    desc: "User input in render inline: — server-side template injection"
+
+
+  - id: SA-RAILS-07
+    type: regex
+    target: "**/*.rb"
+    pattern: "has_one_attached\\s+:\\w+"
+    severity: warning
+    desc: "Active Storage attachment — verify content_type and size validation"
+
+
+  - id: SA-RAILS-08
+    type: regex
+    target: "**/*.rb"
+    pattern: "class\\s+\\w+Channel\\s*<\\s*ApplicationCable::Channel"
+    severity: warning
+    desc: "Action Cable channel — verify authentication in Connection and authorization in subscribed"
+
+
+  # === EXPRESS SECURITY CHECKS ===
+  - id: SA-EXPRESS-01
+    type: regex
+    target: "**/*.{js,ts}"
+    pattern: "app\\.(get|post|put|delete|use)\\s*\\([^)]*\\)[\\s\\S]*?app\\.use\\s*\\(\\s*helmet\\s*\\("
+    severity: error
+    desc: "Routes defined before helmet middleware — missing security headers"
+
+
+  - id: SA-EXPRESS-02
+    type: regex
+    target: "**/*.{js,ts}"
+    pattern: "execSync\\s*\\(.*req\\.(params|query|body)|exec\\s*\\(.*req\\.(params|query|body)"
+    severity: error
+    desc: "User input in shell command — command injection risk"
+
+
+  - id: SA-EXPRESS-03
+    type: regex
+    target: "**/*.{js,ts}"
+    pattern: "res\\.sendFile\\s*\\(\\s*(?:req\\.(params|query|body)|path\\.join\\s*\\([^)]*req\\.(params|query|body))"
+    severity: error
+    desc: "User-controlled path in res.sendFile — path traversal risk"
+
+
+  - id: SA-EXPRESS-04
+    type: regex
+    target: "**/*.{js,ts}"
+    pattern: "session\\s*\\(\\s*\\{[^}]*secret\\s*:\\s*['\"][^'\"]{0,20}['\"]|cookie\\s*:\\s*\\{[^}]*httpOnly\\s*:\\s*false|cookie\\s*:\\s*\\{[^}]*secure\\s*:\\s*false"
+    severity: error
+    desc: "Insecure session configuration — weak secret, missing httpOnly, or missing secure flag"
+
+
+  - id: SA-EXPRESS-05
+    type: regex
+    target: "**/*.{js,ts}"
+    pattern: "app\\.(post|put)\\s*\\(\\s*['\"\\/][^'\"]*(?:login|auth|token|password|register)[^'\"]*['\"]"
+    severity: warning
+    desc: "Auth endpoint — verify rate limiting is applied"
+
+
+  - id: SA-EXPRESS-06
+    type: regex
+    target: "**/*.{js,ts}"
+    pattern: "findByIdAndUpdate\\s*\\([^,]+,\\s*req\\.body\\s*\\)|\\.create\\s*\\(\\s*req\\.body\\s*\\)"
+    severity: warning
+    desc: "Passing req.body directly to database operation — mass assignment risk"
+
+
+  # === NESTJS SECURITY CHECKS ===
+  - id: SA-NEST-01
+    type: regex
+    target: "**/*.ts"
+    pattern: "@UseGuards\\s*\\(\\s*RolesGuard\\s*,\\s*AuthGuard\\s*\\)"
+    severity: error
+    desc: "RolesGuard before AuthGuard — authorization checked before authentication"
+
+
+  - id: SA-NEST-02
+    type: regex
+    target: "**/*.ts"
+    pattern: "new\\s+ValidationPipe\\s*\\(\\s*\\{[^}]*whitelist\\s*:\\s*false"
+    severity: error
+    desc: "ValidationPipe with whitelist:false — extra properties not stripped (mass assignment)"
+
+
+  - id: SA-NEST-03
+    type: regex
+    target: "**/*.ts"
+    pattern: "@Column\\s*\\(\\s*\\)\\s*\\n\\s*password\\s*:|@Column\\s*\\(\\s*\\)\\s*\\n\\s*(?:secret|token|hash|internal)"
+    severity: warning
+    desc: "Sensitive entity column without @Exclude — may be exposed in API responses"
+
+
+  - id: SA-NEST-04
+    type: regex
+    target: "**/*.ts"
+    pattern: "@Param\\s*\\(\\s*['\"][^'\"]+['\"]\\s*\\)\\s+\\w+\\s*:\\s*string"
+    severity: warning
+    desc: "Route parameter without ParseIntPipe/ParseUUIDPipe — type confusion risk"
+
+
+  - id: SA-NEST-05
+    type: regex
+    target: "**/*.ts"
+    pattern: "@Public\\s*\\(\\s*\\)\\s*\\n\\s*@(Delete|Put|Patch)\\s*\\(|@Public\\s*\\(\\s*\\)\\s*\\n\\s*@Controller"
+    severity: error
+    desc: "@Public on state-changing endpoint or entire controller — auth bypass"
+
+
+  - id: SA-NEST-06
+    type: regex
+    target: "**/*.ts"
+    pattern: "@WebSocketGateway\\s*\\("
+    severity: warning
+    desc: "WebSocket gateway — verify handleConnection authentication and message-level guards"
+
+
+  # === AWS SECURITY CHECKS ===
+  - id: SA-AWS-01
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "\"Action\"\\s*:\\s*\"\\*\"|\"Action\"\\s*:\\s*\\[\\s*\"\\*\"\\s*\\]"
+    severity: error
+    desc: "IAM policy with wildcard Action — grants unrestricted permissions"
+
+
+  - id: SA-AWS-02
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "\"Effect\"\\s*:\\s*\"Allow\"[^}]*\"Action\"\\s*:\\s*\"sts:AssumeRole\"(?![^}]*\"Condition\")"
+    severity: warning
+    desc: "AssumeRole without conditions — missing MFA, IP, or external ID restriction"
+
+
+  - id: SA-AWS-03
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "\"Principal\"\\s*:\\s*\\{\\s*\"AWS\"\\s*:\\s*\"\\*\"\\s*\\}|\"Principal\"\\s*:\\s*\"\\*\""
+    severity: error
+    desc: "Overly permissive trust policy — any principal can assume role"
+
+
+  - id: SA-AWS-04
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "\"Action\"\\s*:\\s*\"iam:PassRole\"[^}]*\"Resource\"\\s*:\\s*\"\\*\""
+    severity: error
+    desc: "iam:PassRole with wildcard resource — privilege escalation risk"
+
+
+  - id: SA-AWS-05
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "acl\\s*=\\s*\"public-read\"|acl\\s*=\\s*\"public-read-write\""
+    severity: error
+    desc: "S3 bucket with public ACL — data exposure risk"
+
+
+  - id: SA-AWS-06
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "block_public_acls\\s*=\\s*false|block_public_policy\\s*=\\s*false|restrict_public_buckets\\s*=\\s*false"
+    severity: error
+    desc: "S3 public access block disabled — bucket may become publicly accessible"
+
+
+  - id: SA-AWS-07
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "environment\\s*\\{[^}]*variables\\s*=\\s*\\{[^}]*(PASSWORD|SECRET|API_KEY|TOKEN|PRIVATE_KEY)\\s*=\\s*\"[^\"]+\""
+    severity: error
+    desc: "Lambda environment variable contains hardcoded secret"
+
+
+  - id: SA-AWS-08
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "policy_arn\\s*=\\s*\"arn:aws:iam::aws:policy/AdministratorAccess\"|policy_arn\\s*=\\s*\"arn:aws:iam::aws:policy/PowerUserAccess\""
+    severity: error
+    desc: "Lambda or role with AdministratorAccess/PowerUserAccess — overly permissive"
+
+
+  - id: SA-AWS-09
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "cidr_blocks\\s*=\\s*\\[\\s*\"0\\.0\\.0\\.0/0\"\\s*\\]|CidrIp:\\s*[\"']?0\\.0\\.0\\.0/0"
+    severity: error
+    desc: "Security group ingress open to 0.0.0.0/0 — unrestricted internet access"
+
+
+  - id: SA-AWS-10
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "enable_key_rotation\\s*=\\s*false"
+    severity: warning
+    desc: "KMS key rotation disabled — keys should be rotated automatically"
+
+
+  - id: SA-AWS-11
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "is_multi_region_trail\\s*=\\s*false|enable_log_file_validation\\s*=\\s*false"
+    severity: error
+    desc: "CloudTrail not multi-region or missing log validation"
+
+
+  - id: SA-AWS-12
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "password\\s*=\\s*\"[^\"]+\"|master_password\\s*=\\s*\"[^\"]+\""
+    severity: error
+    desc: "Hardcoded password in Terraform/CloudFormation — use Secrets Manager"
+
+
+  # === GCP SECURITY CHECKS ===
+  - id: SA-GCP-01
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "role\\s*=\\s*\"roles/(owner|editor)\"|\"roles/(owner|editor)\""
+    severity: error
+    desc: "GCP primitive role (Owner/Editor) — use granular predefined roles"
+
+
+  - id: SA-GCP-02
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "resource\\s+\"google_service_account_key\"|google_service_account_key\\s*\\{"
+    severity: error
+    desc: "Service account key file — use Workload Identity Federation instead"
+
+
+  - id: SA-GCP-03
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "\"allUsers\"|\"allAuthenticatedUsers\"|member\\s*=\\s*\"allUsers\"|member\\s*=\\s*\"allAuthenticatedUsers\""
+    severity: error
+    desc: "allUsers/allAuthenticatedUsers binding — public access to GCP resource"
+
+
+  - id: SA-GCP-04
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "google_storage_bucket_iam[^}]*(allUsers|allAuthenticatedUsers)|predefinedAcl:\\s*public"
+    severity: error
+    desc: "Public Cloud Storage bucket — data exposure risk"
+
+
+  - id: SA-GCP-05
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "uniform_bucket_level_access\\s*=\\s*false"
+    severity: warning
+    desc: "Uniform bucket-level access disabled — inconsistent ACLs possible"
+
+
+  - id: SA-GCP-06
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "environment_variables\\s*=\\s*\\{[^}]*(PASSWORD|SECRET|API_KEY|TOKEN|PRIVATE_KEY)\\s*=\\s*\"[^\"]+\""
+    severity: error
+    desc: "Cloud Functions environment variable contains hardcoded secret"
+
+
+  - id: SA-GCP-07
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "cloudfunctions\\.invoker[^}]*allUsers|allUsers[^}]*cloudfunctions\\.invoker"
+    severity: error
+    desc: "Cloud Function invocable by allUsers — unauthenticated access"
+
+
+  - id: SA-GCP-08
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "source_ranges\\s*=\\s*\\[\\s*\"0\\.0\\.0\\.0/0\"\\s*\\]|sourceRanges:[^}]*0\\.0\\.0\\.0/0"
+    severity: error
+    desc: "VPC firewall rule open to 0.0.0.0/0 — unrestricted internet ingress"
+
+
+  - id: SA-GCP-09
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "google_kms_crypto_key_iam[^}]*(allUsers|allAuthenticatedUsers)"
+    severity: error
+    desc: "KMS key accessible by allUsers — encryption key exposure"
+
+
+  - id: SA-GCP-10
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "exempted_members\\s*=\\s*\\["
+    severity: warning
+    desc: "Audit log exemptions configured — all access should be logged"
+
+
+  # === AZURE SECURITY CHECKS ===
+  - id: SA-AZURE-01
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "role_definition_name\\s*=\\s*\"(Owner|Contributor)\"|8e3af657-a8ff-443c-a75c-2fe8c4bcb635|b24988ac-6180-42a0-ab88-20f7382dd24c"
+    severity: error
+    desc: "Owner/Contributor role assignment — use least-privilege roles"
+
+
+  - id: SA-AZURE-02
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "role_definition_name\\s*=\\s*\"Storage Blob Data Owner\"(?![^}]*condition\\s*=)"
+    severity: warning
+    desc: "Storage Blob Data Owner without conditions — add ABAC conditions"
+
+
+  - id: SA-AZURE-03
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "allow_nested_items_to_be_public\\s*=\\s*true|allow_blob_public_access\\s*=\\s*true|allowBlobPublicAccess['\"]?\\s*[:=]\\s*['\"]?true|container_access_type\\s*=\\s*\"(blob|container)\""
+    severity: error
+    desc: "Public blob access enabled — anonymous access to storage data"
+
+
+  - id: SA-AZURE-04
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "authLevel[\"\\s]*[:=]\\s*[\"']?anonymous|\"authLevel\"\\s*:\\s*\"anonymous\""
+    severity: error
+    desc: "Azure Function with anonymous auth level — no authentication required"
+
+
+  - id: SA-AZURE-05
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "app_settings\\s*=\\s*\\{[^}]*(PASSWORD|SECRET|KEY|TOKEN|CONNECTION)\\s*=\\s*\"(?!@Microsoft\\.KeyVault)[^\"]+\""
+    severity: error
+    desc: "Hardcoded secret in Azure Function app settings — use Key Vault references"
+
+
+  - id: SA-AZURE-06
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "source_address_prefix\\s*=\\s*\"\\*\"|sourceAddressPrefix['\"]?\\s*[:=]\\s*['\"]\\*['\"]|\"sourceAddressPrefix\"\\s*:\\s*\"\\*\""
+    severity: error
+    desc: "NSG inbound rule open to * — unrestricted internet access"
+
+
+  - id: SA-AZURE-07
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "purge_protection_enabled\\s*=\\s*false|enablePurgeProtection:\\s*false|\"enablePurgeProtection\"\\s*:\\s*false"
+    severity: error
+    desc: "Key Vault missing purge protection — keys can be permanently deleted"
+
+
+  - id: SA-AZURE-08
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "enable_rbac_authorization\\s*=\\s*false|access_policy\\s*\\{"
+    severity: warning
+    desc: "Key Vault using access policies instead of RBAC — harder to audit"
+
+
+  - id: SA-AZURE-09
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "azurerm_monitor_diagnostic_setting"
+    severity: warning
+    desc: "Diagnostic setting present — verify all critical log categories are enabled"
+
+
+  - id: SA-AZURE-10
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "public_network_access_enabled\\s*=\\s*true|start_ip_address\\s*=\\s*\"0\\.0\\.0\\.0\""
+    severity: error
+    desc: "Azure SQL public network access or permissive firewall rule"
+
+
+  # === WORDPRESS SECURITY ===
+  - id: SA-WP-01
+    type: regex
+    target: "**/*.php"
+    pattern: "\\$wpdb\\s*->\\s*(query|get_results|get_row|get_var|get_col)\\s*\\(\\s*[\"']"
+    severity: error
+    desc: "$wpdb query without $wpdb->prepare() — SQL injection risk"
+
+
+  - id: SA-WP-02
+    type: regex
+    target: "**/*.php"
+    pattern: "unserialize\\s*\\(\\s*\\$_(GET|POST|REQUEST|COOKIE|SERVER)|unserialize\\s*\\(\\s*\\$"
+    severity: error
+    desc: "unserialize() with user-controlled input — object injection risk"
+
+
+  - id: SA-WP-03
+    type: regex
+    target: "**/*.php"
+    pattern: "echo\\s+\\$(?!.*esc_html|.*esc_attr|.*esc_url|.*wp_kses|.*absint|.*intval)"
+    severity: error
+    desc: "Unescaped output — use esc_html(), esc_attr(), esc_url(), or wp_kses()"
+
+
+  - id: SA-WP-04
+    type: regex
+    target: "**/*.php"
+    pattern: "register_rest_route\\s*\\([^)]*(?!permission_callback)[^)]*\\)|permission_callback.*__return_true"
+    severity: error
+    desc: "REST API route without permission_callback or with __return_true — unauthenticated access"
+
+
+  - id: SA-WP-05
+    type: regex
+    target: "**/*.php"
+    pattern: "update_option\\s*\\(|update_post_meta\\s*\\(|delete_option\\s*\\(|delete_post_meta\\s*\\("
+    severity: warning
+    desc: "Option/meta modification — verify current_user_can() and nonce checks are present"
+
+
+  - id: SA-WP-06
+    type: regex
+    target: "**/*.php"
+    pattern: "\\$_POST\\[.*\\]\\s*(?!.*wp_verify_nonce|.*check_ajax_referer|.*wp_nonce)"
+    severity: error
+    desc: "POST data processed without nonce verification — CSRF risk"
+
+
+  - id: SA-WP-07
+    type: regex
+    target: "**/*.php"
+    pattern: "move_uploaded_file\\s*\\(|\\$_FILES\\s*\\[.*\\]\\s*\\[.tmp_name.\\]"
+    severity: error
+    desc: "Direct file upload handling — use wp_handle_upload() with MIME validation"
+
+
+  - id: SA-WP-08
+    type: regex
+    target: "**/*.php"
+    pattern: "WP_DEBUG.*true|WP_DEBUG_DISPLAY.*true|DISALLOW_FILE_EDIT.*false"
+    severity: error
+    desc: "wp-config.php misconfiguration — debug enabled or file editing allowed in production"
+
+
+  - id: SA-WP-09
+    type: regex
+    target: "**/*.php"
+    pattern: "^<\\?php\\s*\\n(?!.*defined\\s*\\(\\s*['\"]ABSPATH['\"])"
+    severity: warning
+    desc: "PHP file missing defined('ABSPATH') check — direct file access possible"
+
+
+  - id: SA-WP-10
+    type: regex
+    target: "**/*.php"
+    pattern: "\\$table_prefix\\s*=\\s*['\"]wp_['\"]"
+    severity: warning
+    desc: "Default WordPress table prefix wp_ — makes targeted SQL injection easier"
+
+
+  # === DRUPAL SECURITY ===
+  - id: SA-DRUPAL-01
+    type: regex
+    target: "**/*.{php,module,install}"
+    pattern: "db_query\\s*\\(\\s*[\"'].*\\$|->query\\s*\\(\\s*[\"'].*\\$|sprintf\\s*\\(\\s*[\"']SELECT"
+    severity: error
+    desc: "Drupal database query with string interpolation — SQL injection risk"
+
+
+  - id: SA-DRUPAL-02
+    type: regex
+    target: "**/*.{php,module,install}"
+    pattern: "#markup.*\\$|#markup.*\\.\\s*\\$|#markup.*getRequest|#markup.*->get\\s*\\("
+    severity: error
+    desc: "Render array #markup with user input — XSS risk, use #plain_text or Html::escape()"
+
+
+  - id: SA-DRUPAL-03
+    type: regex
+    target: "**/*.{php,module,install}"
+    pattern: "['\"]#markup['\"]\\s*=>\\s*.*\\$(?!.*Html::escape|.*Xss::filter|.*check_plain|.*t\\()"
+    severity: error
+    desc: "Unescaped variable in #markup — XSS risk"
+
+
+  - id: SA-DRUPAL-04
+    type: regex
+    target: "**/*.{php,module,install}"
+    pattern: "->delete\\s*\\(\\s*\\)|->save\\s*\\(\\s*\\)"
+    severity: warning
+    desc: "Entity state change — verify Form API CSRF protection or _csrf_token route requirement"
+
+
+  - id: SA-DRUPAL-05
+    type: regex
+    target: "**/*.{php,module,install}"
+    pattern: "entityQuery\\s*\\([^)]*\\)(?!.*accessCheck)|->load\\s*\\(\\s*\\$"
+    severity: error
+    desc: "Entity query or load without access check — bypasses node/field access control"
+
+
+  - id: SA-DRUPAL-06
+    type: regex
+    target: "**/*.{php,module,install}"
+    pattern: "hash_salt.*=\\s*['\"]['\"]|error_level.*verbose|update_free_access.*TRUE"
+    severity: error
+    desc: "Drupal settings.php misconfiguration — empty hash_salt, verbose errors, or update access"
+
+
+  # === JOOMLA SECURITY ===
+  - id: SA-JOOMLA-01
+    type: regex
+    target: "**/*.php"
+    pattern: "->where\\s*\\(.*[\"'].*\\.\\s*\\$|setQuery\\s*\\(\\s*[\"'].*\\$|->where\\s*\\(\\s*[\"'].*\\$"
+    severity: error
+    desc: "Joomla database query with string concatenation — SQL injection risk"
+
+
+  - id: SA-JOOMLA-02
+    type: regex
+    target: "**/*.php"
+    pattern: "->get\\s*\\([^,)]+\\s*,\\s*[^,)]*\\s*,\\s*['\"]RAW['\"]|\\$_GET\\s*\\[|\\$_POST\\s*\\[|\\$_REQUEST\\s*\\["
+    severity: error
+    desc: "JInput RAW filter or direct superglobal access — unvalidated input"
+
+
+  - id: SA-JOOMLA-03
+    type: regex
+    target: "**/*.php"
+    pattern: "extends\\s+BaseController[^{]*\\{[^}]*function\\s+(delete|save|publish)"
+    severity: warning
+    desc: "Controller state-changing method — verify authorise() and checkToken() are present"
+
+
+  - id: SA-JOOMLA-04
+    type: regex
+    target: "**/*.php"
+    pattern: "\\$error_reporting\\s*=\\s*['\"]maximum['\"]|\\$debug\\s*=\\s*1|\\$secret\\s*=\\s*['\"]joomla['\"]"
+    severity: error
+    desc: "Joomla configuration.php misconfiguration — debug enabled or weak secret"
+
+
+  # === ANDROID SDK SECURITY ===
+  - id: SA-ANDROID-01
+    type: regex
+    target: "**/AndroidManifest.xml"
+    pattern: "android:exported\\s*=\\s*\"true\""
+    severity: warning
+    desc: "Exported component — verify intent-filter restrictions and permission guards"
+
+
+  - id: SA-ANDROID-02
+    type: regex
+    target: "**/*.{kt,java}"
+    pattern: "rawQuery\\s*\\(\\s*\"[^\"]*\\+\\s*\\w+|rawQuery\\s*\\(\\s*\"[^\"]*\\$\\{?"
+    severity: error
+    desc: "SQL injection in ContentProvider — use parameterized selectionArgs instead of concatenation"
+
+
+  - id: SA-ANDROID-03
+    type: regex
+    target: "**/*.{kt,java}"
+    pattern: "addJavascriptInterface\\s*\\("
+    severity: error
+    desc: "WebView JavaScript interface — verify API level >= 17 and restrict to trusted origins"
+
+
+  - id: SA-ANDROID-04
+    type: regex
+    target: "**/*.{kt,java}"
+    pattern: "getSharedPreferences\\s*\\([^)]*\\)[\\s\\S]{0,80}(password|token|secret|key|credential)|MODE_WORLD_READABLE"
+    severity: error
+    desc: "Sensitive data in SharedPreferences — use EncryptedSharedPreferences"
+
+
+  - id: SA-ANDROID-05
+    type: regex
+    target: "**/AndroidManifest.xml"
+    pattern: "usesCleartextTraffic\\s*=\\s*\"true\"|cleartextTrafficPermitted\\s*=\\s*\"true\""
+    severity: error
+    desc: "Cleartext traffic allowed — enforce HTTPS via NetworkSecurityConfig"
+
+
+  - id: SA-ANDROID-06
+    type: regex
+    target: "**/AndroidManifest.xml"
+    pattern: "android:debuggable\\s*=\\s*\"true\""
+    severity: error
+    desc: "Debug mode enabled in manifest — must be false for release builds"
+
+
+  - id: SA-ANDROID-07
+    type: regex
+    target: "**/*.{kt,java}"
+    pattern: "registerReceiver\\s*\\(\\s*\\w+\\s*,\\s*\\w+\\s*\\)\\s*$"
+    severity: warning
+    desc: "Broadcast receiver registered without permission — add permission parameter"
+
+
+  - id: SA-ANDROID-08
+    type: regex
+    target: "**/*.{kt,java}"
+    pattern: "new\\s+Random\\s*\\(|java\\.util\\.Random|kotlin\\.random\\.Random"
+    severity: warning
+    desc: "Insecure random number generator — use java.security.SecureRandom for tokens"
+
+
+  - id: SA-ANDROID-09
+    type: regex
+    target: "**/*.{kt,java}"
+    pattern: "SecretKeySpec\\s*\\(\\s*\"[^\"]+\"\\.toByteArray|private\\s+(static\\s+)?final\\s+byte\\[\\]\\s+\\w*(KEY|key|SECRET|secret)"
+    severity: error
+    desc: "Hardcoded encryption key — use Android Keystore for key management"
+
+
+  - id: SA-ANDROID-10
+    type: regex
+    target: "**/*.{kt,java}"
+    pattern: "Log\\.(d|v|i)\\s*\\(\\s*\"[^\"]*\"\\s*,\\s*[^)]*?(password|token|secret|key|credential|session)"
+    severity: warning
+    desc: "Sensitive data in log output — strip debug logs in release builds"
+
+
+  # === IOS SDK SECURITY ===
+  - id: SA-IOS-01
+    type: regex
+    target: "**/*.swift"
+    pattern: "kSecAttrAccessibleAlways[^T]|kSecAttrAccessibleAlways\\b(?!ThisDeviceOnly)"
+    severity: error
+    desc: "Insecure Keychain accessibility — use kSecAttrAccessibleWhenUnlockedThisDeviceOnly"
+
+
+  - id: SA-IOS-02
+    type: regex
+    target: "**/Info.plist"
+    pattern: "NSAllowsArbitraryLoads[\\s\\S]{0,30}<true"
+    severity: error
+    desc: "App Transport Security disabled — enforce HTTPS connections"
+
+
+  - id: SA-IOS-03
+    type: regex
+    target: "**/*.{swift,m}"
+    pattern: "UIWebView"
+    severity: error
+    desc: "Deprecated UIWebView usage — migrate to WKWebView"
+
+
+  - id: SA-IOS-04
+    type: regex
+    target: "**/*.{swift,m}"
+    pattern: "UIPasteboard\\.general\\.(string|setString|setItems|setValue)[\\s\\S]{0,60}(token|password|secret|key|credential|session)"
+    severity: warning
+    desc: "Sensitive data on general pasteboard — use UIPasteboard.withUniqueName()"
+
+
+  - id: SA-IOS-05
+    type: regex
+    target: "**/*.{swift,m}"
+    pattern: "UserDefaults\\.(standard\\.)?set\\s*\\([^,]+,\\s*forKey:\\s*\"(token|password|secret|key|credential|session|auth)|NSUserDefaults.*set(Object|Value).*forKey.*@\"(token|password|secret)"
+    severity: error
+    desc: "Sensitive data in UserDefaults/NSUserDefaults — use Keychain instead"
+
+
+  - id: SA-IOS-06
+    type: regex
+    target: "**/*.{swift,m}"
+    pattern: "application\\s*\\(\\s*_\\s+app.*open\\s+url:\\s*URL|openURL:\\s*\\(NSURL\\s*\\*\\)"
+    severity: warning
+    desc: "URL scheme handler — verify source app validation and parameter sanitization"
+
+
+  - id: SA-IOS-07
+    type: regex
+    target: "**/*.{swift,m}"
+    pattern: "arc4random\\s*\\(|arc4random_uniform\\s*\\([\\s\\S]{0,80}(token|key|secret|session|nonce)"
+    severity: error
+    desc: "Insecure random for security tokens — use SecRandomCopyBytes"
+
+
+  - id: SA-IOS-08
+    type: regex
+    target: "**/*.{swift,m}"
+    pattern: "CC_MD5\\s*\\(|CC_SHA1\\s*\\(|CC_MD5_DIGEST_LENGTH"
+    severity: warning
+    desc: "Weak hash algorithm (MD5/SHA-1) — use SHA-256 via CryptoKit"
+
+
+  - id: SA-IOS-09
+    type: regex
+    target: "**/*.pbxproj"
+    pattern: "GCC_GENERATE_POSITION_DEPENDENT_CODE\\s*=\\s*YES|CLANG_ENABLE_OBJC_ARC\\s*=\\s*NO"
+    severity: error
+    desc: "Missing binary protections (PIE/ARC) — enable in Xcode build settings"
+
+
+  - id: SA-IOS-10
+    type: regex
+    target: "**/*.{swift,m}"
+    pattern: "NSLog\\s*\\(\\s*@?\"[^\"]*%([@dfs])[^\"]*\"\\s*,\\s*[^)]*?(password|token|secret|key|credential|session)"
+    severity: warning
+    desc: "Sensitive data in NSLog — use os_log with .private annotation"
+

--- a/skills/security-audit/checkpoints.yaml
+++ b/skills/security-audit/checkpoints.yaml
@@ -516,6 +516,2228 @@ mechanical:
     severity: error
     desc: "Inline event handlers (on*= attributes) violate CSP. Use addEventListener() in external JavaScript files instead"
 
+  # === Imported from evandervecht/security-audit-skill fork (2026-04-19) ===
+  # Per-language, per-framework, cloud, mobile, and IaC checkpoints.
+  # Authored by E van der Vecht (MIT + CC-BY-SA-4.0 dual-licensed).
+  # Consumed by scripts/security-audit-dispatcher.sh and scripts/scanners/*.sh.
+
+  # === SECURITY DOCUMENTATION ===
+  # === SECRETS NOT IN VCS ===
+  # === COMPOSER AUDIT IN CI ===
+  # === XXE PREVENTION ===
+  # Use command type to avoid false positives from glob fallback to config files
+  # === SQL INJECTION PREVENTION ===
+  # === XSS PREVENTION ===
+  # Use command type to avoid false positives from glob fallback to config files
+  # === DEPENDABOT FOR SECURITY ===
+  # === DESERIALIZATION PREVENTION ===
+  # === INSECURE PASSWORD HASHING ===
+  # === COMMAND INJECTION ===
+  # === INSECURE RANDOMNESS ===
+  # === INFORMATION DISCLOSURE ===
+  # === FILE UPLOAD SAFETY ===
+  # === COOKIE SECURITY ===
+  # === OPEN REDIRECT ===
+  # === SECURITY HEADERS ===
+  # === CODE INJECTION (CWE-94) ===
+  # === IDOR (CWE-639) ===
+  # === SECRET SCANNING ===
+  # === SUPPLY CHAIN ===
+  # === TYPE JUGGLING (CWE-843) ===
+  # === PHAR DESERIALIZATION (CWE-502) ===
+  # === SSTI (CWE-1336) ===
+  # === EMAIL HEADER INJECTION (CWE-93) ===
+  # === LDAP INJECTION (CWE-90) ===
+  # === INSECURE TOKEN GENERATION (CWE-330) ===
+  # === LOG INJECTION / CRLF (CWE-117) ===
+  # === SESSION FIXATION (CWE-384) ===
+  # === HOST HEADER POISONING (CWE-644) ===
+  # === MASS ASSIGNMENT (CWE-915) ===
+  # === SAST TOOLING ===
+  # === DEPENDENCY SCANNING ===
+  # === GITLEAKS IN CI ===
+  # === PATH TRAVERSAL PREVENTION (CWE-22) ===
+  # === SEMGREP IN CI ===
+  # === SECURITY POLICY ===
+  # === INFRASTRUCTURE-AS-CODE SECURITY ===
+  - id: SA-IAC-01
+    type: command
+    target: "for f in Dockerfile*; do [ -f \"$f\" ] || continue; grep -qE '^\\s*USER\\s' \"$f\" || exit 1; ! grep -qE '^\\s*USER\\s+root\\b' \"$f\" || exit 1; done"
+    severity: warning
+    desc: "Dockerfile must declare a non-root USER directive (missing USER means container runs as root)"
+
+  - id: SA-IAC-02
+    type: command
+    target: "! grep -rqE '(COPY|ADD).*\\.env' Dockerfile* 2>/dev/null"
+    severity: error
+    desc: "Dockerfile must not copy .env files into image layers (secrets leak)"
+
+  - id: SA-IAC-03
+    type: command
+    target: "! grep -rqE 'ARG.*(PASSWORD|SECRET|TOKEN|API_KEY)' Dockerfile* 2>/dev/null"
+    severity: error
+    desc: "Dockerfile ARG must not contain secrets (visible in image history)"
+
+  - id: SA-IAC-04
+    type: command
+    target: "! grep -rqE '^FROM\\s+\\w+\\s*$' Dockerfile* 2>/dev/null"
+    severity: warning
+    desc: "Dockerfile base images should be pinned to specific tags or digests, not latest"
+
+  - id: SA-IAC-05
+    type: command
+    target: "! grep -rqE 'privileged:\\s*true' docker-compose*.yml 2>/dev/null"
+    severity: error
+    desc: "Docker Compose must not use privileged mode (container escape risk)"
+
+  - id: SA-IAC-06
+    type: command
+    target: "! grep -rqE '/var/run/docker\\.sock' docker-compose*.yml 2>/dev/null"
+    severity: error
+    desc: "Docker Compose must not mount Docker socket (container escape risk)"
+
+  - id: SA-IAC-07
+    type: command
+    target: "! grep -rqE 'runAsUser:\\s*0' k8s/ kubernetes/ deploy/ manifests/ charts/ 2>/dev/null"
+    severity: error
+    desc: "Kubernetes pods must not run as root (runAsUser: 0)"
+
+  - id: SA-IAC-08
+    type: command
+    target: "! grep -rqE 'hostNetwork:\\s*true' k8s/ kubernetes/ deploy/ manifests/ charts/ 2>/dev/null"
+    severity: error
+    desc: "Kubernetes pods should not use host networking"
+
+  - id: SA-IAC-09
+    type: command
+    target: "! grep -rqE 'cidr_blocks.*0\\.0\\.0\\.0/0' --include='*.tf' . 2>/dev/null"
+    severity: warning
+    desc: "Terraform security groups should not allow unrestricted ingress (0.0.0.0/0)"
+
+  - id: SA-IAC-10
+    type: command
+    target: "! grep -rqE 'acl.*public' --include='*.tf' . 2>/dev/null"
+    severity: warning
+    desc: "Terraform S3 buckets should not use public ACLs"
+
+  # === FRONTEND/CLIENT-SIDE SECURITY ===
+  - id: SA-FE-01
+    type: not_contains
+    target: "**/*.js"
+    pattern: ".innerHTML ="
+    severity: warning
+    desc: "Direct innerHTML assignment may enable DOM-based XSS - use textContent or sanitize"
+
+  - id: SA-FE-02
+    type: not_contains
+    target: "**/*.js"
+    pattern: "document.write("
+    severity: warning
+    desc: "document.write() may enable DOM-based XSS - use DOM manipulation methods"
+
+  - id: SA-FE-03
+    type: command
+    target: "! grep -rqE 'eval\\s*\\(' --include='*.js' --include='*.ts' . 2>/dev/null"
+    severity: warning
+    desc: "eval() in JavaScript enables code injection - use safer alternatives"
+
+  - id: SA-FE-04
+    type: command
+    target: "! grep -rqE 'localStorage\\.(set|get)Item.*(token|password|secret|key|credential|session)' --include='*.js' --include='*.ts' . 2>/dev/null"
+    severity: error
+    desc: "Sensitive data (tokens, passwords, secrets) must not be stored in localStorage"
+
+  - id: SA-FE-05
+    type: command
+    target: "! grep -rqE 'Access-Control-Allow-Origin.*\\*' --include='*.php' --include='*.js' --include='*.conf' --include='*.yaml' --include='*.yml' . 2>/dev/null"
+    severity: warning
+    desc: "CORS wildcard (*) origin should be avoided - use specific allowed origins"
+
+  - id: SA-FE-06
+    type: command
+    target: "! grep -rqE 'new Function\\s*\\(' --include='*.js' --include='*.ts' . 2>/dev/null"
+    severity: warning
+    desc: "new Function() enables dynamic code execution - use safer alternatives"
+
+  # === AI/LLM AGENT SECURITY ===
+  - id: SA-AI-01
+    type: command
+    target: "! grep -rqE '(api_key|apiKey|API_KEY|secret|password|token)\\s*[:=]\\s*[\"'\\''](sk-|AKIA|ghp_|ghs_)' SKILL.md AGENTS.md CLAUDE.md .claude/ 2>/dev/null"
+    severity: error
+    desc: "AI agent config files must not contain hardcoded API keys or secrets"
+
+  - id: SA-AI-02
+    type: command
+    target: "! grep -rqE 'dangerouslyDisableSandbox|--no-verify|--force' SKILL.md AGENTS.md CLAUDE.md .claude/ 2>/dev/null"
+    severity: error
+    desc: "AI agent configs must not disable safety mechanisms (sandbox, hooks, verification)"
+
+  - id: SA-AI-03
+    type: command
+    target: "! grep -rqE 'Bash\\(\\*\\)|allowed-tools:.*Bash\\b[^(]' SKILL.md skills/*/SKILL.md 2>/dev/null"
+    severity: warning
+    desc: "AI skills should not grant unrestricted Bash access - scope to specific commands"
+
+  - id: SA-AI-04
+    type: command
+    target: "! grep -rqE '\"version\"\\s*:\\s*\"latest\"' .claude/mcp*.json mcp.json 2>/dev/null"
+    severity: warning
+    desc: "MCP server versions should be pinned, not 'latest' (supply chain risk)"
+
+  # === JAVASCRIPT/TYPESCRIPT SECURITY ===
+  - id: SA-JS-01
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "eval\\("
+    severity: error
+    desc: "eval() usage detected - potential code injection"
+
+  - id: SA-JS-02
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "\\.innerHTML\\s*="
+    severity: error
+    desc: "innerHTML assignment detected - potential DOM XSS"
+
+  - id: SA-JS-03
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "document\\.write\\("
+    severity: error
+    desc: "document.write() usage detected - potential DOM XSS"
+
+  - id: SA-JS-04
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "addEventListener\\(.message"
+    severity: warning
+    desc: "postMessage handler detected - verify origin validation"
+
+  - id: SA-JS-05
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "Math\\.random\\(\\)"
+    severity: warning
+    desc: "Math.random() is not cryptographically secure - use crypto.getRandomValues()"
+
+  - id: SA-JS-06
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "__proto__"
+    severity: error
+    desc: "__proto__ access detected - potential prototype pollution"
+
+  - id: SA-JS-07
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "new\\s+Function\\("
+    severity: error
+    desc: "Function constructor detected - equivalent to eval()"
+
+  - id: SA-JS-08
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "setTimeout\\(\\s*['\"`]"
+    severity: error
+    desc: "setTimeout with string argument - implicit eval()"
+
+  - id: SA-JS-09
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "\\.outerHTML\\s*="
+    severity: error
+    desc: "outerHTML assignment detected - potential DOM XSS"
+
+  - id: SA-JS-10
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "\\bdebugger\\b"
+    severity: warning
+    desc: "debugger statement detected - must not ship to production"
+
+  - id: SA-JS-11
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "require\\(.serialize-javascript"
+    severity: warning
+    desc: "serialize-javascript outputs executable JS - ensure output is never eval'd"
+
+  - id: SA-JS-12
+    type: regex
+    target: "**/*.{ts,tsx}"
+    pattern: ":\\s*any\\b"
+    severity: warning
+    desc: "TypeScript 'any' type disables type checking - use 'unknown' for untrusted input"
+
+  - id: SA-JS-13
+    type: regex
+    target: "**/*.{ts,tsx}"
+    pattern: "as\\s+unknown\\s+as"
+    severity: error
+    desc: "Double type assertion bypasses TypeScript safety - use runtime validation"
+
+  - id: SA-JS-14
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "import\\([^)]*\\$\\{"
+    severity: error
+    desc: "Dynamic import with template variable - potential module injection"
+
+  - id: SA-JS-15
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "setInterval\\(\\s*['\"`]"
+    severity: error
+    desc: "setInterval with string argument - implicit eval()"
+
+  - id: SA-JS-17
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "postMessage\\([^,]+,\\s*['\"]\\*['\"]"
+    severity: error
+    desc: "postMessage with wildcard origin - data exposed to any frame"
+
+  # === NODE.JS SERVER-SIDE SECURITY (Phase 3) ===
+  - id: SA-NODE-01
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "child_process.*exec\\("
+    severity: error
+    desc: "child_process.exec() with potential command injection — use execFile or spawn instead"
+
+  - id: SA-NODE-02
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "fs\\.(readFile|writeFile|readdir|unlink).*req\\.(query|params|body)"
+    severity: error
+    desc: "fs operation with user input — validate and restrict paths with path.resolve + startsWith"
+
+  - id: SA-NODE-03
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "require\\s*\\(\\s*['\"]vm2?['\"]\\s*\\)"
+    severity: error
+    desc: "vm/vm2 module is not a security boundary — use OS-level isolation for untrusted code"
+
+  - id: SA-NODE-04
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "Buffer\\.(allocUnsafe|allocUnsafeSlow)\\s*\\("
+    severity: warning
+    desc: "Buffer.allocUnsafe returns uninitialized memory — use Buffer.alloc unless fully overwritten"
+
+  - id: SA-NODE-05
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "require\\s*\\(\\s*[^'\"\\s].*[+`]"
+    severity: error
+    desc: "Dynamic require() with variable path — use an allowlist of permitted modules"
+
+  - id: SA-NODE-06
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "(hashSync|compareSync|pbkdf2Sync|scryptSync)\\s*\\("
+    severity: warning
+    desc: "Synchronous crypto in request handler blocks event loop — use async variant"
+
+  - id: SA-NODE-07
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "res\\.(setHeader|writeHead)\\s*\\([^)]*req\\.(query|params|body|headers)"
+    severity: error
+    desc: "User input in HTTP response header — risk of CRLF injection"
+
+  - id: SA-NODE-08
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "Math\\.random\\s*\\("
+    severity: warning
+    desc: "Math.random() is not cryptographically secure — use crypto.randomUUID() or crypto.randomBytes()"
+
+  - id: SA-NODE-09
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "http\\.createServer\\s*\\("
+    severity: warning
+    desc: "http.createServer — verify headersTimeout, requestTimeout, and body size limits are set"
+
+  - id: SA-NODE-10
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "Object\\.assign\\s*\\([^,]+,\\s*req\\.(body|query|params)"
+    severity: error
+    desc: "Object.assign with user input — risk of prototype pollution"
+
+  - id: SA-NODE-11
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "\\beval\\s*\\("
+    severity: error
+    desc: "eval() executes arbitrary code — use safe alternatives"
+
+  - id: SA-NODE-12
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "createHash\\s*\\(\\s*['\"]md5['\"]"
+    severity: warning
+    desc: "MD5 is cryptographically broken — use SHA-256 or stronger"
+
+  - id: SA-NODE-13
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "createHash\\s*\\(\\s*['\"]sha1['\"]"
+    severity: warning
+    desc: "SHA-1 is cryptographically weak — use SHA-256 or stronger"
+
+  - id: SA-NODE-14
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "new\\s+Function\\s*\\("
+    severity: error
+    desc: "new Function() is equivalent to eval — use safe alternatives"
+
+  - id: SA-NODE-15
+    type: regex
+    target: "**/*.{js,ts,mjs,cjs}"
+    pattern: "fetch\\s*\\(\\s*req\\.(query|params|body)"
+    severity: error
+    desc: "fetch with user-supplied URL — risk of SSRF, validate and restrict URLs"
+
+  # === PYTHON SECURITY CHECKS (Phase 4) ===
+  - id: SA-PY-01
+    type: regex
+    target: "**/*.py"
+    pattern: "pickle\\.(loads|load)\\("
+    severity: error
+    desc: "Insecure deserialization via pickle"
+
+  - id: SA-PY-02
+    type: regex
+    target: "**/*.py"
+    pattern: "eval\\("
+    severity: error
+    desc: "Code injection via eval()"
+
+  - id: SA-PY-03
+    type: regex
+    target: "**/*.py"
+    pattern: "exec\\("
+    severity: error
+    desc: "Code injection via exec()"
+
+  - id: SA-PY-04
+    type: regex
+    target: "**/*.py"
+    pattern: "subprocess\\.\\w+\\(.*shell\\s*=\\s*True"
+    severity: error
+    desc: "Command injection via subprocess with shell=True"
+
+  - id: SA-PY-05
+    type: regex
+    target: "**/*.py"
+    pattern: "os\\.system\\("
+    severity: error
+    desc: "Command injection via os.system()"
+
+  - id: SA-PY-06
+    type: regex
+    target: "**/*.py"
+    pattern: "yaml\\.load\\("
+    severity: error
+    desc: "Unsafe YAML loading — use yaml.safe_load() instead"
+
+  - id: SA-PY-07
+    type: regex
+    target: "**/*.py"
+    pattern: "execute\\(f\""
+    severity: error
+    desc: "SQL injection via f-string in query"
+
+  - id: SA-PY-08
+    type: regex
+    target: "**/*.py"
+    pattern: "execute\\(.*\\.format\\("
+    severity: error
+    desc: "SQL injection via .format() in query"
+
+  - id: SA-PY-09
+    type: regex
+    target: "**/*.py"
+    pattern: "hashlib\\.md5\\("
+    severity: warning
+    desc: "Weak hash algorithm MD5 — use SHA-256+ or argon2 for passwords"
+
+  - id: SA-PY-10
+    type: regex
+    target: "**/*.py"
+    pattern: "hashlib\\.sha1\\("
+    severity: warning
+    desc: "Weak hash algorithm SHA1 — use SHA-256+ for integrity checks"
+
+  - id: SA-PY-11
+    type: regex
+    target: "**/*.py"
+    pattern: "tempfile\\.mktemp\\("
+    severity: error
+    desc: "Deprecated tempfile.mktemp() has race condition — use mkstemp()"
+
+  - id: SA-PY-12
+    type: regex
+    target: "**/*.py"
+    pattern: "__import__\\("
+    severity: warning
+    desc: "Dynamic import via __import__() — validate module names against a whitelist"
+
+  - id: SA-PY-13
+    type: regex
+    target: "**/*.py"
+    pattern: "xml\\.etree\\.ElementTree"
+    severity: warning
+    desc: "Standard library XML parser — use defusedxml to prevent XXE attacks"
+
+  - id: SA-PY-14
+    type: regex
+    target: "**/*.py"
+    pattern: "Template\\s*\\(.*\\w+.*\\)"
+    severity: warning
+    desc: "Jinja2/Mako Template with variable input — risk of SSTI"
+
+  - id: SA-PY-15
+    type: regex
+    target: "**/*.py"
+    pattern: "os\\.popen\\("
+    severity: error
+    desc: "Command injection via os.popen()"
+
+  - id: SA-PY-16
+    type: regex
+    target: "**/*.py"
+    pattern: "compile\\(.*,.*,"
+    severity: warning
+    desc: "compile() with dynamic input — risk of code injection"
+
+  - id: SA-PY-17
+    type: regex
+    target: "**/*.py"
+    pattern: "shelve\\.open\\("
+    severity: warning
+    desc: "shelve uses pickle internally — insecure deserialization risk"
+
+  - id: SA-PY-18
+    type: regex
+    target: "**/*.py"
+    pattern: "marshal\\.loads\\("
+    severity: warning
+    desc: "Insecure deserialization via marshal"
+
+  # === RUBY SECURITY CHECKS (Phase 4) ===
+  - id: SA-RB-01
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\beval\\s*\\("
+    severity: error
+    desc: "eval() usage — potential code injection"
+
+  - id: SA-RB-02
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\.send\\s*\\("
+    severity: warning
+    desc: "send() with dynamic method — potential method injection"
+
+  - id: SA-RB-03
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\bsystem\\s*\\("
+    severity: warning
+    desc: "system() call — verify no user input in command string"
+
+  - id: SA-RB-04
+    type: regex
+    target: "**/*.rb"
+    pattern: "Marshal\\.load\\s*\\("
+    severity: error
+    desc: "Marshal.load — insecure deserialization of untrusted data"
+
+  - id: SA-RB-05
+    type: regex
+    target: "**/*.rb"
+    pattern: "YAML\\.load\\s*\\("
+    severity: error
+    desc: "YAML.load without safe_load — insecure deserialization risk"
+
+  - id: SA-RB-06
+    type: regex
+    target: "**/*.rb"
+    pattern: "ERB\\.new\\s*\\("
+    severity: warning
+    desc: "ERB.new — audit for template injection with user input"
+
+  - id: SA-RB-07
+    type: regex
+    target: "**/*.rb"
+    pattern: "find_by_sql\\s*\\("
+    severity: error
+    desc: "find_by_sql — risk of SQL injection with string interpolation"
+
+  - id: SA-RB-08
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\.html_safe\\b"
+    severity: warning
+    desc: "html_safe bypasses Rails XSS escaping — audit for user input"
+
+  - id: SA-RB-09
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\braw\\s*\\("
+    severity: warning
+    desc: "raw() bypasses Rails XSS escaping — audit for user input"
+
+  - id: SA-RB-10
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\bKernel\\.open\\s*\\("
+    severity: error
+    desc: "Kernel.open — pipe injection and SSRF risk with user input"
+
+  - id: SA-RB-11
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\.permit!\\b"
+    severity: error
+    desc: "permit! allows all params — mass assignment vulnerability"
+
+  - id: SA-RB-12
+    type: regex
+    target: "**/*.rb"
+    pattern: "Digest::MD5"
+    severity: warning
+    desc: "MD5 is cryptographically broken — use SHA-256 or bcrypt"
+
+  - id: SA-RB-13
+    type: regex
+    target: "**/*.rb"
+    pattern: "Digest::SHA1"
+    severity: warning
+    desc: "SHA-1 is cryptographically weak — use SHA-256 or stronger"
+
+  - id: SA-RB-14
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\bexec\\s*\\("
+    severity: warning
+    desc: "exec() call — verify no user input in command string"
+
+  - id: SA-RB-15
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\bopen\\s*\\(\\s*[\"']\\|"
+    severity: error
+    desc: "open() with pipe prefix — direct command execution"
+
+  # === JAVA SECURITY CHECKS (Phase 2) ===
+  - id: SA-JAVA-01
+    type: regex
+    target: "**/*.java"
+    pattern: "new\\s+ObjectInputStream\\s*\\("
+    severity: error
+    desc: "ObjectInputStream deserialization — risk of RCE via gadget chains"
+
+  - id: SA-JAVA-02
+    type: regex
+    target: "**/*.java"
+    pattern: "new\\s+XMLDecoder\\s*\\("
+    severity: error
+    desc: "XMLDecoder deserialization — enables arbitrary code execution"
+
+  - id: SA-JAVA-03
+    type: regex
+    target: "**/*.java"
+    pattern: "InitialContext\\s*\\(\\s*\\)[\\s\\S]{0,100}\\.lookup\\s*\\("
+    severity: error
+    desc: "JNDI lookup — risk of remote class loading (Log4Shell pattern)"
+
+  - id: SA-JAVA-04
+    type: regex
+    target: "**/*.java"
+    pattern: "Class\\.forName\\s*\\("
+    severity: warning
+    desc: "Reflection via Class.forName — risk of arbitrary class instantiation"
+
+  - id: SA-JAVA-05
+    type: regex
+    target: "**/*.java"
+    pattern: "(createStatement|executeQuery|executeUpdate)\\s*\\([^)]*\\+"
+    severity: error
+    desc: "JDBC string concatenation — SQL injection risk, use PreparedStatement"
+
+  - id: SA-JAVA-06
+    type: regex
+    target: "**/*.java"
+    pattern: "DocumentBuilderFactory\\.newInstance\\s*\\("
+    severity: warning
+    desc: "XML parsing without explicit XXE protection — disable external entities"
+
+  - id: SA-JAVA-07
+    type: regex
+    target: "**/*.java"
+    pattern: "Runtime\\.getRuntime\\s*\\(\\s*\\)\\.exec\\s*\\("
+    severity: error
+    desc: "Runtime.exec — command injection risk, use ProcessBuilder with array args"
+
+  - id: SA-JAVA-08
+    type: regex
+    target: "**/*.java"
+    pattern: "getInstance\\s*\\(\\s*\"(MD5|SHA-1)\"\\s*\\)"
+    severity: warning
+    desc: "Weak hash algorithm (MD5/SHA-1) — use SHA-256 or stronger"
+
+  - id: SA-JAVA-09
+    type: regex
+    target: "**/*.java"
+    pattern: "new\\s+Random\\s*\\("
+    severity: warning
+    desc: "java.util.Random is predictable — use SecureRandom for security operations"
+
+  - id: SA-JAVA-10
+    type: regex
+    target: "**/*.java"
+    pattern: "Cipher\\.getInstance\\s*\\(\\s*\"(DES|.*ECB)"
+    severity: error
+    desc: "Weak cipher (DES/ECB) — use AES-GCM for authenticated encryption"
+
+  - id: SA-JAVA-11
+    type: regex
+    target: "**/*.java"
+    pattern: "(openConnection|openStream)\\s*\\(\\s*\\)"
+    severity: warning
+    desc: "URL.openConnection/openStream — SSRF risk, validate and restrict URLs"
+
+  - id: SA-JAVA-12
+    type: regex
+    target: "**/*.java"
+    pattern: "new\\s+File\\s*\\(\\s*[^)]*\\+\\s*(request|req|param|input|args)"
+    severity: warning
+    desc: "File path from user input — path traversal risk, validate canonical path"
+
+  # === C# SECURITY CHECKS (Phase 2) ===
+  - id: SA-CS-01
+    type: regex
+    target: "**/*.cs"
+    pattern: "new\\s+BinaryFormatter\\s*\\("
+    severity: error
+    desc: "BinaryFormatter deserialization — RCE risk, use System.Text.Json"
+
+  - id: SA-CS-02
+    type: regex
+    target: "**/*.cs"
+    pattern: "new\\s+NetDataContractSerializer\\s*\\("
+    severity: error
+    desc: "NetDataContractSerializer — insecure deserialization with type embedding"
+
+  - id: SA-CS-03
+    type: regex
+    target: "**/*.cs"
+    pattern: "FromSqlRaw\\s*\\(\\s*\\$"
+    severity: error
+    desc: "FromSqlRaw with interpolation — SQL injection, use FromSqlInterpolated"
+
+  - id: SA-CS-04
+    type: regex
+    target: "**/*.cs"
+    pattern: "new\\s+XmlDocument\\s*\\("
+    severity: warning
+    desc: "XmlDocument — set XmlResolver=null and disable DTD processing"
+
+  - id: SA-CS-05
+    type: regex
+    target: "**/*.cs"
+    pattern: "Process\\.Start\\s*\\("
+    severity: warning
+    desc: "Process.Start — command injection risk, set UseShellExecute=false"
+
+  - id: SA-CS-06
+    type: regex
+    target: "**/*.cs"
+    pattern: "MD5\\.Create\\s*\\("
+    severity: warning
+    desc: "MD5 is cryptographically broken — use SHA256 or stronger"
+
+  - id: SA-CS-07
+    type: regex
+    target: "**/*.cs"
+    pattern: "SHA1\\.Create\\s*\\("
+    severity: warning
+    desc: "SHA-1 is cryptographically weak — use SHA256 or stronger"
+
+  - id: SA-CS-08
+    type: regex
+    target: "**/*.cs"
+    pattern: "new\\s+Random\\s*\\("
+    severity: warning
+    desc: "System.Random is predictable — use RandomNumberGenerator for security"
+
+  - id: SA-CS-09
+    type: regex
+    target: "**/*.cs"
+    pattern: "DESCryptoServiceProvider"
+    severity: error
+    desc: "DES is broken (56-bit key) — use AES-GCM"
+
+  - id: SA-CS-10
+    type: regex
+    target: "**/*.cs"
+    pattern: "AllowAnyOrigin\\s*\\("
+    severity: error
+    desc: "CORS AllowAnyOrigin — use explicit origin allowlist"
+
+  - id: SA-CS-11
+    type: regex
+    target: "**/*.cs"
+    pattern: "DirectorySearcher\\s*\\(\\s*\\$"
+    severity: error
+    desc: "LDAP injection via DirectorySearcher with interpolation"
+
+  - id: SA-CS-12
+    type: regex
+    target: "**/*.cs"
+    pattern: "UseShellExecute\\s*=\\s*true"
+    severity: warning
+    desc: "UseShellExecute=true passes args through shell — set to false"
+
+  # === GO SECURITY CHECKS ===
+  - id: SA-GO-01
+    type: regex
+    target: "**/*.go"
+    pattern: "unsafe\\.(Pointer|Sizeof|Slice|String|Offsetof|Alignof)"
+    severity: warning
+    desc: "unsafe package usage — bypasses Go memory safety, audit required"
+
+  - id: SA-GO-02
+    type: regex
+    target: "**/*.go"
+    pattern: "\"text/template\""
+    severity: error
+    desc: "text/template does not escape HTML — use html/template for web output"
+
+  - id: SA-GO-03
+    type: regex
+    target: "**/*.go"
+    pattern: "(Sprintf|\"\\s*\\+).*(SELECT|INSERT|UPDATE|DELETE|select|insert|update|delete)"
+    severity: error
+    desc: "SQL string concatenation — use parameterized queries"
+
+  - id: SA-GO-04
+    type: regex
+    target: "**/*.go"
+    pattern: "exec\\.Command\\s*\\(\\s*\"(sh|bash|cmd|powershell)\""
+    severity: error
+    desc: "Shell invocation via exec.Command — risk of command injection"
+
+  - id: SA-GO-05
+    type: regex
+    target: "**/*.go"
+    pattern: "filepath\\.Join\\s*\\(.*\\b(r\\.|req\\.|request\\.|URL)"
+    severity: warning
+    desc: "filepath.Join with user input — validate resolved path stays within base"
+
+  - id: SA-GO-06
+    type: regex
+    target: "**/*.go"
+    pattern: "InsecureSkipVerify\\s*:\\s*true"
+    severity: error
+    desc: "TLS certificate verification disabled — enables MITM attacks"
+
+  - id: SA-GO-07
+    type: regex
+    target: "**/*.go"
+    pattern: "\"math/rand\""
+    severity: warning
+    desc: "math/rand is not cryptographically secure — use crypto/rand for secrets"
+
+  - id: SA-GO-08
+    type: regex
+    target: "**/*.go"
+    pattern: "http\\.(Get|Post|Head)\\s*\\(.*\\b(r\\.|req\\.|request\\.|URL)"
+    severity: error
+    desc: "HTTP request with user-controlled URL — SSRF risk"
+
+  - id: SA-GO-09
+    type: regex
+    target: "**/*.go"
+    pattern: "log\\.(Print|Fatal|Panic)(f|ln)?\\s*\\("
+    severity: warning
+    desc: "Unstructured logging — use log/slog for security event logging"
+
+  - id: SA-GO-10
+    type: regex
+    target: "**/*.go"
+    pattern: "Header\\(\\)\\.Set\\s*\\(.*\\b(r\\.|req\\.)"
+    severity: warning
+    desc: "HTTP header set with request data — risk of header injection"
+
+  - id: SA-GO-11
+    type: regex
+    target: "**/*.go"
+    pattern: "VersionTLS1[01]\\b"
+    severity: error
+    desc: "TLS 1.0/1.1 is insecure — use TLS 1.2 or higher"
+
+  - id: SA-GO-12
+    type: regex
+    target: "**/*.go"
+    pattern: "(password|secret|apiKey|token)\\s*[:=]\\s*\"[^\"]{8,}\""
+    severity: error
+    desc: "Potential hardcoded credential — use environment variables or secret manager"
+
+  # === RUST SECURITY CHECKS ===
+  - id: SA-RS-01
+    type: regex
+    target: "**/*.rs"
+    pattern: "unsafe\\s*\\{|unsafe\\s+fn\\s|unsafe\\s+impl\\s"
+    severity: warning
+    desc: "unsafe block/fn/impl — bypasses Rust safety guarantees, audit required"
+
+  - id: SA-RS-02
+    type: regex
+    target: "**/*.rs"
+    pattern: "extern\\s+\"C\"\\s*\\{|#\\[no_mangle\\]"
+    severity: warning
+    desc: "FFI boundary — audit for null pointers, lifetime issues, and error handling"
+
+  - id: SA-RS-03
+    type: regex
+    target: "**/*.rs"
+    pattern: "panic!\\s*\\(|todo!\\s*\\(|unimplemented!\\s*\\("
+    severity: warning
+    desc: "panic!/todo!/unimplemented! in code — can cause DoS via unwinding"
+
+  - id: SA-RS-04
+    type: regex
+    target: "**/*.rs"
+    pattern: "\\.unwrap\\(\\)|\\.expect\\(\\s*\""
+    severity: warning
+    desc: ".unwrap()/.expect() can panic — use ? or match in production paths"
+
+  - id: SA-RS-05
+    type: regex
+    target: "**/*.rs"
+    pattern: "as\\s+\\*const\\s|as\\s+\\*mut\\s"
+    severity: warning
+    desc: "Raw pointer cast — potential use-after-free or null deref in unsafe code"
+
+  - id: SA-RS-06
+    type: regex
+    target: "**/*.rs"
+    pattern: "sql_query\\s*\\(\\s*format!|query.*&format!"
+    severity: error
+    desc: "SQL query with format! string — use parameterized queries"
+
+  - id: SA-RS-07
+    type: regex
+    target: "**/*.rs"
+    pattern: "Command::new\\s*\\(\\s*\"(sh|bash|cmd|powershell)\""
+    severity: error
+    desc: "Shell invocation via Command::new — risk of command injection"
+
+  - id: SA-RS-08
+    type: regex
+    target: "**/*.rs"
+    pattern: "\\.join\\s*\\(.*\\b(req|input|param|query|user)"
+    severity: warning
+    desc: "Path join with user input — validate resolved path stays within base"
+
+  - id: SA-RS-09
+    type: regex
+    target: "**/*.rs"
+    pattern: "serde_json::from_(str|slice|reader)\\s*\\("
+    severity: warning
+    desc: "Deserialization of potentially untrusted data — enforce size limits"
+
+  - id: SA-RS-10
+    type: regex
+    target: "**/*.rs"
+    pattern: "==\\s*(token|secret|hmac|hash|key|password|mac|signature)"
+    severity: error
+    desc: "Non-constant-time comparison of secret — use constant_time_eq"
+
+  - id: SA-RS-11
+    type: regex
+    target: "**/*.rs"
+    pattern: "mem::forget\\s*\\(|ManuallyDrop::new\\s*\\("
+    severity: warning
+    desc: "mem::forget/ManuallyDrop prevents cleanup — sensitive data may persist"
+
+  - id: SA-RS-12
+    type: regex
+    target: "**/*.rs"
+    pattern: "(password|secret|api_key|token)\\s*[:=]\\s*\"[^\"]{8,}\""
+    severity: error
+    desc: "Potential hardcoded credential — use environment variables or secret manager"
+
+  # === VUE.JS SECURITY CHECKS ===
+  - id: SA-VUE-01
+    type: regex
+    target: "**/*.{vue,js,ts}"
+    pattern: "v-html\\s*="
+    severity: warning
+    desc: "v-html directive — potential XSS if used with user input"
+
+  - id: SA-VUE-02
+    type: regex
+    target: "**/*.{vue,js,ts}"
+    pattern: "Vue\\.compile\\s*\\("
+    severity: error
+    desc: "Vue.compile() with dynamic input — potential template injection"
+
+  - id: SA-VUE-03
+    type: regex
+    target: "**/*.{vue,js,ts}"
+    pattern: ":(href|src)\\s*=\\s*\"[^\"]*[a-zA-Z]"
+    severity: warning
+    desc: "v-bind:href/src with variable — validate URL protocol to prevent javascript: XSS"
+
+  - id: SA-VUE-04
+    type: regex
+    target: "**/*.{vue,js,ts}"
+    pattern: "beforeEnter\\s*:|beforeEach\\s*\\("
+    severity: warning
+    desc: "Client-side route guard — ensure server-side authorization exists"
+
+  - id: SA-VUE-05
+    type: regex
+    target: "**/*.{vue,js,ts}"
+    pattern: "(computed|watch|methods)\\s*:\\s*\\{[^}]*eval\\s*\\("
+    severity: error
+    desc: "eval() in Vue reactivity hook — potential code injection"
+
+  - id: SA-VUE-06
+    type: regex
+    target: "**/*.{vue,js,ts}"
+    pattern: "(defineStore|new\\s+Vuex\\.Store)\\s*\\([^)]*\\{[\\s\\S]*?(token|secret|password|apiKey|api_key|ssn|creditCard)"
+    severity: error
+    desc: "Sensitive data in Vuex/Pinia store — exposed via DevTools"
+
+  - id: SA-VUE-07
+    type: regex
+    target: "**/*.{vue,js,ts}"
+    pattern: "(asyncData|serverPrefetch|fetch)\\s*\\([^)]*\\)\\s*\\{[\\s\\S]*?(secret|internal|private|apiKey|connectionString)"
+    severity: error
+    desc: "SSR hydration may leak server-only data to client HTML"
+
+  - id: SA-VUE-08
+    type: regex
+    target: "**/*.{vue,js,ts}"
+    pattern: "Vue\\.mixin\\s*\\(|app\\.mixin\\s*\\("
+    severity: warning
+    desc: "Global mixin — applies to every component, audit for side effects"
+
+  # === ANGULAR SECURITY CHECKS ===
+  - id: SA-ANG-01
+    type: regex
+    target: "**/*.{ts,html}"
+    pattern: "bypassSecurityTrust(Html|Script|Url|ResourceUrl)\\s*\\("
+    severity: error
+    desc: "bypassSecurityTrust* disables Angular sanitization — audit for user input"
+
+  - id: SA-ANG-02
+    type: regex
+    target: "**/*.{ts,html}"
+    pattern: "compiler\\.compileModuleAndAllComponentsAsync|Component\\(\\s*\\{\\s*template\\s*:"
+    severity: error
+    desc: "Dynamic template compilation — potential template injection"
+
+  - id: SA-ANG-03
+    type: regex
+    target: "**/*.{ts,html}"
+    pattern: "@Pipe[\\s\\S]*?bypassSecurityTrust"
+    severity: error
+    desc: "Pipe with bypassSecurityTrust — reusable sanitization bypass"
+
+  - id: SA-ANG-04
+    type: regex
+    target: "**/*.{ts,html}"
+    pattern: "\\[innerHTML\\]\\s*="
+    severity: warning
+    desc: "innerHTML binding — verify input is sanitized before binding"
+
+  - id: SA-ANG-05
+    type: regex
+    target: "**/*.{ts,html}"
+    pattern: "canActivate|CanActivate|canLoad|CanLoad"
+    severity: warning
+    desc: "Client-side route guard — ensure server-side authorization exists"
+
+  - id: SA-ANG-06
+    type: regex
+    target: "**/*.{ts,html}"
+    pattern: "HttpInterceptor[\\s\\S]*?intercept\\s*\\("
+    severity: warning
+    desc: "HTTP interceptor — verify tokens are only sent to trusted origins"
+
+  - id: SA-ANG-07
+    type: regex
+    target: "**/*.{ts,html}"
+    pattern: "eval\\s*\\([^)]*\\)|new\\s+Function\\s*\\("
+    severity: error
+    desc: "eval/new Function in Angular code — potential code injection"
+
+  - id: SA-ANG-08
+    type: regex
+    target: "**/*.{ts,html}"
+    pattern: "ngZone\\.run\\s*\\([\\s\\S]*?(password|token|secret|creditCard|ssn|apiKey)"
+    severity: warning
+    desc: "Sensitive data in Zone.js context — may persist in memory"
+
+  # === REACT SECURITY CHECKS ===
+  - id: SA-REACT-01
+    type: regex
+    target: "**/*.{jsx,tsx}"
+    pattern: "dangerouslySetInnerHTML"
+    severity: warning
+    desc: "dangerouslySetInnerHTML usage — potential XSS"
+
+  - id: SA-REACT-02
+    type: regex
+    target: "**/*.{jsx,tsx}"
+    pattern: "\\{\\s*\\.\\.\\.(?:user|props|data|input|params|query)"
+    severity: warning
+    desc: "Spreading user-controlled object as JSX props — may inject dangerouslySetInnerHTML"
+
+  - id: SA-REACT-03
+    type: regex
+    target: "**/*.{jsx,tsx}"
+    pattern: "href\\s*=\\s*\\{(?!['\"](https?:|mailto:|/)[^}])"
+    severity: warning
+    desc: "Dynamic href from variable — potential javascript: protocol XSS"
+
+  - id: SA-REACT-04
+    type: regex
+    target: "**/*.{jsx,tsx}"
+    pattern: "'use client'[\\s\\S]*?\\b(password|secret|token|ssn|creditCard|hash)\\b"
+    severity: warning
+    desc: "Client component may receive sensitive data as props — data visible in browser"
+
+  - id: SA-REACT-05
+    type: regex
+    target: "**/*.{jsx,tsx}"
+    pattern: "\\beval\\s*\\(|new\\s+Function\\s*\\("
+    severity: error
+    desc: "eval() or Function constructor — code injection risk"
+
+  - id: SA-REACT-06
+    type: regex
+    target: "**/*.{jsx,tsx}"
+    pattern: "useState\\s*\\(\\s*\\{[^}]*(token|secret|password|refreshToken|cvv|ssn|creditCard)"
+    severity: warning
+    desc: "Sensitive data in React state — visible in DevTools"
+
+  - id: SA-REACT-07
+    type: regex
+    target: "**/*.{jsx,tsx}"
+    pattern: "useEffect\\s*\\(\\s*\\(\\)\\s*=>\\s*\\{[^}]*fetch\\s*\\([^)]*\\)\\.then"
+    severity: warning
+    desc: "useEffect fetch without visible auth — verify credentials are included"
+
+  - id: SA-REACT-08
+    type: regex
+    target: "**/*.{jsx,tsx}"
+    pattern: "key\\s*=\\s*\\{[^}]*(index|idx|i)\\s*\\}"
+    severity: info
+    desc: "Array index as React key — may cause state leaks between list items"
+
+  # === NEXT.JS SECURITY CHECKS ===
+  - id: SA-NEXT-01
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx}"
+    pattern: "'use server'[\\s\\S]*?export\\s+async\\s+function\\s+\\w+"
+    severity: warning
+    desc: "Server Action — verify auth/authorization check inside function body"
+
+  - id: SA-NEXT-02
+    type: regex
+    target: "**/*.{js,ts}"
+    pattern: "export\\s+async\\s+function\\s+(GET|POST|PUT|DELETE|PATCH)\\s*\\("
+    severity: warning
+    desc: "Next.js API route handler — verify authentication is enforced"
+
+  - id: SA-NEXT-03
+    type: regex
+    target: "**/*.env*"
+    pattern: "NEXT_PUBLIC_[A-Z_]*(SECRET|KEY|PASSWORD|TOKEN|CREDENTIAL|PRIVATE|DATABASE)"
+    severity: error
+    desc: "NEXT_PUBLIC_ env var with secret-like name — exposed to client bundle"
+
+  - id: SA-NEXT-04
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx}"
+    pattern: "(getServerSideProps|getStaticProps)[\\s\\S]*?return\\s*\\{\\s*props:"
+    severity: warning
+    desc: "getServerSideProps/getStaticProps return — verify no sensitive fields in props"
+
+  - id: SA-NEXT-05
+    type: regex
+    target: "**/next.config.{js,mjs,ts}"
+    pattern: "hostname:\\s*['\"]?\\*{1,2}['\"]?"
+    severity: error
+    desc: "Wildcard hostname in next/image config — SSRF risk via image optimization"
+
+  - id: SA-NEXT-06
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx}"
+    pattern: "Response\\.redirect\\s*\\([^)]*searchParams|redirect\\s*\\(\\s*(?:req|request)"
+    severity: warning
+    desc: "Redirect with user-controlled destination — potential open redirect"
+
+  - id: SA-NEXT-07
+    type: regex
+    target: "**/*.{js,ts,jsx,tsx}"
+    pattern: "JSON\\.stringify\\s*\\([^)]*(config|secret|user|session|token|key|credential)"
+    severity: warning
+    desc: "JSON.stringify of potentially sensitive object — may leak in RSC payload"
+
+  - id: SA-NEXT-08
+    type: regex
+    target: "**/*.{js,ts}"
+    pattern: "export\\s+async\\s+function\\s+POST\\s*\\([^)]*\\)\\s*\\{[^}]*(?:cookie|session|auth)"
+    severity: warning
+    desc: "POST handler with cookie/session auth — verify CSRF protection"
+
+  # === NUXT SECURITY CHECKS ===
+  - id: SA-NUXT-01
+    type: regex
+    target: "server/**/*.{js,ts}"
+    pattern: "defineEventHandler\\s*\\(\\s*async\\s*\\(\\s*event\\s*\\)"
+    severity: warning
+    desc: "Nitro server handler — verify authentication middleware is applied"
+
+  - id: SA-NUXT-02
+    type: regex
+    target: "**/*.{vue,js,ts}"
+    pattern: "useFetch\\s*\\(\\s*['\"][^'\"]*admin|useAsyncData\\s*\\(\\s*['\"][^'\"]*secret"
+    severity: warning
+    desc: "useFetch/useAsyncData fetching sensitive endpoint — data exposed in hydration payload"
+
+  - id: SA-NUXT-03
+    type: regex
+    target: "**/nuxt.config.{js,ts}"
+    pattern: "runtimeConfig[\\s\\S]*?public\\s*:\\s*\\{[^}]*(secret|password|token|key|credential|private|database)"
+    severity: error
+    desc: "Secret in runtimeConfig.public — exposed to client"
+
+  - id: SA-NUXT-04
+    type: regex
+    target: "**/*.vue"
+    pattern: "v-html\\s*="
+    severity: warning
+    desc: "v-html directive — potential XSS, especially dangerous in SSR context"
+
+  - id: SA-NUXT-05
+    type: regex
+    target: "server/**/*.{js,ts}"
+    pattern: "exec\\s*\\(|execSync\\s*\\(|\\$queryRawUnsafe\\s*\\("
+    severity: error
+    desc: "Shell exec or raw SQL in Nitro handler — injection risk"
+
+  - id: SA-NUXT-06
+    type: regex
+    target: "plugins/**/*.{js,ts}"
+    pattern: "defineNuxtPlugin\\s*\\(\\s*(?:async\\s*)?\\(\\s*nuxtApp\\s*\\)\\s*=>"
+    severity: info
+    desc: "Nuxt plugin without enforce/dependsOn — verify execution order for security plugins"
+
+  # === SPRING SECURITY CHECKS ===
+  - id: SA-SPRING-01
+    type: regex
+    target: "**/*.java"
+    pattern: "requestMatchers\\s*\\(\\s*\"\\/(api|admin)\\/\\*\\*\"\\s*\\)\\s*\\.\\s*permitAll\\s*\\(\\s*\\)"
+    severity: error
+    desc: "Spring Security permitAll overreach — verify scope is intentionally broad"
+
+  - id: SA-SPRING-02
+    type: regex
+    target: "**/*.java"
+    pattern: "parseExpression\\s*\\(\\s*[a-zA-Z_]\\w*\\s*\\)"
+    severity: error
+    desc: "SpEL expression parsed from untrusted input — injection risk"
+
+  - id: SA-SPRING-03
+    type: regex
+    target: "**/*.java"
+    pattern: "include\\s*:\\s*[\"']?\\*[\"']?|exposure\\.include\\s*=\\s*\\*"
+    severity: error
+    desc: "Spring Boot actuator wildcard exposure — secrets and heap dumps accessible"
+
+  - id: SA-SPRING-04
+    type: regex
+    target: "**/*.java"
+    pattern: "csrf\\s*\\(\\s*(?:csrf|c)\\s*->\\s*(?:csrf|c)\\.disable\\s*\\(\\s*\\)\\s*\\)|\\.csrf\\(\\)\\.disable\\(\\)"
+    severity: warning
+    desc: "CSRF protection disabled — verify endpoint is stateless (JWT/Bearer)"
+
+  - id: SA-SPRING-05
+    type: regex
+    target: "**/*.java"
+    pattern: "@PreAuthorize\\s*\\("
+    severity: warning
+    desc: "@PreAuthorize found — verify @EnableMethodSecurity is declared on a @Configuration class"
+
+  - id: SA-SPRING-06
+    type: regex
+    target: "**/*.java"
+    pattern: "return\\s+(?:request|param|input|query|\\w+)\\s*;"
+    severity: warning
+    desc: "Controller return value may be user-controlled — Thymeleaf SSTI risk"
+
+  - id: SA-SPRING-07
+    type: regex
+    target: "**/*.java"
+    pattern: "@ModelAttribute\\s+(?!.*Dto|.*Request|.*Form|.*Command)\\w+\\s+\\w+"
+    severity: warning
+    desc: "@ModelAttribute binds to entity directly — mass assignment risk"
+
+  - id: SA-SPRING-08
+    type: regex
+    target: "**/*.java"
+    pattern: "enableDefaultTyping\\s*\\(|activateDefaultTyping\\s*\\("
+    severity: error
+    desc: "Jackson default typing enabled — deserialization gadget chain risk"
+
+  # === .NET SECURITY CHECKS ===
+  - id: SA-DOTNET-01
+    type: regex
+    target: "**/*.cs"
+    pattern: "UseAuthentication\\s*\\(\\s*\\)[\\s\\S]{0,200}UseRouting\\s*\\(\\s*\\)|MapControllers\\s*\\(\\s*\\)[\\s\\S]{0,200}UseAuthentication\\s*\\(\\s*\\)|UseAuthorization\\s*\\(\\s*\\)[\\s\\S]{0,200}UseAuthentication\\s*\\(\\s*\\)"
+    severity: error
+    desc: "ASP.NET Core middleware ordering wrong — auth must come before routing/endpoints"
+
+  - id: SA-DOTNET-02
+    type: regex
+    target: "**/*.cs"
+    pattern: "FromSqlRaw\\s*\\(\\s*\\$\"|FromSqlRaw\\s*\\(\\s*\"[^\"]*\"\\s*\\+|ExecuteSqlRaw\\s*\\(\\s*\\$\"|ExecuteSqlRaw\\s*\\(\\s*\"[^\"]*\"\\s*\\+"
+    severity: error
+    desc: "Entity Framework raw SQL with string interpolation/concatenation — SQL injection"
+
+  - id: SA-DOTNET-03
+    type: regex
+    target: "**/*.cs"
+    pattern: "\\[AllowAnonymous\\]\\s*(?:\\r?\\n\\s*)*(?:public\\s+class|\\[(?:ApiController|Route)\\])"
+    severity: error
+    desc: "[AllowAnonymous] on controller class — all actions are publicly accessible"
+
+  - id: SA-DOTNET-04
+    type: regex
+    target: "**/*.cs"
+    pattern: "Html\\.Raw\\s*\\((?!.*Sanitiz)|@\\(\\s*\\(MarkupString\\)\\s*\\w+"
+    severity: error
+    desc: "Razor Html.Raw or MarkupString with unsanitized input — XSS risk"
+
+  - id: SA-DOTNET-05
+    type: regex
+    target: "**/*.cs"
+    pattern: "AllowAnyOrigin\\s*\\(\\s*\\)|SetIsOriginAllowed\\s*\\(\\s*_?\\s*=>\\s*true\\s*\\)"
+    severity: error
+    desc: "CORS policy allows any origin — credential theft via cross-origin requests"
+
+  - id: SA-DOTNET-06
+    type: regex
+    target: "**/*.cs"
+    pattern: "IgnoreAntiforgeryTokenAttribute\\s*\\(\\s*\\)|IgnoreAntiforgeryToken\\]"
+    severity: warning
+    desc: "Anti-forgery token validation disabled — CSRF risk"
+
+  - id: SA-DOTNET-07
+    type: regex
+    target: "**/*.cs"
+    pattern: "DisableAutomaticKeyGeneration\\s*\\(\\s*\\)"
+    severity: warning
+    desc: "Data Protection automatic key generation disabled — keys will expire without rotation"
+
+  - id: SA-DOTNET-08
+    type: regex
+    target: "**/*.cs"
+    pattern: "class\\s+\\w+Hub\\s*:\\s*Hub\\b"
+    severity: warning
+    desc: "SignalR hub found — verify [Authorize] attribute is applied"
+
+  # === BLAZOR SECURITY CHECKS ===
+  - id: SA-BLAZOR-01
+    type: regex
+    target: "**/*.{razor,cs}"
+    pattern: "Http\\.\\w+Async\\s*\\(\\s*\"[^\"]*(?:admin|secret|internal|private|manage)"
+    severity: error
+    desc: "Blazor WASM calling sensitive API — verify server-side [Authorize] enforcement"
+
+  - id: SA-BLAZOR-02
+    type: regex
+    target: "**/*.{razor,cs}"
+    pattern: "(?:private|protected|public)\\s+string\\s+(?:creditCard|cvv|ssn|password|secret|token|apiKey)\\s*="
+    severity: warning
+    desc: "Sensitive data stored in Blazor component state — exposure via circuit or prerender"
+
+  - id: SA-BLAZOR-03
+    type: regex
+    target: "**/*.{razor,cs}"
+    pattern: "InvokeVoidAsync\\s*\\(\\s*\"eval\"|InvokeAsync\\s*\\(\\s*\"eval\""
+    severity: error
+    desc: "JS interop calling eval — injection risk from untrusted input"
+
+  - id: SA-BLAZOR-04
+    type: regex
+    target: "**/*.{razor,cs}"
+    pattern: "\\[Authorize\\][\\s\\S]{0,200}prerender\\s*:\\s*true"
+    severity: warning
+    desc: "[Authorize] with prerender enabled — auth state may not be available during prerender"
+
+  - id: SA-BLAZOR-05
+    type: regex
+    target: "**/*.{razor,cs}"
+    pattern: "OnInitializedAsync[\\s\\S]{0,300}(?:Sensitive|Secret|Private|Confidential|GetCredentials|GetTokens)"
+    severity: warning
+    desc: "Sensitive data loaded in OnInitializedAsync — may leak via prerendering"
+
+  # === DJANGO SECURITY ===
+  - id: SA-DJANGO-01
+    type: regex
+    target: "**/*.py"
+    pattern: "\\.raw\\s*\\(\\s*f[\"']|\\.raw\\s*\\(\\s*[\"'].*%s.*[\"']\\s*%|\\.extra\\s*\\(|cursor\\.execute\\s*\\(\\s*f[\"']|cursor\\.execute\\s*\\(\\s*[\"'].*%s.*[\"']\\s*%"
+    severity: error
+    desc: "Django ORM injection via raw(), extra(), or cursor.execute() with string interpolation"
+
+  - id: SA-DJANGO-02
+    type: regex
+    target: "**/*.py"
+    pattern: "@csrf_exempt|csrf_exempt\\s*\\(|decorators\\.csrf\\s+import\\s+csrf_exempt"
+    severity: error
+    desc: "CSRF protection disabled via @csrf_exempt decorator"
+
+  - id: SA-DJANGO-03
+    type: regex
+    target: "**/*.py"
+    pattern: "DEBUG\\s*=\\s*True"
+    severity: error
+    desc: "Django DEBUG=True — exposes tracebacks, SQL queries, and settings in production"
+
+  - id: SA-DJANGO-04
+    type: regex
+    target: "**/*.py"
+    pattern: "mark_safe\\s*\\(|\\.safestring\\s+import|safestring\\.mark_safe"
+    severity: error
+    desc: "XSS risk via mark_safe() — bypasses Django auto-escaping"
+
+  - id: SA-DJANGO-05
+    type: regex
+    target: "**/*.py"
+    pattern: "SECRET_KEY\\s*=\\s*[\"'][^\"']{8,}[\"']"
+    severity: error
+    desc: "Django SECRET_KEY hardcoded in source — enables session/token forgery if leaked"
+
+  - id: SA-DJANGO-06
+    type: regex
+    target: "**/*.py"
+    pattern: "PickleSerializer|SESSION_SERIALIZER.*[Pp]ickle"
+    severity: error
+    desc: "Pickle session serializer — enables RCE if SECRET_KEY is compromised"
+
+  - id: SA-DJANGO-07
+    type: regex
+    target: "**/*.py"
+    pattern: "path\\s*\\(\\s*[\"']admin/[\"']|url\\s*\\(\\s*r?\\s*[\"'].*admin/"
+    severity: warning
+    desc: "Django admin on default /admin/ URL — consider obscuring path and adding IP restrictions"
+
+  - id: SA-DJANGO-08
+    type: regex
+    target: "**/*.py"
+    pattern: "FileField\\s*\\(\\s*upload_to\\s*=\\s*[\"'][^\"']*[\"'](?:\\s*\\)|\\s*,\\s*\\))|request\\.FILES\\["
+    severity: warning
+    desc: "File upload without visible validation — verify size, type, and filename sanitization"
+
+  # === FLASK SECURITY ===
+  - id: SA-FLASK-01
+    type: regex
+    target: "**/*.py"
+    pattern: "render_template_string\\s*\\("
+    severity: error
+    desc: "Flask render_template_string() — potential SSTI if user input reaches template"
+
+  - id: SA-FLASK-02
+    type: regex
+    target: "**/*.py"
+    pattern: "request\\.args\\s*\\[|request\\.args\\.get\\s*\\(|request\\.form\\s*\\[|request\\.form\\.get\\s*\\(|request\\.values"
+    severity: warning
+    desc: "Flask request parameter access — verify input is validated before use"
+
+  - id: SA-FLASK-03
+    type: regex
+    target: "**/*.py"
+    pattern: "send_file\\s*\\(\\s*f[\"']|send_file\\s*\\(\\s*.*request\\.|send_file\\s*\\(\\s*os\\.path\\.join"
+    severity: error
+    desc: "Flask send_file() with dynamic path — potential path traversal"
+
+  - id: SA-FLASK-04
+    type: regex
+    target: "**/*.py"
+    pattern: "app\\.run\\s*\\(.*debug\\s*=\\s*True|\\.config\\s*\\[\\s*[\"']DEBUG[\"']\\s*\\]\\s*=\\s*True|FLASK_DEBUG\\s*=\\s*1"
+    severity: error
+    desc: "Flask debug=True — Werkzeug debugger enables arbitrary code execution"
+
+  - id: SA-FLASK-05
+    type: regex
+    target: "**/*.py"
+    pattern: "secret_key\\s*=\\s*[\"'][^\"']{1,30}[\"']|app\\.config\\s*\\[\\s*[\"']SECRET_KEY[\"']\\s*\\]\\s*=\\s*[\"']"
+    severity: error
+    desc: "Flask SECRET_KEY hardcoded or weak — enables session cookie forgery"
+
+  - id: SA-FLASK-06
+    type: regex
+    target: "**/*.py"
+    pattern: "db\\.session\\.execute\\s*\\(\\s*f[\"']|db\\.session\\.execute\\s*\\(\\s*[\"'].*%s.*[\"']\\s*%|db\\.engine\\.execute\\s*\\(\\s*f[\"']|\\.execute\\s*\\(\\s*f[\"']SELECT|\\.execute\\s*\\(\\s*f[\"']INSERT|\\.execute\\s*\\(\\s*f[\"']UPDATE|\\.execute\\s*\\(\\s*f[\"']DELETE"
+    severity: error
+    desc: "SQLAlchemy raw query with string interpolation — SQL injection risk"
+
+  # === FASTAPI SECURITY ===
+  - id: SA-FASTAPI-01
+    type: regex
+    target: "**/*.py"
+    pattern: "@app\\.(get|post|put|patch|delete)\\("
+    severity: warning
+    desc: "FastAPI endpoint without Depends() — verify authentication is not missing"
+
+  - id: SA-FASTAPI-02
+    type: regex
+    target: "**/*.py"
+    pattern: "def\\s+\\w+\\s*\\([^)]*:\\s*dict\\s*[,\\)]|:\\s*Any\\s*[,\\)=]|extra\\s*=\\s*[\"']allow[\"']"
+    severity: warning
+    desc: "Pydantic validation bypass via dict/Any type or extra='allow'"
+
+  - id: SA-FASTAPI-03
+    type: regex
+    target: "**/*.py"
+    pattern: "allow_origins\\s*=\\s*\\[\\s*[\"']\\*[\"']\\s*\\]|CORSMiddleware.*allow_origins.*\\*"
+    severity: error
+    desc: "FastAPI CORS wildcard origin — allows any domain to make cross-origin requests"
+
+  - id: SA-FASTAPI-04
+    type: regex
+    target: "**/*.py"
+    pattern: "response\\.headers\\s*\\[.*\\]\\s*=\\s*f[\"']|response\\.headers\\s*\\[.*\\]\\s*=.*request\\.|.headers\\s*\\[\\s*[\"']Set-Cookie[\"']\\s*\\]\\s*="
+    severity: warning
+    desc: "Response header set from user input — potential header injection"
+
+  - id: SA-FASTAPI-05
+    type: regex
+    target: "**/*.py"
+    pattern: "UploadFile.*filename|file\\.filename|shutil\\.copyfileobj\\s*\\(\\s*file"
+    severity: warning
+    desc: "FastAPI file upload — verify size limit, type validation, and filename sanitization"
+
+  - id: SA-FASTAPI-06
+    type: regex
+    target: "**/*.py"
+    pattern: "algorithms\\s*=\\s*\\[.*none.*\\]|jwt\\.decode\\s*\\(\\s*token\\s*,\\s*[^,]+\\s*\\)\\s*$|ACCESS_TOKEN_EXPIRE.*(?:525600|86400|43200)"
+    severity: error
+    desc: "OAuth2/JWT implementation issue — algorithm confusion, missing validation, or excessive expiry"
+
+  # === GIN (GO) SECURITY CHECKS ===
+  - id: SA-GIN-01
+    type: regex
+    target: "**/*.go"
+    pattern: "\\.Use\\(auth[A-Za-z]*\\("
+    severity: error
+    desc: "Auth middleware may be registered after routes — verify ordering"
+
+  - id: SA-GIN-02
+    type: regex
+    target: "**/*.go"
+    pattern: "c\\.(Bind|ShouldBind|ShouldBindJSON|BindJSON|ShouldBindQuery)\\s*\\("
+    severity: warning
+    desc: "Gin binding function — verify struct does not contain sensitive fields (mass assignment)"
+
+  - id: SA-GIN-03
+    type: regex
+    target: "**/*.go"
+    pattern: "template\\.HTML\\s*\\(|c\\.Data\\s*\\([^)]*\"text/html|c\\.Writer\\.WriteString\\s*\\("
+    severity: error
+    desc: "Raw HTML output bypassing template auto-escaping — potential XSS"
+
+  - id: SA-GIN-04
+    type: regex
+    target: "**/*.go"
+    pattern: "AllowAllOrigins\\s*:\\s*true|AllowOrigins\\s*:\\s*\\[\\s*\"\\*\"\\s*\\]|AllowOriginFunc\\s*:.*return\\s+true"
+    severity: error
+    desc: "CORS misconfiguration — wildcard or permissive origin policy"
+
+  - id: SA-GIN-05
+    type: regex
+    target: "**/*.go"
+    pattern: "c\\.(File|FileAttachment)\\s*\\([^)]*c\\.(Param|Query|PostForm)\\s*\\("
+    severity: error
+    desc: "User-controlled path in c.File/c.FileAttachment — path traversal risk"
+
+  - id: SA-GIN-06
+    type: regex
+    target: "**/*.go"
+    pattern: "gin\\.New\\s*\\(\\s*\\)"
+    severity: warning
+    desc: "gin.New() without default middleware — verify Recovery() is registered first"
+
+  # === RAILS SECURITY CHECKS ===
+  - id: SA-RAILS-01
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\.permit!|params\\[:[a-z_]+\\]\\.permit\\([^)]*(?:role|admin|superuser|permission)"
+    severity: error
+    desc: "Mass assignment — permit! or permitting sensitive fields"
+
+  - id: SA-RAILS-02
+    type: regex
+    target: "**/*.rb"
+    pattern: "\\.html_safe|raw\\s*\\(|<%=="
+    severity: error
+    desc: "html_safe/raw/<%== bypasses Rails auto-escaping — XSS risk"
+
+  - id: SA-RAILS-03
+    type: regex
+    target: "**/*.rb"
+    pattern: "find_by_sql\\s*\\(.*#\\{|\\.where\\s*\\(.*#\\{|\\.order\\s*\\(\\s*params"
+    severity: error
+    desc: "String interpolation in SQL query — SQL injection risk"
+
+  - id: SA-RAILS-04
+    type: regex
+    target: "**/*.rb"
+    pattern: "skip_before_action\\s*:verify_authenticity_token|protect_from_forgery\\s+with:\\s*:null_session"
+    severity: error
+    desc: "CSRF protection disabled or misconfigured"
+
+  - id: SA-RAILS-05
+    type: regex
+    target: "**/*.rb"
+    pattern: "send_file\\s*.*params\\[|send_data\\s*.*filename:\\s*params\\["
+    severity: error
+    desc: "User-controlled path in send_file/send_data — path traversal risk"
+
+  - id: SA-RAILS-06
+    type: regex
+    target: "**/*.rb"
+    pattern: "render\\s+inline:\\s*.*params\\[|render\\s+inline:\\s*.*#\\{"
+    severity: error
+    desc: "User input in render inline: — server-side template injection"
+
+  - id: SA-RAILS-07
+    type: regex
+    target: "**/*.rb"
+    pattern: "has_one_attached\\s+:\\w+"
+    severity: warning
+    desc: "Active Storage attachment — verify content_type and size validation"
+
+  - id: SA-RAILS-08
+    type: regex
+    target: "**/*.rb"
+    pattern: "class\\s+\\w+Channel\\s*<\\s*ApplicationCable::Channel"
+    severity: warning
+    desc: "Action Cable channel — verify authentication in Connection and authorization in subscribed"
+
+  # === EXPRESS SECURITY CHECKS ===
+  - id: SA-EXPRESS-01
+    type: regex
+    target: "**/*.{js,ts}"
+    pattern: "app\\.(get|post|put|delete|use)\\s*\\([^)]*\\)[\\s\\S]*?app\\.use\\s*\\(\\s*helmet\\s*\\("
+    severity: error
+    desc: "Routes defined before helmet middleware — missing security headers"
+
+  - id: SA-EXPRESS-02
+    type: regex
+    target: "**/*.{js,ts}"
+    pattern: "execSync\\s*\\(.*req\\.(params|query|body)|exec\\s*\\(.*req\\.(params|query|body)"
+    severity: error
+    desc: "User input in shell command — command injection risk"
+
+  - id: SA-EXPRESS-03
+    type: regex
+    target: "**/*.{js,ts}"
+    pattern: "res\\.sendFile\\s*\\(\\s*(?:req\\.(params|query|body)|path\\.join\\s*\\([^)]*req\\.(params|query|body))"
+    severity: error
+    desc: "User-controlled path in res.sendFile — path traversal risk"
+
+  - id: SA-EXPRESS-04
+    type: regex
+    target: "**/*.{js,ts}"
+    pattern: "session\\s*\\(\\s*\\{[^}]*secret\\s*:\\s*['\"][^'\"]{0,20}['\"]|cookie\\s*:\\s*\\{[^}]*httpOnly\\s*:\\s*false|cookie\\s*:\\s*\\{[^}]*secure\\s*:\\s*false"
+    severity: error
+    desc: "Insecure session configuration — weak secret, missing httpOnly, or missing secure flag"
+
+  - id: SA-EXPRESS-05
+    type: regex
+    target: "**/*.{js,ts}"
+    pattern: "app\\.(post|put)\\s*\\(\\s*['\"\\/][^'\"]*(?:login|auth|token|password|register)[^'\"]*['\"]"
+    severity: warning
+    desc: "Auth endpoint — verify rate limiting is applied"
+
+  - id: SA-EXPRESS-06
+    type: regex
+    target: "**/*.{js,ts}"
+    pattern: "findByIdAndUpdate\\s*\\([^,]+,\\s*req\\.body\\s*\\)|\\.create\\s*\\(\\s*req\\.body\\s*\\)"
+    severity: warning
+    desc: "Passing req.body directly to database operation — mass assignment risk"
+
+  # === NESTJS SECURITY CHECKS ===
+  - id: SA-NEST-01
+    type: regex
+    target: "**/*.ts"
+    pattern: "@UseGuards\\s*\\(\\s*RolesGuard\\s*,\\s*AuthGuard\\s*\\)"
+    severity: error
+    desc: "RolesGuard before AuthGuard — authorization checked before authentication"
+
+  - id: SA-NEST-02
+    type: regex
+    target: "**/*.ts"
+    pattern: "new\\s+ValidationPipe\\s*\\(\\s*\\{[^}]*whitelist\\s*:\\s*false"
+    severity: error
+    desc: "ValidationPipe with whitelist:false — extra properties not stripped (mass assignment)"
+
+  - id: SA-NEST-03
+    type: regex
+    target: "**/*.ts"
+    pattern: "@Column\\s*\\(\\s*\\)\\s*\\n\\s*password\\s*:|@Column\\s*\\(\\s*\\)\\s*\\n\\s*(?:secret|token|hash|internal)"
+    severity: warning
+    desc: "Sensitive entity column without @Exclude — may be exposed in API responses"
+
+  - id: SA-NEST-04
+    type: regex
+    target: "**/*.ts"
+    pattern: "@Param\\s*\\(\\s*['\"][^'\"]+['\"]\\s*\\)\\s+\\w+\\s*:\\s*string"
+    severity: warning
+    desc: "Route parameter without ParseIntPipe/ParseUUIDPipe — type confusion risk"
+
+  - id: SA-NEST-05
+    type: regex
+    target: "**/*.ts"
+    pattern: "@Public\\s*\\(\\s*\\)\\s*\\n\\s*@(Delete|Put|Patch)\\s*\\(|@Public\\s*\\(\\s*\\)\\s*\\n\\s*@Controller"
+    severity: error
+    desc: "@Public on state-changing endpoint or entire controller — auth bypass"
+
+  - id: SA-NEST-06
+    type: regex
+    target: "**/*.ts"
+    pattern: "@WebSocketGateway\\s*\\("
+    severity: warning
+    desc: "WebSocket gateway — verify handleConnection authentication and message-level guards"
+
+  # === AWS SECURITY CHECKS ===
+  - id: SA-AWS-01
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "\"Action\"\\s*:\\s*\"\\*\"|\"Action\"\\s*:\\s*\\[\\s*\"\\*\"\\s*\\]"
+    severity: error
+    desc: "IAM policy with wildcard Action — grants unrestricted permissions"
+
+  - id: SA-AWS-02
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "\"Effect\"\\s*:\\s*\"Allow\"[^}]*\"Action\"\\s*:\\s*\"sts:AssumeRole\"(?![^}]*\"Condition\")"
+    severity: warning
+    desc: "AssumeRole without conditions — missing MFA, IP, or external ID restriction"
+
+  - id: SA-AWS-03
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "\"Principal\"\\s*:\\s*\\{\\s*\"AWS\"\\s*:\\s*\"\\*\"\\s*\\}|\"Principal\"\\s*:\\s*\"\\*\""
+    severity: error
+    desc: "Overly permissive trust policy — any principal can assume role"
+
+  - id: SA-AWS-04
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "\"Action\"\\s*:\\s*\"iam:PassRole\"[^}]*\"Resource\"\\s*:\\s*\"\\*\""
+    severity: error
+    desc: "iam:PassRole with wildcard resource — privilege escalation risk"
+
+  - id: SA-AWS-05
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "acl\\s*=\\s*\"public-read\"|acl\\s*=\\s*\"public-read-write\""
+    severity: error
+    desc: "S3 bucket with public ACL — data exposure risk"
+
+  - id: SA-AWS-06
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "block_public_acls\\s*=\\s*false|block_public_policy\\s*=\\s*false|restrict_public_buckets\\s*=\\s*false"
+    severity: error
+    desc: "S3 public access block disabled — bucket may become publicly accessible"
+
+  - id: SA-AWS-07
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "environment\\s*\\{[^}]*variables\\s*=\\s*\\{[^}]*(PASSWORD|SECRET|API_KEY|TOKEN|PRIVATE_KEY)\\s*=\\s*\"[^\"]+\""
+    severity: error
+    desc: "Lambda environment variable contains hardcoded secret"
+
+  - id: SA-AWS-08
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "policy_arn\\s*=\\s*\"arn:aws:iam::aws:policy/AdministratorAccess\"|policy_arn\\s*=\\s*\"arn:aws:iam::aws:policy/PowerUserAccess\""
+    severity: error
+    desc: "Lambda or role with AdministratorAccess/PowerUserAccess — overly permissive"
+
+  - id: SA-AWS-09
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "cidr_blocks\\s*=\\s*\\[\\s*\"0\\.0\\.0\\.0/0\"\\s*\\]|CidrIp:\\s*[\"']?0\\.0\\.0\\.0/0"
+    severity: error
+    desc: "Security group ingress open to 0.0.0.0/0 — unrestricted internet access"
+
+  - id: SA-AWS-10
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "enable_key_rotation\\s*=\\s*false"
+    severity: warning
+    desc: "KMS key rotation disabled — keys should be rotated automatically"
+
+  - id: SA-AWS-11
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "is_multi_region_trail\\s*=\\s*false|enable_log_file_validation\\s*=\\s*false"
+    severity: error
+    desc: "CloudTrail not multi-region or missing log validation"
+
+  - id: SA-AWS-12
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "password\\s*=\\s*\"[^\"]+\"|master_password\\s*=\\s*\"[^\"]+\""
+    severity: error
+    desc: "Hardcoded password in Terraform/CloudFormation — use Secrets Manager"
+
+  # === GCP SECURITY CHECKS ===
+  - id: SA-GCP-01
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "role\\s*=\\s*\"roles/(owner|editor)\"|\"roles/(owner|editor)\""
+    severity: error
+    desc: "GCP primitive role (Owner/Editor) — use granular predefined roles"
+
+  - id: SA-GCP-02
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "resource\\s+\"google_service_account_key\"|google_service_account_key\\s*\\{"
+    severity: error
+    desc: "Service account key file — use Workload Identity Federation instead"
+
+  - id: SA-GCP-03
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "\"allUsers\"|\"allAuthenticatedUsers\"|member\\s*=\\s*\"allUsers\"|member\\s*=\\s*\"allAuthenticatedUsers\""
+    severity: error
+    desc: "allUsers/allAuthenticatedUsers binding — public access to GCP resource"
+
+  - id: SA-GCP-04
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "google_storage_bucket_iam[^}]*(allUsers|allAuthenticatedUsers)|predefinedAcl:\\s*public"
+    severity: error
+    desc: "Public Cloud Storage bucket — data exposure risk"
+
+  - id: SA-GCP-05
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "uniform_bucket_level_access\\s*=\\s*false"
+    severity: warning
+    desc: "Uniform bucket-level access disabled — inconsistent ACLs possible"
+
+  - id: SA-GCP-06
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "environment_variables\\s*=\\s*\\{[^}]*(PASSWORD|SECRET|API_KEY|TOKEN|PRIVATE_KEY)\\s*=\\s*\"[^\"]+\""
+    severity: error
+    desc: "Cloud Functions environment variable contains hardcoded secret"
+
+  - id: SA-GCP-07
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "cloudfunctions\\.invoker[^}]*allUsers|allUsers[^}]*cloudfunctions\\.invoker"
+    severity: error
+    desc: "Cloud Function invocable by allUsers — unauthenticated access"
+
+  - id: SA-GCP-08
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "source_ranges\\s*=\\s*\\[\\s*\"0\\.0\\.0\\.0/0\"\\s*\\]|sourceRanges:[^}]*0\\.0\\.0\\.0/0"
+    severity: error
+    desc: "VPC firewall rule open to 0.0.0.0/0 — unrestricted internet ingress"
+
+  - id: SA-GCP-09
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "google_kms_crypto_key_iam[^}]*(allUsers|allAuthenticatedUsers)"
+    severity: error
+    desc: "KMS key accessible by allUsers — encryption key exposure"
+
+  - id: SA-GCP-10
+    type: regex
+    target: "**/*.{tf,json,yaml,yml}"
+    pattern: "exempted_members\\s*=\\s*\\["
+    severity: warning
+    desc: "Audit log exemptions configured — all access should be logged"
+
+  # === AZURE SECURITY CHECKS ===
+  - id: SA-AZURE-01
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "role_definition_name\\s*=\\s*\"(Owner|Contributor)\"|8e3af657-a8ff-443c-a75c-2fe8c4bcb635|b24988ac-6180-42a0-ab88-20f7382dd24c"
+    severity: error
+    desc: "Owner/Contributor role assignment — use least-privilege roles"
+
+  - id: SA-AZURE-02
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "role_definition_name\\s*=\\s*\"Storage Blob Data Owner\"(?![^}]*condition\\s*=)"
+    severity: warning
+    desc: "Storage Blob Data Owner without conditions — add ABAC conditions"
+
+  - id: SA-AZURE-03
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "allow_nested_items_to_be_public\\s*=\\s*true|allow_blob_public_access\\s*=\\s*true|allowBlobPublicAccess['\"]?\\s*[:=]\\s*['\"]?true|container_access_type\\s*=\\s*\"(blob|container)\""
+    severity: error
+    desc: "Public blob access enabled — anonymous access to storage data"
+
+  - id: SA-AZURE-04
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "authLevel[\"\\s]*[:=]\\s*[\"']?anonymous|\"authLevel\"\\s*:\\s*\"anonymous\""
+    severity: error
+    desc: "Azure Function with anonymous auth level — no authentication required"
+
+  - id: SA-AZURE-05
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "app_settings\\s*=\\s*\\{[^}]*(PASSWORD|SECRET|KEY|TOKEN|CONNECTION)\\s*=\\s*\"(?!@Microsoft\\.KeyVault)[^\"]+\""
+    severity: error
+    desc: "Hardcoded secret in Azure Function app settings — use Key Vault references"
+
+  - id: SA-AZURE-06
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "source_address_prefix\\s*=\\s*\"\\*\"|sourceAddressPrefix['\"]?\\s*[:=]\\s*['\"]\\*['\"]|\"sourceAddressPrefix\"\\s*:\\s*\"\\*\""
+    severity: error
+    desc: "NSG inbound rule open to * — unrestricted internet access"
+
+  - id: SA-AZURE-07
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "purge_protection_enabled\\s*=\\s*false|enablePurgeProtection:\\s*false|\"enablePurgeProtection\"\\s*:\\s*false"
+    severity: error
+    desc: "Key Vault missing purge protection — keys can be permanently deleted"
+
+  - id: SA-AZURE-08
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "enable_rbac_authorization\\s*=\\s*false|access_policy\\s*\\{"
+    severity: warning
+    desc: "Key Vault using access policies instead of RBAC — harder to audit"
+
+  - id: SA-AZURE-09
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "azurerm_monitor_diagnostic_setting"
+    severity: warning
+    desc: "Diagnostic setting present — verify all critical log categories are enabled"
+
+  - id: SA-AZURE-10
+    type: regex
+    target: "**/*.{tf,json,bicep,yaml,yml}"
+    pattern: "public_network_access_enabled\\s*=\\s*true|start_ip_address\\s*=\\s*\"0\\.0\\.0\\.0\""
+    severity: error
+    desc: "Azure SQL public network access or permissive firewall rule"
+
+  # === WORDPRESS SECURITY ===
+  - id: SA-WP-01
+    type: regex
+    target: "**/*.php"
+    pattern: "\\$wpdb\\s*->\\s*(query|get_results|get_row|get_var|get_col)\\s*\\(\\s*[\"']"
+    severity: error
+    desc: "$wpdb query without $wpdb->prepare() — SQL injection risk"
+
+  - id: SA-WP-02
+    type: regex
+    target: "**/*.php"
+    pattern: "unserialize\\s*\\(\\s*\\$_(GET|POST|REQUEST|COOKIE|SERVER)|unserialize\\s*\\(\\s*\\$"
+    severity: error
+    desc: "unserialize() with user-controlled input — object injection risk"
+
+  - id: SA-WP-03
+    type: regex
+    target: "**/*.php"
+    pattern: "echo\\s+\\$(?!.*esc_html|.*esc_attr|.*esc_url|.*wp_kses|.*absint|.*intval)"
+    severity: error
+    desc: "Unescaped output — use esc_html(), esc_attr(), esc_url(), or wp_kses()"
+
+  - id: SA-WP-04
+    type: regex
+    target: "**/*.php"
+    pattern: "register_rest_route\\s*\\([^)]*(?!permission_callback)[^)]*\\)|permission_callback.*__return_true"
+    severity: error
+    desc: "REST API route without permission_callback or with __return_true — unauthenticated access"
+
+  - id: SA-WP-05
+    type: regex
+    target: "**/*.php"
+    pattern: "update_option\\s*\\(|update_post_meta\\s*\\(|delete_option\\s*\\(|delete_post_meta\\s*\\("
+    severity: warning
+    desc: "Option/meta modification — verify current_user_can() and nonce checks are present"
+
+  - id: SA-WP-06
+    type: regex
+    target: "**/*.php"
+    pattern: "\\$_POST\\[.*\\]\\s*(?!.*wp_verify_nonce|.*check_ajax_referer|.*wp_nonce)"
+    severity: error
+    desc: "POST data processed without nonce verification — CSRF risk"
+
+  - id: SA-WP-07
+    type: regex
+    target: "**/*.php"
+    pattern: "move_uploaded_file\\s*\\(|\\$_FILES\\s*\\[.*\\]\\s*\\[.tmp_name.\\]"
+    severity: error
+    desc: "Direct file upload handling — use wp_handle_upload() with MIME validation"
+
+  - id: SA-WP-08
+    type: regex
+    target: "**/*.php"
+    pattern: "WP_DEBUG.*true|WP_DEBUG_DISPLAY.*true|DISALLOW_FILE_EDIT.*false"
+    severity: error
+    desc: "wp-config.php misconfiguration — debug enabled or file editing allowed in production"
+
+  - id: SA-WP-09
+    type: regex
+    target: "**/*.php"
+    pattern: "^<\\?php\\s*\\n(?!.*defined\\s*\\(\\s*['\"]ABSPATH['\"])"
+    severity: warning
+    desc: "PHP file missing defined('ABSPATH') check — direct file access possible"
+
+  - id: SA-WP-10
+    type: regex
+    target: "**/*.php"
+    pattern: "\\$table_prefix\\s*=\\s*['\"]wp_['\"]"
+    severity: warning
+    desc: "Default WordPress table prefix wp_ — makes targeted SQL injection easier"
+
+  # === DRUPAL SECURITY ===
+  - id: SA-DRUPAL-01
+    type: regex
+    target: "**/*.{php,module,install}"
+    pattern: "db_query\\s*\\(\\s*[\"'].*\\$|->query\\s*\\(\\s*[\"'].*\\$|sprintf\\s*\\(\\s*[\"']SELECT"
+    severity: error
+    desc: "Drupal database query with string interpolation — SQL injection risk"
+
+  - id: SA-DRUPAL-02
+    type: regex
+    target: "**/*.{php,module,install}"
+    pattern: "#markup.*\\$|#markup.*\\.\\s*\\$|#markup.*getRequest|#markup.*->get\\s*\\("
+    severity: error
+    desc: "Render array #markup with user input — XSS risk, use #plain_text or Html::escape()"
+
+  - id: SA-DRUPAL-03
+    type: regex
+    target: "**/*.{php,module,install}"
+    pattern: "['\"]#markup['\"]\\s*=>\\s*.*\\$(?!.*Html::escape|.*Xss::filter|.*check_plain|.*t\\()"
+    severity: error
+    desc: "Unescaped variable in #markup — XSS risk"
+
+  - id: SA-DRUPAL-04
+    type: regex
+    target: "**/*.{php,module,install}"
+    pattern: "->delete\\s*\\(\\s*\\)|->save\\s*\\(\\s*\\)"
+    severity: warning
+    desc: "Entity state change — verify Form API CSRF protection or _csrf_token route requirement"
+
+  - id: SA-DRUPAL-05
+    type: regex
+    target: "**/*.{php,module,install}"
+    pattern: "entityQuery\\s*\\([^)]*\\)(?!.*accessCheck)|->load\\s*\\(\\s*\\$"
+    severity: error
+    desc: "Entity query or load without access check — bypasses node/field access control"
+
+  - id: SA-DRUPAL-06
+    type: regex
+    target: "**/*.{php,module,install}"
+    pattern: "hash_salt.*=\\s*['\"]['\"]|error_level.*verbose|update_free_access.*TRUE"
+    severity: error
+    desc: "Drupal settings.php misconfiguration — empty hash_salt, verbose errors, or update access"
+
+  # === JOOMLA SECURITY ===
+  - id: SA-JOOMLA-01
+    type: regex
+    target: "**/*.php"
+    pattern: "->where\\s*\\(.*[\"'].*\\.\\s*\\$|setQuery\\s*\\(\\s*[\"'].*\\$|->where\\s*\\(\\s*[\"'].*\\$"
+    severity: error
+    desc: "Joomla database query with string concatenation — SQL injection risk"
+
+  - id: SA-JOOMLA-02
+    type: regex
+    target: "**/*.php"
+    pattern: "->get\\s*\\([^,)]+\\s*,\\s*[^,)]*\\s*,\\s*['\"]RAW['\"]|\\$_GET\\s*\\[|\\$_POST\\s*\\[|\\$_REQUEST\\s*\\["
+    severity: error
+    desc: "JInput RAW filter or direct superglobal access — unvalidated input"
+
+  - id: SA-JOOMLA-03
+    type: regex
+    target: "**/*.php"
+    pattern: "extends\\s+BaseController[^{]*\\{[^}]*function\\s+(delete|save|publish)"
+    severity: warning
+    desc: "Controller state-changing method — verify authorise() and checkToken() are present"
+
+  - id: SA-JOOMLA-04
+    type: regex
+    target: "**/*.php"
+    pattern: "\\$error_reporting\\s*=\\s*['\"]maximum['\"]|\\$debug\\s*=\\s*1|\\$secret\\s*=\\s*['\"]joomla['\"]"
+    severity: error
+    desc: "Joomla configuration.php misconfiguration — debug enabled or weak secret"
+
+  # === ANDROID SDK SECURITY ===
+  - id: SA-ANDROID-01
+    type: regex
+    target: "**/AndroidManifest.xml"
+    pattern: "android:exported\\s*=\\s*\"true\""
+    severity: warning
+    desc: "Exported component — verify intent-filter restrictions and permission guards"
+
+  - id: SA-ANDROID-02
+    type: regex
+    target: "**/*.{kt,java}"
+    pattern: "rawQuery\\s*\\(\\s*\"[^\"]*\\+\\s*\\w+|rawQuery\\s*\\(\\s*\"[^\"]*\\$\\{?"
+    severity: error
+    desc: "SQL injection in ContentProvider — use parameterized selectionArgs instead of concatenation"
+
+  - id: SA-ANDROID-03
+    type: regex
+    target: "**/*.{kt,java}"
+    pattern: "addJavascriptInterface\\s*\\("
+    severity: error
+    desc: "WebView JavaScript interface — verify API level >= 17 and restrict to trusted origins"
+
+  - id: SA-ANDROID-04
+    type: regex
+    target: "**/*.{kt,java}"
+    pattern: "getSharedPreferences\\s*\\([^)]*\\)[\\s\\S]{0,80}(password|token|secret|key|credential)|MODE_WORLD_READABLE"
+    severity: error
+    desc: "Sensitive data in SharedPreferences — use EncryptedSharedPreferences"
+
+  - id: SA-ANDROID-05
+    type: regex
+    target: "**/AndroidManifest.xml"
+    pattern: "usesCleartextTraffic\\s*=\\s*\"true\"|cleartextTrafficPermitted\\s*=\\s*\"true\""
+    severity: error
+    desc: "Cleartext traffic allowed — enforce HTTPS via NetworkSecurityConfig"
+
+  - id: SA-ANDROID-06
+    type: regex
+    target: "**/AndroidManifest.xml"
+    pattern: "android:debuggable\\s*=\\s*\"true\""
+    severity: error
+    desc: "Debug mode enabled in manifest — must be false for release builds"
+
+  - id: SA-ANDROID-07
+    type: regex
+    target: "**/*.{kt,java}"
+    pattern: "registerReceiver\\s*\\(\\s*\\w+\\s*,\\s*\\w+\\s*\\)\\s*$"
+    severity: warning
+    desc: "Broadcast receiver registered without permission — add permission parameter"
+
+  - id: SA-ANDROID-08
+    type: regex
+    target: "**/*.{kt,java}"
+    pattern: "new\\s+Random\\s*\\(|java\\.util\\.Random|kotlin\\.random\\.Random"
+    severity: warning
+    desc: "Insecure random number generator — use java.security.SecureRandom for tokens"
+
+  - id: SA-ANDROID-09
+    type: regex
+    target: "**/*.{kt,java}"
+    pattern: "SecretKeySpec\\s*\\(\\s*\"[^\"]+\"\\.toByteArray|private\\s+(static\\s+)?final\\s+byte\\[\\]\\s+\\w*(KEY|key|SECRET|secret)"
+    severity: error
+    desc: "Hardcoded encryption key — use Android Keystore for key management"
+
+  - id: SA-ANDROID-10
+    type: regex
+    target: "**/*.{kt,java}"
+    pattern: "Log\\.(d|v|i)\\s*\\(\\s*\"[^\"]*\"\\s*,\\s*[^)]*?(password|token|secret|key|credential|session)"
+    severity: warning
+    desc: "Sensitive data in log output — strip debug logs in release builds"
+
+  # === IOS SDK SECURITY ===
+  - id: SA-IOS-01
+    type: regex
+    target: "**/*.swift"
+    pattern: "kSecAttrAccessibleAlways[^T]|kSecAttrAccessibleAlways\\b(?!ThisDeviceOnly)"
+    severity: error
+    desc: "Insecure Keychain accessibility — use kSecAttrAccessibleWhenUnlockedThisDeviceOnly"
+
+  - id: SA-IOS-02
+    type: regex
+    target: "**/Info.plist"
+    pattern: "NSAllowsArbitraryLoads[\\s\\S]{0,30}<true"
+    severity: error
+    desc: "App Transport Security disabled — enforce HTTPS connections"
+
+  - id: SA-IOS-03
+    type: regex
+    target: "**/*.{swift,m}"
+    pattern: "UIWebView"
+    severity: error
+    desc: "Deprecated UIWebView usage — migrate to WKWebView"
+
+  - id: SA-IOS-04
+    type: regex
+    target: "**/*.{swift,m}"
+    pattern: "UIPasteboard\\.general\\.(string|setString|setItems|setValue)[\\s\\S]{0,60}(token|password|secret|key|credential|session)"
+    severity: warning
+    desc: "Sensitive data on general pasteboard — use UIPasteboard.withUniqueName()"
+
+  - id: SA-IOS-05
+    type: regex
+    target: "**/*.{swift,m}"
+    pattern: "UserDefaults\\.(standard\\.)?set\\s*\\([^,]+,\\s*forKey:\\s*\"(token|password|secret|key|credential|session|auth)|NSUserDefaults.*set(Object|Value).*forKey.*@\"(token|password|secret)"
+    severity: error
+    desc: "Sensitive data in UserDefaults/NSUserDefaults — use Keychain instead"
+
+  - id: SA-IOS-06
+    type: regex
+    target: "**/*.{swift,m}"
+    pattern: "application\\s*\\(\\s*_\\s+app.*open\\s+url:\\s*URL|openURL:\\s*\\(NSURL\\s*\\*\\)"
+    severity: warning
+    desc: "URL scheme handler — verify source app validation and parameter sanitization"
+
+  - id: SA-IOS-07
+    type: regex
+    target: "**/*.{swift,m}"
+    pattern: "arc4random\\s*\\(|arc4random_uniform\\s*\\([\\s\\S]{0,80}(token|key|secret|session|nonce)"
+    severity: error
+    desc: "Insecure random for security tokens — use SecRandomCopyBytes"
+
+  - id: SA-IOS-08
+    type: regex
+    target: "**/*.{swift,m}"
+    pattern: "CC_MD5\\s*\\(|CC_SHA1\\s*\\(|CC_MD5_DIGEST_LENGTH"
+    severity: warning
+    desc: "Weak hash algorithm (MD5/SHA-1) — use SHA-256 via CryptoKit"
+
+  - id: SA-IOS-09
+    type: regex
+    target: "**/*.pbxproj"
+    pattern: "GCC_GENERATE_POSITION_DEPENDENT_CODE\\s*=\\s*YES|CLANG_ENABLE_OBJC_ARC\\s*=\\s*NO"
+    severity: error
+    desc: "Missing binary protections (PIE/ARC) — enable in Xcode build settings"
+
+  - id: SA-IOS-10
+    type: regex
+    target: "**/*.{swift,m}"
+    pattern: "NSLog\\s*\\(\\s*@?\"[^\"]*%([@dfs])[^\"]*\"\\s*,\\s*[^)]*?(password|token|secret|key|credential|session)"
+    severity: warning
+    desc: "Sensitive data in NSLog — use os_log with .private annotation"
+
 llm_reviews:
   # === HARDCODED CREDENTIALS REVIEW ===
   - id: SA-16
@@ -1382,2534 +3604,3 @@ llm_reviews:
       Report specific injection vectors and their remediation.
     severity: error
     desc: "Review GitHub Actions for injection vectors, permission scope, and secret exposure"
-
-  # === Imported from evandervecht/security-audit-skill fork (2026-04-19) ===
-  # Per-language, per-framework, cloud, mobile, and IaC checkpoints.
-  # Authored by E van der Vecht (MIT + CC-BY-SA-4.0 dual-licensed).
-  # Consumed by scripts/security-audit-dispatcher.sh and scripts/scanners/*.sh.
-
-  # === SECURITY DOCUMENTATION ===
-  # === SECRETS NOT IN VCS ===
-  # === COMPOSER AUDIT IN CI ===
-  # === XXE PREVENTION ===
-  # Use command type to avoid false positives from glob fallback to config files
-  # === SQL INJECTION PREVENTION ===
-  # === XSS PREVENTION ===
-  # Use command type to avoid false positives from glob fallback to config files
-  # === DEPENDABOT FOR SECURITY ===
-  # === DESERIALIZATION PREVENTION ===
-  # === INSECURE PASSWORD HASHING ===
-  # === COMMAND INJECTION ===
-  # === INSECURE RANDOMNESS ===
-  # === INFORMATION DISCLOSURE ===
-  # === FILE UPLOAD SAFETY ===
-  # === COOKIE SECURITY ===
-  # === OPEN REDIRECT ===
-  # === SECURITY HEADERS ===
-  # === CODE INJECTION (CWE-94) ===
-  # === IDOR (CWE-639) ===
-  # === SECRET SCANNING ===
-  # === SUPPLY CHAIN ===
-  # === TYPE JUGGLING (CWE-843) ===
-  # === PHAR DESERIALIZATION (CWE-502) ===
-  # === SSTI (CWE-1336) ===
-  # === EMAIL HEADER INJECTION (CWE-93) ===
-  # === LDAP INJECTION (CWE-90) ===
-  # === INSECURE TOKEN GENERATION (CWE-330) ===
-  # === LOG INJECTION / CRLF (CWE-117) ===
-  # === SESSION FIXATION (CWE-384) ===
-  # === HOST HEADER POISONING (CWE-644) ===
-  # === MASS ASSIGNMENT (CWE-915) ===
-  # === SAST TOOLING ===
-  # === DEPENDENCY SCANNING ===
-  # === GITLEAKS IN CI ===
-  # === PATH TRAVERSAL PREVENTION (CWE-22) ===
-  # === SEMGREP IN CI ===
-  # === SECURITY POLICY ===
-  # === INFRASTRUCTURE-AS-CODE SECURITY ===
-  - id: SA-IAC-01
-    type: command
-    target: "! grep -rqP '^USER\\s+root' Dockerfile* 2>/dev/null || ! grep -rqP '^USER\\s' Dockerfile* 2>/dev/null"
-    severity: warning
-    desc: "Dockerfile should not run as root - add a USER directive with a non-root user"
-
-
-  - id: SA-IAC-02
-    type: command
-    target: "! grep -rqE '(COPY|ADD).*\\.env' Dockerfile* 2>/dev/null"
-    severity: error
-    desc: "Dockerfile must not copy .env files into image layers (secrets leak)"
-
-
-  - id: SA-IAC-03
-    type: command
-    target: "! grep -rqE 'ARG.*(PASSWORD|SECRET|TOKEN|API_KEY)' Dockerfile* 2>/dev/null"
-    severity: error
-    desc: "Dockerfile ARG must not contain secrets (visible in image history)"
-
-
-  - id: SA-IAC-04
-    type: command
-    target: "! grep -rqE '^FROM\\s+\\w+\\s*$' Dockerfile* 2>/dev/null"
-    severity: warning
-    desc: "Dockerfile base images should be pinned to specific tags or digests, not latest"
-
-
-  - id: SA-IAC-05
-    type: command
-    target: "! grep -rqE 'privileged:\\s*true' docker-compose*.yml 2>/dev/null"
-    severity: error
-    desc: "Docker Compose must not use privileged mode (container escape risk)"
-
-
-  - id: SA-IAC-06
-    type: command
-    target: "! grep -rqE '/var/run/docker\\.sock' docker-compose*.yml 2>/dev/null"
-    severity: error
-    desc: "Docker Compose must not mount Docker socket (container escape risk)"
-
-
-  - id: SA-IAC-07
-    type: command
-    target: "! grep -rqE 'runAsUser:\\s*0' k8s/ kubernetes/ deploy/ manifests/ charts/ 2>/dev/null"
-    severity: error
-    desc: "Kubernetes pods must not run as root (runAsUser: 0)"
-
-
-  - id: SA-IAC-08
-    type: command
-    target: "! grep -rqE 'hostNetwork:\\s*true' k8s/ kubernetes/ deploy/ manifests/ charts/ 2>/dev/null"
-    severity: error
-    desc: "Kubernetes pods should not use host networking"
-
-
-  - id: SA-IAC-09
-    type: command
-    target: "! grep -rqE 'cidr_blocks.*0\\.0\\.0\\.0/0' *.tf **/*.tf 2>/dev/null"
-    severity: warning
-    desc: "Terraform security groups should not allow unrestricted ingress (0.0.0.0/0)"
-
-
-  - id: SA-IAC-10
-    type: command
-    target: "! grep -rqE 'acl.*public' *.tf **/*.tf 2>/dev/null"
-    severity: warning
-    desc: "Terraform S3 buckets should not use public ACLs"
-
-
-  # === FRONTEND/CLIENT-SIDE SECURITY ===
-  - id: SA-FE-01
-    type: not_contains
-    target: "**/*.js"
-    pattern: ".innerHTML ="
-    severity: warning
-    desc: "Direct innerHTML assignment may enable DOM-based XSS - use textContent or sanitize"
-
-
-  - id: SA-FE-02
-    type: not_contains
-    target: "**/*.js"
-    pattern: "document.write("
-    severity: warning
-    desc: "document.write() may enable DOM-based XSS - use DOM manipulation methods"
-
-
-  - id: SA-FE-03
-    type: command
-    target: "! grep -rqE 'eval\\s*\\(' --include='*.js' --include='*.ts' . 2>/dev/null"
-    severity: warning
-    desc: "eval() in JavaScript enables code injection - use safer alternatives"
-
-
-  - id: SA-FE-04
-    type: command
-    target: "! grep -rqE 'localStorage\\.(set|get)Item.*(token|password|secret|key|credential|session)' --include='*.js' --include='*.ts' . 2>/dev/null"
-    severity: error
-    desc: "Sensitive data (tokens, passwords, secrets) must not be stored in localStorage"
-
-
-  - id: SA-FE-05
-    type: command
-    target: "! grep -rqE 'Access-Control-Allow-Origin.*\\*' --include='*.php' --include='*.js' --include='*.conf' --include='*.yaml' --include='*.yml' . 2>/dev/null"
-    severity: warning
-    desc: "CORS wildcard (*) origin should be avoided - use specific allowed origins"
-
-
-  - id: SA-FE-06
-    type: command
-    target: "! grep -rqE 'new Function\\s*\\(' --include='*.js' --include='*.ts' . 2>/dev/null"
-    severity: warning
-    desc: "new Function() enables dynamic code execution - use safer alternatives"
-
-
-  # === AI/LLM AGENT SECURITY ===
-  - id: SA-AI-01
-    type: command
-    target: "! grep -rqE '(api_key|apiKey|API_KEY|secret|password|token)\\s*[:=]\\s*[\"'\\''](sk-|AKIA|ghp_|ghs_)' SKILL.md AGENTS.md CLAUDE.md .claude/ 2>/dev/null"
-    severity: error
-    desc: "AI agent config files must not contain hardcoded API keys or secrets"
-
-
-  - id: SA-AI-02
-    type: command
-    target: "! grep -rqE 'dangerouslyDisableSandbox|--no-verify|--force' SKILL.md AGENTS.md CLAUDE.md .claude/ 2>/dev/null"
-    severity: error
-    desc: "AI agent configs must not disable safety mechanisms (sandbox, hooks, verification)"
-
-
-  - id: SA-AI-03
-    type: command
-    target: "! grep -rqE 'Bash\\(\\*\\)|allowed-tools:.*Bash\\b[^(]' SKILL.md skills/*/SKILL.md 2>/dev/null"
-    severity: warning
-    desc: "AI skills should not grant unrestricted Bash access - scope to specific commands"
-
-
-  - id: SA-AI-04
-    type: command
-    target: "! grep -rqE '\"version\"\\s*:\\s*\"latest\"' .claude/mcp*.json mcp.json 2>/dev/null"
-    severity: warning
-    desc: "MCP server versions should be pinned, not 'latest' (supply chain risk)"
-
-
-  # === JAVASCRIPT/TYPESCRIPT SECURITY ===
-  - id: SA-JS-01
-    type: regex
-    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
-    pattern: "eval\\("
-    severity: error
-    desc: "eval() usage detected - potential code injection"
-
-
-  - id: SA-JS-02
-    type: regex
-    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
-    pattern: "\\.innerHTML\\s*="
-    severity: error
-    desc: "innerHTML assignment detected - potential DOM XSS"
-
-
-  - id: SA-JS-03
-    type: regex
-    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
-    pattern: "document\\.write\\("
-    severity: error
-    desc: "document.write() usage detected - potential DOM XSS"
-
-
-  - id: SA-JS-04
-    type: regex
-    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
-    pattern: "addEventListener\\(.message"
-    severity: warning
-    desc: "postMessage handler detected - verify origin validation"
-
-
-  - id: SA-JS-05
-    type: regex
-    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
-    pattern: "Math\\.random\\(\\)"
-    severity: warning
-    desc: "Math.random() is not cryptographically secure - use crypto.getRandomValues()"
-
-
-  - id: SA-JS-06
-    type: regex
-    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
-    pattern: "__proto__"
-    severity: error
-    desc: "__proto__ access detected - potential prototype pollution"
-
-
-  - id: SA-JS-07
-    type: regex
-    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
-    pattern: "new\\s+Function\\("
-    severity: error
-    desc: "Function constructor detected - equivalent to eval()"
-
-
-  - id: SA-JS-08
-    type: regex
-    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
-    pattern: "setTimeout\\(\\s*['\"`]"
-    severity: error
-    desc: "setTimeout with string argument - implicit eval()"
-
-
-  - id: SA-JS-09
-    type: regex
-    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
-    pattern: "\\.outerHTML\\s*="
-    severity: error
-    desc: "outerHTML assignment detected - potential DOM XSS"
-
-
-  - id: SA-JS-10
-    type: regex
-    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
-    pattern: "\\bdebugger\\b"
-    severity: warning
-    desc: "debugger statement detected - must not ship to production"
-
-
-  - id: SA-JS-11
-    type: regex
-    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
-    pattern: "require\\(.serialize-javascript"
-    severity: warning
-    desc: "serialize-javascript outputs executable JS - ensure output is never eval'd"
-
-
-  - id: SA-JS-12
-    type: regex
-    target: "**/*.{ts,tsx}"
-    pattern: ":\\s*any\\b"
-    severity: warning
-    desc: "TypeScript 'any' type disables type checking - use 'unknown' for untrusted input"
-
-
-  - id: SA-JS-13
-    type: regex
-    target: "**/*.{ts,tsx}"
-    pattern: "as\\s+unknown\\s+as"
-    severity: error
-    desc: "Double type assertion bypasses TypeScript safety - use runtime validation"
-
-
-  - id: SA-JS-14
-    type: regex
-    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
-    pattern: "import\\([^)]*\\$\\{"
-    severity: error
-    desc: "Dynamic import with template variable - potential module injection"
-
-
-  - id: SA-JS-15
-    type: regex
-    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
-    pattern: "setInterval\\(\\s*['\"`]"
-    severity: error
-    desc: "setInterval with string argument - implicit eval()"
-
-
-  - id: SA-JS-17
-    type: regex
-    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
-    pattern: "postMessage\\([^,]+,\\s*['\"]\\*['\"]"
-    severity: error
-    desc: "postMessage with wildcard origin - data exposed to any frame"
-
-
-  # === NODE.JS SERVER-SIDE SECURITY (Phase 3) ===
-  - id: SA-NODE-01
-    type: regex
-    target: "**/*.{js,ts,mjs,cjs}"
-    pattern: "child_process.*exec\\("
-    severity: error
-    desc: "child_process.exec() with potential command injection — use execFile or spawn instead"
-
-
-  - id: SA-NODE-02
-    type: regex
-    target: "**/*.{js,ts,mjs,cjs}"
-    pattern: "fs\\.(readFile|writeFile|readdir|unlink).*req\\.(query|params|body)"
-    severity: error
-    desc: "fs operation with user input — validate and restrict paths with path.resolve + startsWith"
-
-
-  - id: SA-NODE-03
-    type: regex
-    target: "**/*.{js,ts,mjs,cjs}"
-    pattern: "require\\s*\\(\\s*['\"]vm2?['\"]\\s*\\)"
-    severity: error
-    desc: "vm/vm2 module is not a security boundary — use OS-level isolation for untrusted code"
-
-
-  - id: SA-NODE-04
-    type: regex
-    target: "**/*.{js,ts,mjs,cjs}"
-    pattern: "Buffer\\.(allocUnsafe|allocUnsafeSlow)\\s*\\("
-    severity: warning
-    desc: "Buffer.allocUnsafe returns uninitialized memory — use Buffer.alloc unless fully overwritten"
-
-
-  - id: SA-NODE-05
-    type: regex
-    target: "**/*.{js,ts,mjs,cjs}"
-    pattern: "require\\s*\\(\\s*[^'\"\\s].*[+`]"
-    severity: error
-    desc: "Dynamic require() with variable path — use an allowlist of permitted modules"
-
-
-  - id: SA-NODE-06
-    type: regex
-    target: "**/*.{js,ts,mjs,cjs}"
-    pattern: "(hashSync|compareSync|pbkdf2Sync|scryptSync)\\s*\\("
-    severity: warning
-    desc: "Synchronous crypto in request handler blocks event loop — use async variant"
-
-
-  - id: SA-NODE-07
-    type: regex
-    target: "**/*.{js,ts,mjs,cjs}"
-    pattern: "res\\.(setHeader|writeHead)\\s*\\([^)]*req\\.(query|params|body|headers)"
-    severity: error
-    desc: "User input in HTTP response header — risk of CRLF injection"
-
-
-  - id: SA-NODE-08
-    type: regex
-    target: "**/*.{js,ts,mjs,cjs}"
-    pattern: "Math\\.random\\s*\\("
-    severity: warning
-    desc: "Math.random() is not cryptographically secure — use crypto.randomUUID() or crypto.randomBytes()"
-
-
-  - id: SA-NODE-09
-    type: regex
-    target: "**/*.{js,ts,mjs,cjs}"
-    pattern: "http\\.createServer\\s*\\("
-    severity: warning
-    desc: "http.createServer — verify headersTimeout, requestTimeout, and body size limits are set"
-
-
-  - id: SA-NODE-10
-    type: regex
-    target: "**/*.{js,ts,mjs,cjs}"
-    pattern: "Object\\.assign\\s*\\([^,]+,\\s*req\\.(body|query|params)"
-    severity: error
-    desc: "Object.assign with user input — risk of prototype pollution"
-
-
-  - id: SA-NODE-11
-    type: regex
-    target: "**/*.{js,ts,mjs,cjs}"
-    pattern: "\\beval\\s*\\("
-    severity: error
-    desc: "eval() executes arbitrary code — use safe alternatives"
-
-
-  - id: SA-NODE-12
-    type: regex
-    target: "**/*.{js,ts,mjs,cjs}"
-    pattern: "createHash\\s*\\(\\s*['\"]md5['\"]"
-    severity: warning
-    desc: "MD5 is cryptographically broken — use SHA-256 or stronger"
-
-
-  - id: SA-NODE-13
-    type: regex
-    target: "**/*.{js,ts,mjs,cjs}"
-    pattern: "createHash\\s*\\(\\s*['\"]sha1['\"]"
-    severity: warning
-    desc: "SHA-1 is cryptographically weak — use SHA-256 or stronger"
-
-
-  - id: SA-NODE-14
-    type: regex
-    target: "**/*.{js,ts,mjs,cjs}"
-    pattern: "new\\s+Function\\s*\\("
-    severity: error
-    desc: "new Function() is equivalent to eval — use safe alternatives"
-
-
-  - id: SA-NODE-15
-    type: regex
-    target: "**/*.{js,ts,mjs,cjs}"
-    pattern: "fetch\\s*\\(\\s*req\\.(query|params|body)"
-    severity: error
-    desc: "fetch with user-supplied URL — risk of SSRF, validate and restrict URLs"
-
-
-  # === PYTHON SECURITY CHECKS (Phase 4) ===
-  - id: SA-PY-01
-    type: regex
-    target: "**/*.py"
-    pattern: "pickle\\.(loads|load)\\("
-    severity: error
-    desc: "Insecure deserialization via pickle"
-
-
-  - id: SA-PY-02
-    type: regex
-    target: "**/*.py"
-    pattern: "eval\\("
-    severity: error
-    desc: "Code injection via eval()"
-
-
-  - id: SA-PY-03
-    type: regex
-    target: "**/*.py"
-    pattern: "exec\\("
-    severity: error
-    desc: "Code injection via exec()"
-
-
-  - id: SA-PY-04
-    type: regex
-    target: "**/*.py"
-    pattern: "subprocess\\.\\w+\\(.*shell\\s*=\\s*True"
-    severity: error
-    desc: "Command injection via subprocess with shell=True"
-
-
-  - id: SA-PY-05
-    type: regex
-    target: "**/*.py"
-    pattern: "os\\.system\\("
-    severity: error
-    desc: "Command injection via os.system()"
-
-
-  - id: SA-PY-06
-    type: regex
-    target: "**/*.py"
-    pattern: "yaml\\.load\\("
-    severity: error
-    desc: "Unsafe YAML loading — use yaml.safe_load() instead"
-
-
-  - id: SA-PY-07
-    type: regex
-    target: "**/*.py"
-    pattern: "execute\\(f\""
-    severity: error
-    desc: "SQL injection via f-string in query"
-
-
-  - id: SA-PY-08
-    type: regex
-    target: "**/*.py"
-    pattern: "execute\\(.*\\.format\\("
-    severity: error
-    desc: "SQL injection via .format() in query"
-
-
-  - id: SA-PY-09
-    type: regex
-    target: "**/*.py"
-    pattern: "hashlib\\.md5\\("
-    severity: warning
-    desc: "Weak hash algorithm MD5 — use SHA-256+ or argon2 for passwords"
-
-
-  - id: SA-PY-10
-    type: regex
-    target: "**/*.py"
-    pattern: "hashlib\\.sha1\\("
-    severity: warning
-    desc: "Weak hash algorithm SHA1 — use SHA-256+ for integrity checks"
-
-
-  - id: SA-PY-11
-    type: regex
-    target: "**/*.py"
-    pattern: "tempfile\\.mktemp\\("
-    severity: error
-    desc: "Deprecated tempfile.mktemp() has race condition — use mkstemp()"
-
-
-  - id: SA-PY-12
-    type: regex
-    target: "**/*.py"
-    pattern: "__import__\\("
-    severity: warning
-    desc: "Dynamic import via __import__() — validate module names against a whitelist"
-
-
-  - id: SA-PY-13
-    type: regex
-    target: "**/*.py"
-    pattern: "xml\\.etree\\.ElementTree"
-    severity: warning
-    desc: "Standard library XML parser — use defusedxml to prevent XXE attacks"
-
-
-  - id: SA-PY-14
-    type: regex
-    target: "**/*.py"
-    pattern: "Template\\s*\\(.*\\w+.*\\)"
-    severity: warning
-    desc: "Jinja2/Mako Template with variable input — risk of SSTI"
-
-
-  - id: SA-PY-15
-    type: regex
-    target: "**/*.py"
-    pattern: "os\\.popen\\("
-    severity: error
-    desc: "Command injection via os.popen()"
-
-
-  - id: SA-PY-16
-    type: regex
-    target: "**/*.py"
-    pattern: "compile\\(.*,.*,"
-    severity: warning
-    desc: "compile() with dynamic input — risk of code injection"
-
-
-  - id: SA-PY-17
-    type: regex
-    target: "**/*.py"
-    pattern: "shelve\\.open\\("
-    severity: warning
-    desc: "shelve uses pickle internally — insecure deserialization risk"
-
-
-  - id: SA-PY-18
-    type: regex
-    target: "**/*.py"
-    pattern: "marshal\\.loads\\("
-    severity: warning
-    desc: "Insecure deserialization via marshal"
-
-
-  # === RUBY SECURITY CHECKS (Phase 4) ===
-  - id: SA-RB-01
-    type: regex
-    target: "**/*.rb"
-    pattern: "\\beval\\s*\\("
-    severity: error
-    desc: "eval() usage — potential code injection"
-
-
-  - id: SA-RB-02
-    type: regex
-    target: "**/*.rb"
-    pattern: "\\.send\\s*\\("
-    severity: warning
-    desc: "send() with dynamic method — potential method injection"
-
-
-  - id: SA-RB-03
-    type: regex
-    target: "**/*.rb"
-    pattern: "\\bsystem\\s*\\("
-    severity: warning
-    desc: "system() call — verify no user input in command string"
-
-
-  - id: SA-RB-04
-    type: regex
-    target: "**/*.rb"
-    pattern: "Marshal\\.load\\s*\\("
-    severity: error
-    desc: "Marshal.load — insecure deserialization of untrusted data"
-
-
-  - id: SA-RB-05
-    type: regex
-    target: "**/*.rb"
-    pattern: "YAML\\.load\\s*\\("
-    severity: error
-    desc: "YAML.load without safe_load — insecure deserialization risk"
-
-
-  - id: SA-RB-06
-    type: regex
-    target: "**/*.rb"
-    pattern: "ERB\\.new\\s*\\("
-    severity: warning
-    desc: "ERB.new — audit for template injection with user input"
-
-
-  - id: SA-RB-07
-    type: regex
-    target: "**/*.rb"
-    pattern: "find_by_sql\\s*\\("
-    severity: error
-    desc: "find_by_sql — risk of SQL injection with string interpolation"
-
-
-  - id: SA-RB-08
-    type: regex
-    target: "**/*.rb"
-    pattern: "\\.html_safe\\b"
-    severity: warning
-    desc: "html_safe bypasses Rails XSS escaping — audit for user input"
-
-
-  - id: SA-RB-09
-    type: regex
-    target: "**/*.rb"
-    pattern: "\\braw\\s*\\("
-    severity: warning
-    desc: "raw() bypasses Rails XSS escaping — audit for user input"
-
-
-  - id: SA-RB-10
-    type: regex
-    target: "**/*.rb"
-    pattern: "\\bKernel\\.open\\s*\\("
-    severity: error
-    desc: "Kernel.open — pipe injection and SSRF risk with user input"
-
-
-  - id: SA-RB-11
-    type: regex
-    target: "**/*.rb"
-    pattern: "\\.permit!\\b"
-    severity: error
-    desc: "permit! allows all params — mass assignment vulnerability"
-
-
-  - id: SA-RB-12
-    type: regex
-    target: "**/*.rb"
-    pattern: "Digest::MD5"
-    severity: warning
-    desc: "MD5 is cryptographically broken — use SHA-256 or bcrypt"
-
-
-  - id: SA-RB-13
-    type: regex
-    target: "**/*.rb"
-    pattern: "Digest::SHA1"
-    severity: warning
-    desc: "SHA-1 is cryptographically weak — use SHA-256 or stronger"
-
-
-  - id: SA-RB-14
-    type: regex
-    target: "**/*.rb"
-    pattern: "\\bexec\\s*\\("
-    severity: warning
-    desc: "exec() call — verify no user input in command string"
-
-
-  - id: SA-RB-15
-    type: regex
-    target: "**/*.rb"
-    pattern: "\\bopen\\s*\\(\\s*[\"']\\|"
-    severity: error
-    desc: "open() with pipe prefix — direct command execution"
-
-
-  # === JAVA SECURITY CHECKS (Phase 2) ===
-  - id: SA-JAVA-01
-    type: regex
-    target: "**/*.java"
-    pattern: "new\\s+ObjectInputStream\\s*\\("
-    severity: error
-    desc: "ObjectInputStream deserialization — risk of RCE via gadget chains"
-
-
-  - id: SA-JAVA-02
-    type: regex
-    target: "**/*.java"
-    pattern: "new\\s+XMLDecoder\\s*\\("
-    severity: error
-    desc: "XMLDecoder deserialization — enables arbitrary code execution"
-
-
-  - id: SA-JAVA-03
-    type: regex
-    target: "**/*.java"
-    pattern: "InitialContext\\s*\\(\\s*\\)[\\s\\S]{0,100}\\.lookup\\s*\\("
-    severity: error
-    desc: "JNDI lookup — risk of remote class loading (Log4Shell pattern)"
-
-
-  - id: SA-JAVA-04
-    type: regex
-    target: "**/*.java"
-    pattern: "Class\\.forName\\s*\\("
-    severity: warning
-    desc: "Reflection via Class.forName — risk of arbitrary class instantiation"
-
-
-  - id: SA-JAVA-05
-    type: regex
-    target: "**/*.java"
-    pattern: "(createStatement|executeQuery|executeUpdate)\\s*\\([^)]*\\+"
-    severity: error
-    desc: "JDBC string concatenation — SQL injection risk, use PreparedStatement"
-
-
-  - id: SA-JAVA-06
-    type: regex
-    target: "**/*.java"
-    pattern: "DocumentBuilderFactory\\.newInstance\\s*\\("
-    severity: warning
-    desc: "XML parsing without explicit XXE protection — disable external entities"
-
-
-  - id: SA-JAVA-07
-    type: regex
-    target: "**/*.java"
-    pattern: "Runtime\\.getRuntime\\s*\\(\\s*\\)\\.exec\\s*\\("
-    severity: error
-    desc: "Runtime.exec — command injection risk, use ProcessBuilder with array args"
-
-
-  - id: SA-JAVA-08
-    type: regex
-    target: "**/*.java"
-    pattern: "getInstance\\s*\\(\\s*\"(MD5|SHA-1)\"\\s*\\)"
-    severity: warning
-    desc: "Weak hash algorithm (MD5/SHA-1) — use SHA-256 or stronger"
-
-
-  - id: SA-JAVA-09
-    type: regex
-    target: "**/*.java"
-    pattern: "new\\s+Random\\s*\\("
-    severity: warning
-    desc: "java.util.Random is predictable — use SecureRandom for security operations"
-
-
-  - id: SA-JAVA-10
-    type: regex
-    target: "**/*.java"
-    pattern: "Cipher\\.getInstance\\s*\\(\\s*\"(DES|.*ECB)"
-    severity: error
-    desc: "Weak cipher (DES/ECB) — use AES-GCM for authenticated encryption"
-
-
-  - id: SA-JAVA-11
-    type: regex
-    target: "**/*.java"
-    pattern: "(openConnection|openStream)\\s*\\(\\s*\\)"
-    severity: warning
-    desc: "URL.openConnection/openStream — SSRF risk, validate and restrict URLs"
-
-
-  - id: SA-JAVA-12
-    type: regex
-    target: "**/*.java"
-    pattern: "new\\s+File\\s*\\(\\s*[^)]*\\+\\s*(request|req|param|input|args)"
-    severity: warning
-    desc: "File path from user input — path traversal risk, validate canonical path"
-
-
-  # === C# SECURITY CHECKS (Phase 2) ===
-  - id: SA-CS-01
-    type: regex
-    target: "**/*.cs"
-    pattern: "new\\s+BinaryFormatter\\s*\\("
-    severity: error
-    desc: "BinaryFormatter deserialization — RCE risk, use System.Text.Json"
-
-
-  - id: SA-CS-02
-    type: regex
-    target: "**/*.cs"
-    pattern: "new\\s+NetDataContractSerializer\\s*\\("
-    severity: error
-    desc: "NetDataContractSerializer — insecure deserialization with type embedding"
-
-
-  - id: SA-CS-03
-    type: regex
-    target: "**/*.cs"
-    pattern: "FromSqlRaw\\s*\\(\\s*\\$"
-    severity: error
-    desc: "FromSqlRaw with interpolation — SQL injection, use FromSqlInterpolated"
-
-
-  - id: SA-CS-04
-    type: regex
-    target: "**/*.cs"
-    pattern: "new\\s+XmlDocument\\s*\\("
-    severity: warning
-    desc: "XmlDocument — set XmlResolver=null and disable DTD processing"
-
-
-  - id: SA-CS-05
-    type: regex
-    target: "**/*.cs"
-    pattern: "Process\\.Start\\s*\\("
-    severity: warning
-    desc: "Process.Start — command injection risk, set UseShellExecute=false"
-
-
-  - id: SA-CS-06
-    type: regex
-    target: "**/*.cs"
-    pattern: "MD5\\.Create\\s*\\("
-    severity: warning
-    desc: "MD5 is cryptographically broken — use SHA256 or stronger"
-
-
-  - id: SA-CS-07
-    type: regex
-    target: "**/*.cs"
-    pattern: "SHA1\\.Create\\s*\\("
-    severity: warning
-    desc: "SHA-1 is cryptographically weak — use SHA256 or stronger"
-
-
-  - id: SA-CS-08
-    type: regex
-    target: "**/*.cs"
-    pattern: "new\\s+Random\\s*\\("
-    severity: warning
-    desc: "System.Random is predictable — use RandomNumberGenerator for security"
-
-
-  - id: SA-CS-09
-    type: regex
-    target: "**/*.cs"
-    pattern: "DESCryptoServiceProvider"
-    severity: error
-    desc: "DES is broken (56-bit key) — use AES-GCM"
-
-
-  - id: SA-CS-10
-    type: regex
-    target: "**/*.cs"
-    pattern: "AllowAnyOrigin\\s*\\("
-    severity: error
-    desc: "CORS AllowAnyOrigin — use explicit origin allowlist"
-
-
-  - id: SA-CS-11
-    type: regex
-    target: "**/*.cs"
-    pattern: "DirectorySearcher\\s*\\(\\s*\\$"
-    severity: error
-    desc: "LDAP injection via DirectorySearcher with interpolation"
-
-
-  - id: SA-CS-12
-    type: regex
-    target: "**/*.cs"
-    pattern: "UseShellExecute\\s*=\\s*true"
-    severity: warning
-    desc: "UseShellExecute=true passes args through shell — set to false"
-
-
-  # === GO SECURITY CHECKS ===
-  - id: SA-GO-01
-    type: regex
-    target: "**/*.go"
-    pattern: "unsafe\\.(Pointer|Sizeof|Slice|String|Offsetof|Alignof)"
-    severity: warning
-    desc: "unsafe package usage — bypasses Go memory safety, audit required"
-
-
-  - id: SA-GO-02
-    type: regex
-    target: "**/*.go"
-    pattern: "\"text/template\""
-    severity: error
-    desc: "text/template does not escape HTML — use html/template for web output"
-
-
-  - id: SA-GO-03
-    type: regex
-    target: "**/*.go"
-    pattern: "(Sprintf|\"\\s*\\+).*(SELECT|INSERT|UPDATE|DELETE|select|insert|update|delete)"
-    severity: error
-    desc: "SQL string concatenation — use parameterized queries"
-
-
-  - id: SA-GO-04
-    type: regex
-    target: "**/*.go"
-    pattern: "exec\\.Command\\s*\\(\\s*\"(sh|bash|cmd|powershell)\""
-    severity: error
-    desc: "Shell invocation via exec.Command — risk of command injection"
-
-
-  - id: SA-GO-05
-    type: regex
-    target: "**/*.go"
-    pattern: "filepath\\.Join\\s*\\(.*\\b(r\\.|req\\.|request\\.|URL)"
-    severity: warning
-    desc: "filepath.Join with user input — validate resolved path stays within base"
-
-
-  - id: SA-GO-06
-    type: regex
-    target: "**/*.go"
-    pattern: "InsecureSkipVerify\\s*:\\s*true"
-    severity: error
-    desc: "TLS certificate verification disabled — enables MITM attacks"
-
-
-  - id: SA-GO-07
-    type: regex
-    target: "**/*.go"
-    pattern: "\"math/rand\""
-    severity: warning
-    desc: "math/rand is not cryptographically secure — use crypto/rand for secrets"
-
-
-  - id: SA-GO-08
-    type: regex
-    target: "**/*.go"
-    pattern: "http\\.(Get|Post|Head)\\s*\\(.*\\b(r\\.|req\\.|request\\.|URL)"
-    severity: error
-    desc: "HTTP request with user-controlled URL — SSRF risk"
-
-
-  - id: SA-GO-09
-    type: regex
-    target: "**/*.go"
-    pattern: "log\\.(Print|Fatal|Panic)(f|ln)?\\s*\\("
-    severity: warning
-    desc: "Unstructured logging — use log/slog for security event logging"
-
-
-  - id: SA-GO-10
-    type: regex
-    target: "**/*.go"
-    pattern: "Header\\(\\)\\.Set\\s*\\(.*\\b(r\\.|req\\.)"
-    severity: warning
-    desc: "HTTP header set with request data — risk of header injection"
-
-
-  - id: SA-GO-11
-    type: regex
-    target: "**/*.go"
-    pattern: "VersionTLS1[01]\\b"
-    severity: error
-    desc: "TLS 1.0/1.1 is insecure — use TLS 1.2 or higher"
-
-
-  - id: SA-GO-12
-    type: regex
-    target: "**/*.go"
-    pattern: "(password|secret|apiKey|token)\\s*[:=]\\s*\"[^\"]{8,}\""
-    severity: error
-    desc: "Potential hardcoded credential — use environment variables or secret manager"
-
-
-  # === RUST SECURITY CHECKS ===
-  - id: SA-RS-01
-    type: regex
-    target: "**/*.rs"
-    pattern: "unsafe\\s*\\{|unsafe\\s+fn\\s|unsafe\\s+impl\\s"
-    severity: warning
-    desc: "unsafe block/fn/impl — bypasses Rust safety guarantees, audit required"
-
-
-  - id: SA-RS-02
-    type: regex
-    target: "**/*.rs"
-    pattern: "extern\\s+\"C\"\\s*\\{|#\\[no_mangle\\]"
-    severity: warning
-    desc: "FFI boundary — audit for null pointers, lifetime issues, and error handling"
-
-
-  - id: SA-RS-03
-    type: regex
-    target: "**/*.rs"
-    pattern: "panic!\\s*\\(|todo!\\s*\\(|unimplemented!\\s*\\("
-    severity: warning
-    desc: "panic!/todo!/unimplemented! in code — can cause DoS via unwinding"
-
-
-  - id: SA-RS-04
-    type: regex
-    target: "**/*.rs"
-    pattern: "\\.unwrap\\(\\)|\\.expect\\(\\s*\""
-    severity: warning
-    desc: ".unwrap()/.expect() can panic — use ? or match in production paths"
-
-
-  - id: SA-RS-05
-    type: regex
-    target: "**/*.rs"
-    pattern: "as\\s+\\*const\\s|as\\s+\\*mut\\s"
-    severity: warning
-    desc: "Raw pointer cast — potential use-after-free or null deref in unsafe code"
-
-
-  - id: SA-RS-06
-    type: regex
-    target: "**/*.rs"
-    pattern: "sql_query\\s*\\(\\s*format!|query.*&format!"
-    severity: error
-    desc: "SQL query with format! string — use parameterized queries"
-
-
-  - id: SA-RS-07
-    type: regex
-    target: "**/*.rs"
-    pattern: "Command::new\\s*\\(\\s*\"(sh|bash|cmd|powershell)\""
-    severity: error
-    desc: "Shell invocation via Command::new — risk of command injection"
-
-
-  - id: SA-RS-08
-    type: regex
-    target: "**/*.rs"
-    pattern: "\\.join\\s*\\(.*\\b(req|input|param|query|user)"
-    severity: warning
-    desc: "Path join with user input — validate resolved path stays within base"
-
-
-  - id: SA-RS-09
-    type: regex
-    target: "**/*.rs"
-    pattern: "serde_json::from_(str|slice|reader)\\s*\\("
-    severity: warning
-    desc: "Deserialization of potentially untrusted data — enforce size limits"
-
-
-  - id: SA-RS-10
-    type: regex
-    target: "**/*.rs"
-    pattern: "==\\s*(token|secret|hmac|hash|key|password|mac|signature)"
-    severity: error
-    desc: "Non-constant-time comparison of secret — use constant_time_eq"
-
-
-  - id: SA-RS-11
-    type: regex
-    target: "**/*.rs"
-    pattern: "mem::forget\\s*\\(|ManuallyDrop::new\\s*\\("
-    severity: warning
-    desc: "mem::forget/ManuallyDrop prevents cleanup — sensitive data may persist"
-
-
-  - id: SA-RS-12
-    type: regex
-    target: "**/*.rs"
-    pattern: "(password|secret|api_key|token)\\s*[:=]\\s*\"[^\"]{8,}\""
-    severity: error
-    desc: "Potential hardcoded credential — use environment variables or secret manager"
-
-
-  # === VUE.JS SECURITY CHECKS ===
-  - id: SA-VUE-01
-    type: regex
-    target: "**/*.{vue,js,ts}"
-    pattern: "v-html\\s*="
-    severity: warning
-    desc: "v-html directive — potential XSS if used with user input"
-
-
-  - id: SA-VUE-02
-    type: regex
-    target: "**/*.{vue,js,ts}"
-    pattern: "Vue\\.compile\\s*\\("
-    severity: error
-    desc: "Vue.compile() with dynamic input — potential template injection"
-
-
-  - id: SA-VUE-03
-    type: regex
-    target: "**/*.{vue,js,ts}"
-    pattern: ":(href|src)\\s*=\\s*\"[^\"]*[a-zA-Z]"
-    severity: warning
-    desc: "v-bind:href/src with variable — validate URL protocol to prevent javascript: XSS"
-
-
-  - id: SA-VUE-04
-    type: regex
-    target: "**/*.{vue,js,ts}"
-    pattern: "beforeEnter\\s*:|beforeEach\\s*\\("
-    severity: warning
-    desc: "Client-side route guard — ensure server-side authorization exists"
-
-
-  - id: SA-VUE-05
-    type: regex
-    target: "**/*.{vue,js,ts}"
-    pattern: "(computed|watch|methods)\\s*:\\s*\\{[^}]*eval\\s*\\("
-    severity: error
-    desc: "eval() in Vue reactivity hook — potential code injection"
-
-
-  - id: SA-VUE-06
-    type: regex
-    target: "**/*.{vue,js,ts}"
-    pattern: "(defineStore|new\\s+Vuex\\.Store)\\s*\\([^)]*\\{[\\s\\S]*?(token|secret|password|apiKey|api_key|ssn|creditCard)"
-    severity: error
-    desc: "Sensitive data in Vuex/Pinia store — exposed via DevTools"
-
-
-  - id: SA-VUE-07
-    type: regex
-    target: "**/*.{vue,js,ts}"
-    pattern: "(asyncData|serverPrefetch|fetch)\\s*\\([^)]*\\)\\s*\\{[\\s\\S]*?(secret|internal|private|apiKey|connectionString)"
-    severity: error
-    desc: "SSR hydration may leak server-only data to client HTML"
-
-
-  - id: SA-VUE-08
-    type: regex
-    target: "**/*.{vue,js,ts}"
-    pattern: "Vue\\.mixin\\s*\\(|app\\.mixin\\s*\\("
-    severity: warning
-    desc: "Global mixin — applies to every component, audit for side effects"
-
-
-  # === ANGULAR SECURITY CHECKS ===
-  - id: SA-ANG-01
-    type: regex
-    target: "**/*.{ts,html}"
-    pattern: "bypassSecurityTrust(Html|Script|Url|ResourceUrl)\\s*\\("
-    severity: error
-    desc: "bypassSecurityTrust* disables Angular sanitization — audit for user input"
-
-
-  - id: SA-ANG-02
-    type: regex
-    target: "**/*.{ts,html}"
-    pattern: "compiler\\.compileModuleAndAllComponentsAsync|Component\\(\\s*\\{\\s*template\\s*:"
-    severity: error
-    desc: "Dynamic template compilation — potential template injection"
-
-
-  - id: SA-ANG-03
-    type: regex
-    target: "**/*.{ts,html}"
-    pattern: "@Pipe[\\s\\S]*?bypassSecurityTrust"
-    severity: error
-    desc: "Pipe with bypassSecurityTrust — reusable sanitization bypass"
-
-
-  - id: SA-ANG-04
-    type: regex
-    target: "**/*.{ts,html}"
-    pattern: "\\[innerHTML\\]\\s*="
-    severity: warning
-    desc: "innerHTML binding — verify input is sanitized before binding"
-
-
-  - id: SA-ANG-05
-    type: regex
-    target: "**/*.{ts,html}"
-    pattern: "canActivate|CanActivate|canLoad|CanLoad"
-    severity: warning
-    desc: "Client-side route guard — ensure server-side authorization exists"
-
-
-  - id: SA-ANG-06
-    type: regex
-    target: "**/*.{ts,html}"
-    pattern: "HttpInterceptor[\\s\\S]*?intercept\\s*\\("
-    severity: warning
-    desc: "HTTP interceptor — verify tokens are only sent to trusted origins"
-
-
-  - id: SA-ANG-07
-    type: regex
-    target: "**/*.{ts,html}"
-    pattern: "eval\\s*\\([^)]*\\)|new\\s+Function\\s*\\("
-    severity: error
-    desc: "eval/new Function in Angular code — potential code injection"
-
-
-  - id: SA-ANG-08
-    type: regex
-    target: "**/*.{ts,html}"
-    pattern: "ngZone\\.run\\s*\\([\\s\\S]*?(password|token|secret|creditCard|ssn|apiKey)"
-    severity: warning
-    desc: "Sensitive data in Zone.js context — may persist in memory"
-
-
-  # === REACT SECURITY CHECKS ===
-  - id: SA-REACT-01
-    type: regex
-    target: "**/*.{jsx,tsx}"
-    pattern: "dangerouslySetInnerHTML"
-    severity: warning
-    desc: "dangerouslySetInnerHTML usage — potential XSS"
-
-
-  - id: SA-REACT-02
-    type: regex
-    target: "**/*.{jsx,tsx}"
-    pattern: "\\{\\s*\\.\\.\\.(?:user|props|data|input|params|query)"
-    severity: warning
-    desc: "Spreading user-controlled object as JSX props — may inject dangerouslySetInnerHTML"
-
-
-  - id: SA-REACT-03
-    type: regex
-    target: "**/*.{jsx,tsx}"
-    pattern: "href\\s*=\\s*\\{(?!['\"](https?:|mailto:|/)[^}])"
-    severity: warning
-    desc: "Dynamic href from variable — potential javascript: protocol XSS"
-
-
-  - id: SA-REACT-04
-    type: regex
-    target: "**/*.{jsx,tsx}"
-    pattern: "'use client'[\\s\\S]*?\\b(password|secret|token|ssn|creditCard|hash)\\b"
-    severity: warning
-    desc: "Client component may receive sensitive data as props — data visible in browser"
-
-
-  - id: SA-REACT-05
-    type: regex
-    target: "**/*.{jsx,tsx}"
-    pattern: "\\beval\\s*\\(|new\\s+Function\\s*\\("
-    severity: error
-    desc: "eval() or Function constructor — code injection risk"
-
-
-  - id: SA-REACT-06
-    type: regex
-    target: "**/*.{jsx,tsx}"
-    pattern: "useState\\s*\\(\\s*\\{[^}]*(token|secret|password|refreshToken|cvv|ssn|creditCard)"
-    severity: warning
-    desc: "Sensitive data in React state — visible in DevTools"
-
-
-  - id: SA-REACT-07
-    type: regex
-    target: "**/*.{jsx,tsx}"
-    pattern: "useEffect\\s*\\(\\s*\\(\\)\\s*=>\\s*\\{[^}]*fetch\\s*\\([^)]*\\)\\.then"
-    severity: warning
-    desc: "useEffect fetch without visible auth — verify credentials are included"
-
-
-  - id: SA-REACT-08
-    type: regex
-    target: "**/*.{jsx,tsx}"
-    pattern: "key\\s*=\\s*\\{[^}]*(index|idx|i)\\s*\\}"
-    severity: info
-    desc: "Array index as React key — may cause state leaks between list items"
-
-
-  # === NEXT.JS SECURITY CHECKS ===
-  - id: SA-NEXT-01
-    type: regex
-    target: "**/*.{js,ts,jsx,tsx}"
-    pattern: "'use server'[\\s\\S]*?export\\s+async\\s+function\\s+\\w+"
-    severity: warning
-    desc: "Server Action — verify auth/authorization check inside function body"
-
-
-  - id: SA-NEXT-02
-    type: regex
-    target: "**/*.{js,ts}"
-    pattern: "export\\s+async\\s+function\\s+(GET|POST|PUT|DELETE|PATCH)\\s*\\("
-    severity: warning
-    desc: "Next.js API route handler — verify authentication is enforced"
-
-
-  - id: SA-NEXT-03
-    type: regex
-    target: "**/*.env*"
-    pattern: "NEXT_PUBLIC_[A-Z_]*(SECRET|KEY|PASSWORD|TOKEN|CREDENTIAL|PRIVATE|DATABASE)"
-    severity: error
-    desc: "NEXT_PUBLIC_ env var with secret-like name — exposed to client bundle"
-
-
-  - id: SA-NEXT-04
-    type: regex
-    target: "**/*.{js,ts,jsx,tsx}"
-    pattern: "(getServerSideProps|getStaticProps)[\\s\\S]*?return\\s*\\{\\s*props:"
-    severity: warning
-    desc: "getServerSideProps/getStaticProps return — verify no sensitive fields in props"
-
-
-  - id: SA-NEXT-05
-    type: regex
-    target: "**/next.config.{js,mjs,ts}"
-    pattern: "hostname:\\s*['\"]?\\*{1,2}['\"]?"
-    severity: error
-    desc: "Wildcard hostname in next/image config — SSRF risk via image optimization"
-
-
-  - id: SA-NEXT-06
-    type: regex
-    target: "**/*.{js,ts,jsx,tsx}"
-    pattern: "Response\\.redirect\\s*\\([^)]*searchParams|redirect\\s*\\(\\s*(?:req|request)"
-    severity: warning
-    desc: "Redirect with user-controlled destination — potential open redirect"
-
-
-  - id: SA-NEXT-07
-    type: regex
-    target: "**/*.{js,ts,jsx,tsx}"
-    pattern: "JSON\\.stringify\\s*\\([^)]*(config|secret|user|session|token|key|credential)"
-    severity: warning
-    desc: "JSON.stringify of potentially sensitive object — may leak in RSC payload"
-
-
-  - id: SA-NEXT-08
-    type: regex
-    target: "**/*.{js,ts}"
-    pattern: "export\\s+async\\s+function\\s+POST\\s*\\([^)]*\\)\\s*\\{[^}]*(?:cookie|session|auth)"
-    severity: warning
-    desc: "POST handler with cookie/session auth — verify CSRF protection"
-
-
-  # === NUXT SECURITY CHECKS ===
-  - id: SA-NUXT-01
-    type: regex
-    target: "server/**/*.{js,ts}"
-    pattern: "defineEventHandler\\s*\\(\\s*async\\s*\\(\\s*event\\s*\\)"
-    severity: warning
-    desc: "Nitro server handler — verify authentication middleware is applied"
-
-
-  - id: SA-NUXT-02
-    type: regex
-    target: "**/*.{vue,js,ts}"
-    pattern: "useFetch\\s*\\(\\s*['\"][^'\"]*admin|useAsyncData\\s*\\(\\s*['\"][^'\"]*secret"
-    severity: warning
-    desc: "useFetch/useAsyncData fetching sensitive endpoint — data exposed in hydration payload"
-
-
-  - id: SA-NUXT-03
-    type: regex
-    target: "**/nuxt.config.{js,ts}"
-    pattern: "runtimeConfig[\\s\\S]*?public\\s*:\\s*\\{[^}]*(secret|password|token|key|credential|private|database)"
-    severity: error
-    desc: "Secret in runtimeConfig.public — exposed to client"
-
-
-  - id: SA-NUXT-04
-    type: regex
-    target: "**/*.vue"
-    pattern: "v-html\\s*="
-    severity: warning
-    desc: "v-html directive — potential XSS, especially dangerous in SSR context"
-
-
-  - id: SA-NUXT-05
-    type: regex
-    target: "server/**/*.{js,ts}"
-    pattern: "exec\\s*\\(|execSync\\s*\\(|\\$queryRawUnsafe\\s*\\("
-    severity: error
-    desc: "Shell exec or raw SQL in Nitro handler — injection risk"
-
-
-  - id: SA-NUXT-06
-    type: regex
-    target: "plugins/**/*.{js,ts}"
-    pattern: "defineNuxtPlugin\\s*\\(\\s*(?:async\\s*)?\\(\\s*nuxtApp\\s*\\)\\s*=>"
-    severity: info
-    desc: "Nuxt plugin without enforce/dependsOn — verify execution order for security plugins"
-
-
-  # === SPRING SECURITY CHECKS ===
-  - id: SA-SPRING-01
-    type: regex
-    target: "**/*.java"
-    pattern: "requestMatchers\\s*\\(\\s*\"\\/(api|admin)\\/\\*\\*\"\\s*\\)\\s*\\.\\s*permitAll\\s*\\(\\s*\\)"
-    severity: error
-    desc: "Spring Security permitAll overreach — verify scope is intentionally broad"
-
-
-  - id: SA-SPRING-02
-    type: regex
-    target: "**/*.java"
-    pattern: "parseExpression\\s*\\(\\s*[a-zA-Z_]\\w*\\s*\\)"
-    severity: error
-    desc: "SpEL expression parsed from untrusted input — injection risk"
-
-
-  - id: SA-SPRING-03
-    type: regex
-    target: "**/*.java"
-    pattern: "include\\s*:\\s*[\"']?\\*[\"']?|exposure\\.include\\s*=\\s*\\*"
-    severity: error
-    desc: "Spring Boot actuator wildcard exposure — secrets and heap dumps accessible"
-
-
-  - id: SA-SPRING-04
-    type: regex
-    target: "**/*.java"
-    pattern: "csrf\\s*\\(\\s*(?:csrf|c)\\s*->\\s*(?:csrf|c)\\.disable\\s*\\(\\s*\\)\\s*\\)|\\.csrf\\(\\)\\.disable\\(\\)"
-    severity: warning
-    desc: "CSRF protection disabled — verify endpoint is stateless (JWT/Bearer)"
-
-
-  - id: SA-SPRING-05
-    type: regex
-    target: "**/*.java"
-    pattern: "@PreAuthorize\\s*\\("
-    severity: warning
-    desc: "@PreAuthorize found — verify @EnableMethodSecurity is declared on a @Configuration class"
-
-
-  - id: SA-SPRING-06
-    type: regex
-    target: "**/*.java"
-    pattern: "return\\s+(?:request|param|input|query|\\w+)\\s*;"
-    severity: warning
-    desc: "Controller return value may be user-controlled — Thymeleaf SSTI risk"
-
-
-  - id: SA-SPRING-07
-    type: regex
-    target: "**/*.java"
-    pattern: "@ModelAttribute\\s+(?!.*Dto|.*Request|.*Form|.*Command)\\w+\\s+\\w+"
-    severity: warning
-    desc: "@ModelAttribute binds to entity directly — mass assignment risk"
-
-
-  - id: SA-SPRING-08
-    type: regex
-    target: "**/*.java"
-    pattern: "enableDefaultTyping\\s*\\(|activateDefaultTyping\\s*\\("
-    severity: error
-    desc: "Jackson default typing enabled — deserialization gadget chain risk"
-
-
-  # === .NET SECURITY CHECKS ===
-  - id: SA-DOTNET-01
-    type: regex
-    target: "**/*.cs"
-    pattern: "UseAuthentication\\s*\\(\\s*\\)[\\s\\S]{0,200}UseRouting\\s*\\(\\s*\\)|MapControllers\\s*\\(\\s*\\)[\\s\\S]{0,200}UseAuthentication\\s*\\(\\s*\\)|UseAuthorization\\s*\\(\\s*\\)[\\s\\S]{0,200}UseAuthentication\\s*\\(\\s*\\)"
-    severity: error
-    desc: "ASP.NET Core middleware ordering wrong — auth must come before routing/endpoints"
-
-
-  - id: SA-DOTNET-02
-    type: regex
-    target: "**/*.cs"
-    pattern: "FromSqlRaw\\s*\\(\\s*\\$\"|FromSqlRaw\\s*\\(\\s*\"[^\"]*\"\\s*\\+|ExecuteSqlRaw\\s*\\(\\s*\\$\"|ExecuteSqlRaw\\s*\\(\\s*\"[^\"]*\"\\s*\\+"
-    severity: error
-    desc: "Entity Framework raw SQL with string interpolation/concatenation — SQL injection"
-
-
-  - id: SA-DOTNET-03
-    type: regex
-    target: "**/*.cs"
-    pattern: "\\[AllowAnonymous\\]\\s*(?:\\r?\\n\\s*)*(?:public\\s+class|\\[(?:ApiController|Route)\\])"
-    severity: error
-    desc: "[AllowAnonymous] on controller class — all actions are publicly accessible"
-
-
-  - id: SA-DOTNET-04
-    type: regex
-    target: "**/*.cs"
-    pattern: "Html\\.Raw\\s*\\((?!.*Sanitiz)|@\\(\\s*\\(MarkupString\\)\\s*\\w+"
-    severity: error
-    desc: "Razor Html.Raw or MarkupString with unsanitized input — XSS risk"
-
-
-  - id: SA-DOTNET-05
-    type: regex
-    target: "**/*.cs"
-    pattern: "AllowAnyOrigin\\s*\\(\\s*\\)|SetIsOriginAllowed\\s*\\(\\s*_?\\s*=>\\s*true\\s*\\)"
-    severity: error
-    desc: "CORS policy allows any origin — credential theft via cross-origin requests"
-
-
-  - id: SA-DOTNET-06
-    type: regex
-    target: "**/*.cs"
-    pattern: "IgnoreAntiforgeryTokenAttribute\\s*\\(\\s*\\)|IgnoreAntiforgeryToken\\]"
-    severity: warning
-    desc: "Anti-forgery token validation disabled — CSRF risk"
-
-
-  - id: SA-DOTNET-07
-    type: regex
-    target: "**/*.cs"
-    pattern: "DisableAutomaticKeyGeneration\\s*\\(\\s*\\)"
-    severity: warning
-    desc: "Data Protection automatic key generation disabled — keys will expire without rotation"
-
-
-  - id: SA-DOTNET-08
-    type: regex
-    target: "**/*.cs"
-    pattern: "class\\s+\\w+Hub\\s*:\\s*Hub\\b"
-    severity: warning
-    desc: "SignalR hub found — verify [Authorize] attribute is applied"
-
-
-  # === BLAZOR SECURITY CHECKS ===
-  - id: SA-BLAZOR-01
-    type: regex
-    target: "**/*.{razor,cs}"
-    pattern: "Http\\.\\w+Async\\s*\\(\\s*\"[^\"]*(?:admin|secret|internal|private|manage)"
-    severity: error
-    desc: "Blazor WASM calling sensitive API — verify server-side [Authorize] enforcement"
-
-
-  - id: SA-BLAZOR-02
-    type: regex
-    target: "**/*.{razor,cs}"
-    pattern: "(?:private|protected|public)\\s+string\\s+(?:creditCard|cvv|ssn|password|secret|token|apiKey)\\s*="
-    severity: warning
-    desc: "Sensitive data stored in Blazor component state — exposure via circuit or prerender"
-
-
-  - id: SA-BLAZOR-03
-    type: regex
-    target: "**/*.{razor,cs}"
-    pattern: "InvokeVoidAsync\\s*\\(\\s*\"eval\"|InvokeAsync\\s*\\(\\s*\"eval\""
-    severity: error
-    desc: "JS interop calling eval — injection risk from untrusted input"
-
-
-  - id: SA-BLAZOR-04
-    type: regex
-    target: "**/*.{razor,cs}"
-    pattern: "\\[Authorize\\][\\s\\S]{0,200}prerender\\s*:\\s*true"
-    severity: warning
-    desc: "[Authorize] with prerender enabled — auth state may not be available during prerender"
-
-
-  - id: SA-BLAZOR-05
-    type: regex
-    target: "**/*.{razor,cs}"
-    pattern: "OnInitializedAsync[\\s\\S]{0,300}(?:Sensitive|Secret|Private|Confidential|GetCredentials|GetTokens)"
-    severity: warning
-    desc: "Sensitive data loaded in OnInitializedAsync — may leak via prerendering"
-
-
-  # === DJANGO SECURITY ===
-  - id: SA-DJANGO-01
-    type: regex
-    target: "**/*.py"
-    pattern: "\\.raw\\s*\\(\\s*f[\"']|\\.raw\\s*\\(\\s*[\"'].*%s.*[\"']\\s*%|\\.extra\\s*\\(|cursor\\.execute\\s*\\(\\s*f[\"']|cursor\\.execute\\s*\\(\\s*[\"'].*%s.*[\"']\\s*%"
-    severity: error
-    desc: "Django ORM injection via raw(), extra(), or cursor.execute() with string interpolation"
-
-
-  - id: SA-DJANGO-02
-    type: regex
-    target: "**/*.py"
-    pattern: "@csrf_exempt|csrf_exempt\\s*\\(|decorators\\.csrf\\s+import\\s+csrf_exempt"
-    severity: error
-    desc: "CSRF protection disabled via @csrf_exempt decorator"
-
-
-  - id: SA-DJANGO-03
-    type: regex
-    target: "**/*.py"
-    pattern: "DEBUG\\s*=\\s*True"
-    severity: error
-    desc: "Django DEBUG=True — exposes tracebacks, SQL queries, and settings in production"
-
-
-  - id: SA-DJANGO-04
-    type: regex
-    target: "**/*.py"
-    pattern: "mark_safe\\s*\\(|\\.safestring\\s+import|safestring\\.mark_safe"
-    severity: error
-    desc: "XSS risk via mark_safe() — bypasses Django auto-escaping"
-
-
-  - id: SA-DJANGO-05
-    type: regex
-    target: "**/*.py"
-    pattern: "SECRET_KEY\\s*=\\s*[\"'][^\"']{8,}[\"']"
-    severity: error
-    desc: "Django SECRET_KEY hardcoded in source — enables session/token forgery if leaked"
-
-
-  - id: SA-DJANGO-06
-    type: regex
-    target: "**/*.py"
-    pattern: "PickleSerializer|SESSION_SERIALIZER.*[Pp]ickle"
-    severity: error
-    desc: "Pickle session serializer — enables RCE if SECRET_KEY is compromised"
-
-
-  - id: SA-DJANGO-07
-    type: regex
-    target: "**/*.py"
-    pattern: "path\\s*\\(\\s*[\"']admin/[\"']|url\\s*\\(\\s*r?\\s*[\"'].*admin/"
-    severity: warning
-    desc: "Django admin on default /admin/ URL — consider obscuring path and adding IP restrictions"
-
-
-  - id: SA-DJANGO-08
-    type: regex
-    target: "**/*.py"
-    pattern: "FileField\\s*\\(\\s*upload_to\\s*=\\s*[\"'][^\"']*[\"'](?:\\s*\\)|\\s*,\\s*\\))|request\\.FILES\\["
-    severity: warning
-    desc: "File upload without visible validation — verify size, type, and filename sanitization"
-
-
-  # === FLASK SECURITY ===
-  - id: SA-FLASK-01
-    type: regex
-    target: "**/*.py"
-    pattern: "render_template_string\\s*\\("
-    severity: error
-    desc: "Flask render_template_string() — potential SSTI if user input reaches template"
-
-
-  - id: SA-FLASK-02
-    type: regex
-    target: "**/*.py"
-    pattern: "request\\.args\\s*\\[|request\\.args\\.get\\s*\\(|request\\.form\\s*\\[|request\\.form\\.get\\s*\\(|request\\.values"
-    severity: warning
-    desc: "Flask request parameter access — verify input is validated before use"
-
-
-  - id: SA-FLASK-03
-    type: regex
-    target: "**/*.py"
-    pattern: "send_file\\s*\\(\\s*f[\"']|send_file\\s*\\(\\s*.*request\\.|send_file\\s*\\(\\s*os\\.path\\.join"
-    severity: error
-    desc: "Flask send_file() with dynamic path — potential path traversal"
-
-
-  - id: SA-FLASK-04
-    type: regex
-    target: "**/*.py"
-    pattern: "app\\.run\\s*\\(.*debug\\s*=\\s*True|\\.config\\s*\\[\\s*[\"']DEBUG[\"']\\s*\\]\\s*=\\s*True|FLASK_DEBUG\\s*=\\s*1"
-    severity: error
-    desc: "Flask debug=True — Werkzeug debugger enables arbitrary code execution"
-
-
-  - id: SA-FLASK-05
-    type: regex
-    target: "**/*.py"
-    pattern: "secret_key\\s*=\\s*[\"'][^\"']{1,30}[\"']|app\\.config\\s*\\[\\s*[\"']SECRET_KEY[\"']\\s*\\]\\s*=\\s*[\"']"
-    severity: error
-    desc: "Flask SECRET_KEY hardcoded or weak — enables session cookie forgery"
-
-
-  - id: SA-FLASK-06
-    type: regex
-    target: "**/*.py"
-    pattern: "db\\.session\\.execute\\s*\\(\\s*f[\"']|db\\.session\\.execute\\s*\\(\\s*[\"'].*%s.*[\"']\\s*%|db\\.engine\\.execute\\s*\\(\\s*f[\"']|\\.execute\\s*\\(\\s*f[\"']SELECT|\\.execute\\s*\\(\\s*f[\"']INSERT|\\.execute\\s*\\(\\s*f[\"']UPDATE|\\.execute\\s*\\(\\s*f[\"']DELETE"
-    severity: error
-    desc: "SQLAlchemy raw query with string interpolation — SQL injection risk"
-
-
-  # === FASTAPI SECURITY ===
-  - id: SA-FASTAPI-01
-    type: regex
-    target: "**/*.py"
-    pattern: "@app\\.(get|post|put|patch|delete)\\("
-    severity: warning
-    desc: "FastAPI endpoint without Depends() — verify authentication is not missing"
-
-
-  - id: SA-FASTAPI-02
-    type: regex
-    target: "**/*.py"
-    pattern: "def\\s+\\w+\\s*\\([^)]*:\\s*dict\\s*[,\\)]|:\\s*Any\\s*[,\\)=]|extra\\s*=\\s*[\"']allow[\"']"
-    severity: warning
-    desc: "Pydantic validation bypass via dict/Any type or extra='allow'"
-
-
-  - id: SA-FASTAPI-03
-    type: regex
-    target: "**/*.py"
-    pattern: "allow_origins\\s*=\\s*\\[\\s*[\"']\\*[\"']\\s*\\]|CORSMiddleware.*allow_origins.*\\*"
-    severity: error
-    desc: "FastAPI CORS wildcard origin — allows any domain to make cross-origin requests"
-
-
-  - id: SA-FASTAPI-04
-    type: regex
-    target: "**/*.py"
-    pattern: "response\\.headers\\s*\\[.*\\]\\s*=\\s*f[\"']|response\\.headers\\s*\\[.*\\]\\s*=.*request\\.|.headers\\s*\\[\\s*[\"']Set-Cookie[\"']\\s*\\]\\s*="
-    severity: warning
-    desc: "Response header set from user input — potential header injection"
-
-
-  - id: SA-FASTAPI-05
-    type: regex
-    target: "**/*.py"
-    pattern: "UploadFile.*filename|file\\.filename|shutil\\.copyfileobj\\s*\\(\\s*file"
-    severity: warning
-    desc: "FastAPI file upload — verify size limit, type validation, and filename sanitization"
-
-
-  - id: SA-FASTAPI-06
-    type: regex
-    target: "**/*.py"
-    pattern: "algorithms\\s*=\\s*\\[.*none.*\\]|jwt\\.decode\\s*\\(\\s*token\\s*,\\s*[^,]+\\s*\\)\\s*$|ACCESS_TOKEN_EXPIRE.*(?:525600|86400|43200)"
-    severity: error
-    desc: "OAuth2/JWT implementation issue — algorithm confusion, missing validation, or excessive expiry"
-
-
-  # === GIN (GO) SECURITY CHECKS ===
-  - id: SA-GIN-01
-    type: regex
-    target: "**/*.go"
-    pattern: "\\.Use\\(auth[A-Za-z]*\\("
-    severity: error
-    desc: "Auth middleware may be registered after routes — verify ordering"
-
-
-  - id: SA-GIN-02
-    type: regex
-    target: "**/*.go"
-    pattern: "c\\.(Bind|ShouldBind|ShouldBindJSON|BindJSON|ShouldBindQuery)\\s*\\("
-    severity: warning
-    desc: "Gin binding function — verify struct does not contain sensitive fields (mass assignment)"
-
-
-  - id: SA-GIN-03
-    type: regex
-    target: "**/*.go"
-    pattern: "template\\.HTML\\s*\\(|c\\.Data\\s*\\([^)]*\"text/html|c\\.Writer\\.WriteString\\s*\\("
-    severity: error
-    desc: "Raw HTML output bypassing template auto-escaping — potential XSS"
-
-
-  - id: SA-GIN-04
-    type: regex
-    target: "**/*.go"
-    pattern: "AllowAllOrigins\\s*:\\s*true|AllowOrigins\\s*:\\s*\\[\\s*\"\\*\"\\s*\\]|AllowOriginFunc\\s*:.*return\\s+true"
-    severity: error
-    desc: "CORS misconfiguration — wildcard or permissive origin policy"
-
-
-  - id: SA-GIN-05
-    type: regex
-    target: "**/*.go"
-    pattern: "c\\.(File|FileAttachment)\\s*\\([^)]*c\\.(Param|Query|PostForm)\\s*\\("
-    severity: error
-    desc: "User-controlled path in c.File/c.FileAttachment — path traversal risk"
-
-
-  - id: SA-GIN-06
-    type: regex
-    target: "**/*.go"
-    pattern: "gin\\.New\\s*\\(\\s*\\)"
-    severity: warning
-    desc: "gin.New() without default middleware — verify Recovery() is registered first"
-
-
-  # === RAILS SECURITY CHECKS ===
-  - id: SA-RAILS-01
-    type: regex
-    target: "**/*.rb"
-    pattern: "\\.permit!|params\\[:[a-z_]+\\]\\.permit\\([^)]*(?:role|admin|superuser|permission)"
-    severity: error
-    desc: "Mass assignment — permit! or permitting sensitive fields"
-
-
-  - id: SA-RAILS-02
-    type: regex
-    target: "**/*.rb"
-    pattern: "\\.html_safe|raw\\s*\\(|<%=="
-    severity: error
-    desc: "html_safe/raw/<%== bypasses Rails auto-escaping — XSS risk"
-
-
-  - id: SA-RAILS-03
-    type: regex
-    target: "**/*.rb"
-    pattern: "find_by_sql\\s*\\(.*#\\{|\\.where\\s*\\(.*#\\{|\\.order\\s*\\(\\s*params"
-    severity: error
-    desc: "String interpolation in SQL query — SQL injection risk"
-
-
-  - id: SA-RAILS-04
-    type: regex
-    target: "**/*.rb"
-    pattern: "skip_before_action\\s*:verify_authenticity_token|protect_from_forgery\\s+with:\\s*:null_session"
-    severity: error
-    desc: "CSRF protection disabled or misconfigured"
-
-
-  - id: SA-RAILS-05
-    type: regex
-    target: "**/*.rb"
-    pattern: "send_file\\s*.*params\\[|send_data\\s*.*filename:\\s*params\\["
-    severity: error
-    desc: "User-controlled path in send_file/send_data — path traversal risk"
-
-
-  - id: SA-RAILS-06
-    type: regex
-    target: "**/*.rb"
-    pattern: "render\\s+inline:\\s*.*params\\[|render\\s+inline:\\s*.*#\\{"
-    severity: error
-    desc: "User input in render inline: — server-side template injection"
-
-
-  - id: SA-RAILS-07
-    type: regex
-    target: "**/*.rb"
-    pattern: "has_one_attached\\s+:\\w+"
-    severity: warning
-    desc: "Active Storage attachment — verify content_type and size validation"
-
-
-  - id: SA-RAILS-08
-    type: regex
-    target: "**/*.rb"
-    pattern: "class\\s+\\w+Channel\\s*<\\s*ApplicationCable::Channel"
-    severity: warning
-    desc: "Action Cable channel — verify authentication in Connection and authorization in subscribed"
-
-
-  # === EXPRESS SECURITY CHECKS ===
-  - id: SA-EXPRESS-01
-    type: regex
-    target: "**/*.{js,ts}"
-    pattern: "app\\.(get|post|put|delete|use)\\s*\\([^)]*\\)[\\s\\S]*?app\\.use\\s*\\(\\s*helmet\\s*\\("
-    severity: error
-    desc: "Routes defined before helmet middleware — missing security headers"
-
-
-  - id: SA-EXPRESS-02
-    type: regex
-    target: "**/*.{js,ts}"
-    pattern: "execSync\\s*\\(.*req\\.(params|query|body)|exec\\s*\\(.*req\\.(params|query|body)"
-    severity: error
-    desc: "User input in shell command — command injection risk"
-
-
-  - id: SA-EXPRESS-03
-    type: regex
-    target: "**/*.{js,ts}"
-    pattern: "res\\.sendFile\\s*\\(\\s*(?:req\\.(params|query|body)|path\\.join\\s*\\([^)]*req\\.(params|query|body))"
-    severity: error
-    desc: "User-controlled path in res.sendFile — path traversal risk"
-
-
-  - id: SA-EXPRESS-04
-    type: regex
-    target: "**/*.{js,ts}"
-    pattern: "session\\s*\\(\\s*\\{[^}]*secret\\s*:\\s*['\"][^'\"]{0,20}['\"]|cookie\\s*:\\s*\\{[^}]*httpOnly\\s*:\\s*false|cookie\\s*:\\s*\\{[^}]*secure\\s*:\\s*false"
-    severity: error
-    desc: "Insecure session configuration — weak secret, missing httpOnly, or missing secure flag"
-
-
-  - id: SA-EXPRESS-05
-    type: regex
-    target: "**/*.{js,ts}"
-    pattern: "app\\.(post|put)\\s*\\(\\s*['\"\\/][^'\"]*(?:login|auth|token|password|register)[^'\"]*['\"]"
-    severity: warning
-    desc: "Auth endpoint — verify rate limiting is applied"
-
-
-  - id: SA-EXPRESS-06
-    type: regex
-    target: "**/*.{js,ts}"
-    pattern: "findByIdAndUpdate\\s*\\([^,]+,\\s*req\\.body\\s*\\)|\\.create\\s*\\(\\s*req\\.body\\s*\\)"
-    severity: warning
-    desc: "Passing req.body directly to database operation — mass assignment risk"
-
-
-  # === NESTJS SECURITY CHECKS ===
-  - id: SA-NEST-01
-    type: regex
-    target: "**/*.ts"
-    pattern: "@UseGuards\\s*\\(\\s*RolesGuard\\s*,\\s*AuthGuard\\s*\\)"
-    severity: error
-    desc: "RolesGuard before AuthGuard — authorization checked before authentication"
-
-
-  - id: SA-NEST-02
-    type: regex
-    target: "**/*.ts"
-    pattern: "new\\s+ValidationPipe\\s*\\(\\s*\\{[^}]*whitelist\\s*:\\s*false"
-    severity: error
-    desc: "ValidationPipe with whitelist:false — extra properties not stripped (mass assignment)"
-
-
-  - id: SA-NEST-03
-    type: regex
-    target: "**/*.ts"
-    pattern: "@Column\\s*\\(\\s*\\)\\s*\\n\\s*password\\s*:|@Column\\s*\\(\\s*\\)\\s*\\n\\s*(?:secret|token|hash|internal)"
-    severity: warning
-    desc: "Sensitive entity column without @Exclude — may be exposed in API responses"
-
-
-  - id: SA-NEST-04
-    type: regex
-    target: "**/*.ts"
-    pattern: "@Param\\s*\\(\\s*['\"][^'\"]+['\"]\\s*\\)\\s+\\w+\\s*:\\s*string"
-    severity: warning
-    desc: "Route parameter without ParseIntPipe/ParseUUIDPipe — type confusion risk"
-
-
-  - id: SA-NEST-05
-    type: regex
-    target: "**/*.ts"
-    pattern: "@Public\\s*\\(\\s*\\)\\s*\\n\\s*@(Delete|Put|Patch)\\s*\\(|@Public\\s*\\(\\s*\\)\\s*\\n\\s*@Controller"
-    severity: error
-    desc: "@Public on state-changing endpoint or entire controller — auth bypass"
-
-
-  - id: SA-NEST-06
-    type: regex
-    target: "**/*.ts"
-    pattern: "@WebSocketGateway\\s*\\("
-    severity: warning
-    desc: "WebSocket gateway — verify handleConnection authentication and message-level guards"
-
-
-  # === AWS SECURITY CHECKS ===
-  - id: SA-AWS-01
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "\"Action\"\\s*:\\s*\"\\*\"|\"Action\"\\s*:\\s*\\[\\s*\"\\*\"\\s*\\]"
-    severity: error
-    desc: "IAM policy with wildcard Action — grants unrestricted permissions"
-
-
-  - id: SA-AWS-02
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "\"Effect\"\\s*:\\s*\"Allow\"[^}]*\"Action\"\\s*:\\s*\"sts:AssumeRole\"(?![^}]*\"Condition\")"
-    severity: warning
-    desc: "AssumeRole without conditions — missing MFA, IP, or external ID restriction"
-
-
-  - id: SA-AWS-03
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "\"Principal\"\\s*:\\s*\\{\\s*\"AWS\"\\s*:\\s*\"\\*\"\\s*\\}|\"Principal\"\\s*:\\s*\"\\*\""
-    severity: error
-    desc: "Overly permissive trust policy — any principal can assume role"
-
-
-  - id: SA-AWS-04
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "\"Action\"\\s*:\\s*\"iam:PassRole\"[^}]*\"Resource\"\\s*:\\s*\"\\*\""
-    severity: error
-    desc: "iam:PassRole with wildcard resource — privilege escalation risk"
-
-
-  - id: SA-AWS-05
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "acl\\s*=\\s*\"public-read\"|acl\\s*=\\s*\"public-read-write\""
-    severity: error
-    desc: "S3 bucket with public ACL — data exposure risk"
-
-
-  - id: SA-AWS-06
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "block_public_acls\\s*=\\s*false|block_public_policy\\s*=\\s*false|restrict_public_buckets\\s*=\\s*false"
-    severity: error
-    desc: "S3 public access block disabled — bucket may become publicly accessible"
-
-
-  - id: SA-AWS-07
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "environment\\s*\\{[^}]*variables\\s*=\\s*\\{[^}]*(PASSWORD|SECRET|API_KEY|TOKEN|PRIVATE_KEY)\\s*=\\s*\"[^\"]+\""
-    severity: error
-    desc: "Lambda environment variable contains hardcoded secret"
-
-
-  - id: SA-AWS-08
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "policy_arn\\s*=\\s*\"arn:aws:iam::aws:policy/AdministratorAccess\"|policy_arn\\s*=\\s*\"arn:aws:iam::aws:policy/PowerUserAccess\""
-    severity: error
-    desc: "Lambda or role with AdministratorAccess/PowerUserAccess — overly permissive"
-
-
-  - id: SA-AWS-09
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "cidr_blocks\\s*=\\s*\\[\\s*\"0\\.0\\.0\\.0/0\"\\s*\\]|CidrIp:\\s*[\"']?0\\.0\\.0\\.0/0"
-    severity: error
-    desc: "Security group ingress open to 0.0.0.0/0 — unrestricted internet access"
-
-
-  - id: SA-AWS-10
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "enable_key_rotation\\s*=\\s*false"
-    severity: warning
-    desc: "KMS key rotation disabled — keys should be rotated automatically"
-
-
-  - id: SA-AWS-11
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "is_multi_region_trail\\s*=\\s*false|enable_log_file_validation\\s*=\\s*false"
-    severity: error
-    desc: "CloudTrail not multi-region or missing log validation"
-
-
-  - id: SA-AWS-12
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "password\\s*=\\s*\"[^\"]+\"|master_password\\s*=\\s*\"[^\"]+\""
-    severity: error
-    desc: "Hardcoded password in Terraform/CloudFormation — use Secrets Manager"
-
-
-  # === GCP SECURITY CHECKS ===
-  - id: SA-GCP-01
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "role\\s*=\\s*\"roles/(owner|editor)\"|\"roles/(owner|editor)\""
-    severity: error
-    desc: "GCP primitive role (Owner/Editor) — use granular predefined roles"
-
-
-  - id: SA-GCP-02
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "resource\\s+\"google_service_account_key\"|google_service_account_key\\s*\\{"
-    severity: error
-    desc: "Service account key file — use Workload Identity Federation instead"
-
-
-  - id: SA-GCP-03
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "\"allUsers\"|\"allAuthenticatedUsers\"|member\\s*=\\s*\"allUsers\"|member\\s*=\\s*\"allAuthenticatedUsers\""
-    severity: error
-    desc: "allUsers/allAuthenticatedUsers binding — public access to GCP resource"
-
-
-  - id: SA-GCP-04
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "google_storage_bucket_iam[^}]*(allUsers|allAuthenticatedUsers)|predefinedAcl:\\s*public"
-    severity: error
-    desc: "Public Cloud Storage bucket — data exposure risk"
-
-
-  - id: SA-GCP-05
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "uniform_bucket_level_access\\s*=\\s*false"
-    severity: warning
-    desc: "Uniform bucket-level access disabled — inconsistent ACLs possible"
-
-
-  - id: SA-GCP-06
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "environment_variables\\s*=\\s*\\{[^}]*(PASSWORD|SECRET|API_KEY|TOKEN|PRIVATE_KEY)\\s*=\\s*\"[^\"]+\""
-    severity: error
-    desc: "Cloud Functions environment variable contains hardcoded secret"
-
-
-  - id: SA-GCP-07
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "cloudfunctions\\.invoker[^}]*allUsers|allUsers[^}]*cloudfunctions\\.invoker"
-    severity: error
-    desc: "Cloud Function invocable by allUsers — unauthenticated access"
-
-
-  - id: SA-GCP-08
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "source_ranges\\s*=\\s*\\[\\s*\"0\\.0\\.0\\.0/0\"\\s*\\]|sourceRanges:[^}]*0\\.0\\.0\\.0/0"
-    severity: error
-    desc: "VPC firewall rule open to 0.0.0.0/0 — unrestricted internet ingress"
-
-
-  - id: SA-GCP-09
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "google_kms_crypto_key_iam[^}]*(allUsers|allAuthenticatedUsers)"
-    severity: error
-    desc: "KMS key accessible by allUsers — encryption key exposure"
-
-
-  - id: SA-GCP-10
-    type: regex
-    target: "**/*.{tf,json,yaml,yml}"
-    pattern: "exempted_members\\s*=\\s*\\["
-    severity: warning
-    desc: "Audit log exemptions configured — all access should be logged"
-
-
-  # === AZURE SECURITY CHECKS ===
-  - id: SA-AZURE-01
-    type: regex
-    target: "**/*.{tf,json,bicep,yaml,yml}"
-    pattern: "role_definition_name\\s*=\\s*\"(Owner|Contributor)\"|8e3af657-a8ff-443c-a75c-2fe8c4bcb635|b24988ac-6180-42a0-ab88-20f7382dd24c"
-    severity: error
-    desc: "Owner/Contributor role assignment — use least-privilege roles"
-
-
-  - id: SA-AZURE-02
-    type: regex
-    target: "**/*.{tf,json,bicep,yaml,yml}"
-    pattern: "role_definition_name\\s*=\\s*\"Storage Blob Data Owner\"(?![^}]*condition\\s*=)"
-    severity: warning
-    desc: "Storage Blob Data Owner without conditions — add ABAC conditions"
-
-
-  - id: SA-AZURE-03
-    type: regex
-    target: "**/*.{tf,json,bicep,yaml,yml}"
-    pattern: "allow_nested_items_to_be_public\\s*=\\s*true|allow_blob_public_access\\s*=\\s*true|allowBlobPublicAccess['\"]?\\s*[:=]\\s*['\"]?true|container_access_type\\s*=\\s*\"(blob|container)\""
-    severity: error
-    desc: "Public blob access enabled — anonymous access to storage data"
-
-
-  - id: SA-AZURE-04
-    type: regex
-    target: "**/*.{tf,json,bicep,yaml,yml}"
-    pattern: "authLevel[\"\\s]*[:=]\\s*[\"']?anonymous|\"authLevel\"\\s*:\\s*\"anonymous\""
-    severity: error
-    desc: "Azure Function with anonymous auth level — no authentication required"
-
-
-  - id: SA-AZURE-05
-    type: regex
-    target: "**/*.{tf,json,bicep,yaml,yml}"
-    pattern: "app_settings\\s*=\\s*\\{[^}]*(PASSWORD|SECRET|KEY|TOKEN|CONNECTION)\\s*=\\s*\"(?!@Microsoft\\.KeyVault)[^\"]+\""
-    severity: error
-    desc: "Hardcoded secret in Azure Function app settings — use Key Vault references"
-
-
-  - id: SA-AZURE-06
-    type: regex
-    target: "**/*.{tf,json,bicep,yaml,yml}"
-    pattern: "source_address_prefix\\s*=\\s*\"\\*\"|sourceAddressPrefix['\"]?\\s*[:=]\\s*['\"]\\*['\"]|\"sourceAddressPrefix\"\\s*:\\s*\"\\*\""
-    severity: error
-    desc: "NSG inbound rule open to * — unrestricted internet access"
-
-
-  - id: SA-AZURE-07
-    type: regex
-    target: "**/*.{tf,json,bicep,yaml,yml}"
-    pattern: "purge_protection_enabled\\s*=\\s*false|enablePurgeProtection:\\s*false|\"enablePurgeProtection\"\\s*:\\s*false"
-    severity: error
-    desc: "Key Vault missing purge protection — keys can be permanently deleted"
-
-
-  - id: SA-AZURE-08
-    type: regex
-    target: "**/*.{tf,json,bicep,yaml,yml}"
-    pattern: "enable_rbac_authorization\\s*=\\s*false|access_policy\\s*\\{"
-    severity: warning
-    desc: "Key Vault using access policies instead of RBAC — harder to audit"
-
-
-  - id: SA-AZURE-09
-    type: regex
-    target: "**/*.{tf,json,bicep,yaml,yml}"
-    pattern: "azurerm_monitor_diagnostic_setting"
-    severity: warning
-    desc: "Diagnostic setting present — verify all critical log categories are enabled"
-
-
-  - id: SA-AZURE-10
-    type: regex
-    target: "**/*.{tf,json,bicep,yaml,yml}"
-    pattern: "public_network_access_enabled\\s*=\\s*true|start_ip_address\\s*=\\s*\"0\\.0\\.0\\.0\""
-    severity: error
-    desc: "Azure SQL public network access or permissive firewall rule"
-
-
-  # === WORDPRESS SECURITY ===
-  - id: SA-WP-01
-    type: regex
-    target: "**/*.php"
-    pattern: "\\$wpdb\\s*->\\s*(query|get_results|get_row|get_var|get_col)\\s*\\(\\s*[\"']"
-    severity: error
-    desc: "$wpdb query without $wpdb->prepare() — SQL injection risk"
-
-
-  - id: SA-WP-02
-    type: regex
-    target: "**/*.php"
-    pattern: "unserialize\\s*\\(\\s*\\$_(GET|POST|REQUEST|COOKIE|SERVER)|unserialize\\s*\\(\\s*\\$"
-    severity: error
-    desc: "unserialize() with user-controlled input — object injection risk"
-
-
-  - id: SA-WP-03
-    type: regex
-    target: "**/*.php"
-    pattern: "echo\\s+\\$(?!.*esc_html|.*esc_attr|.*esc_url|.*wp_kses|.*absint|.*intval)"
-    severity: error
-    desc: "Unescaped output — use esc_html(), esc_attr(), esc_url(), or wp_kses()"
-
-
-  - id: SA-WP-04
-    type: regex
-    target: "**/*.php"
-    pattern: "register_rest_route\\s*\\([^)]*(?!permission_callback)[^)]*\\)|permission_callback.*__return_true"
-    severity: error
-    desc: "REST API route without permission_callback or with __return_true — unauthenticated access"
-
-
-  - id: SA-WP-05
-    type: regex
-    target: "**/*.php"
-    pattern: "update_option\\s*\\(|update_post_meta\\s*\\(|delete_option\\s*\\(|delete_post_meta\\s*\\("
-    severity: warning
-    desc: "Option/meta modification — verify current_user_can() and nonce checks are present"
-
-
-  - id: SA-WP-06
-    type: regex
-    target: "**/*.php"
-    pattern: "\\$_POST\\[.*\\]\\s*(?!.*wp_verify_nonce|.*check_ajax_referer|.*wp_nonce)"
-    severity: error
-    desc: "POST data processed without nonce verification — CSRF risk"
-
-
-  - id: SA-WP-07
-    type: regex
-    target: "**/*.php"
-    pattern: "move_uploaded_file\\s*\\(|\\$_FILES\\s*\\[.*\\]\\s*\\[.tmp_name.\\]"
-    severity: error
-    desc: "Direct file upload handling — use wp_handle_upload() with MIME validation"
-
-
-  - id: SA-WP-08
-    type: regex
-    target: "**/*.php"
-    pattern: "WP_DEBUG.*true|WP_DEBUG_DISPLAY.*true|DISALLOW_FILE_EDIT.*false"
-    severity: error
-    desc: "wp-config.php misconfiguration — debug enabled or file editing allowed in production"
-
-
-  - id: SA-WP-09
-    type: regex
-    target: "**/*.php"
-    pattern: "^<\\?php\\s*\\n(?!.*defined\\s*\\(\\s*['\"]ABSPATH['\"])"
-    severity: warning
-    desc: "PHP file missing defined('ABSPATH') check — direct file access possible"
-
-
-  - id: SA-WP-10
-    type: regex
-    target: "**/*.php"
-    pattern: "\\$table_prefix\\s*=\\s*['\"]wp_['\"]"
-    severity: warning
-    desc: "Default WordPress table prefix wp_ — makes targeted SQL injection easier"
-
-
-  # === DRUPAL SECURITY ===
-  - id: SA-DRUPAL-01
-    type: regex
-    target: "**/*.{php,module,install}"
-    pattern: "db_query\\s*\\(\\s*[\"'].*\\$|->query\\s*\\(\\s*[\"'].*\\$|sprintf\\s*\\(\\s*[\"']SELECT"
-    severity: error
-    desc: "Drupal database query with string interpolation — SQL injection risk"
-
-
-  - id: SA-DRUPAL-02
-    type: regex
-    target: "**/*.{php,module,install}"
-    pattern: "#markup.*\\$|#markup.*\\.\\s*\\$|#markup.*getRequest|#markup.*->get\\s*\\("
-    severity: error
-    desc: "Render array #markup with user input — XSS risk, use #plain_text or Html::escape()"
-
-
-  - id: SA-DRUPAL-03
-    type: regex
-    target: "**/*.{php,module,install}"
-    pattern: "['\"]#markup['\"]\\s*=>\\s*.*\\$(?!.*Html::escape|.*Xss::filter|.*check_plain|.*t\\()"
-    severity: error
-    desc: "Unescaped variable in #markup — XSS risk"
-
-
-  - id: SA-DRUPAL-04
-    type: regex
-    target: "**/*.{php,module,install}"
-    pattern: "->delete\\s*\\(\\s*\\)|->save\\s*\\(\\s*\\)"
-    severity: warning
-    desc: "Entity state change — verify Form API CSRF protection or _csrf_token route requirement"
-
-
-  - id: SA-DRUPAL-05
-    type: regex
-    target: "**/*.{php,module,install}"
-    pattern: "entityQuery\\s*\\([^)]*\\)(?!.*accessCheck)|->load\\s*\\(\\s*\\$"
-    severity: error
-    desc: "Entity query or load without access check — bypasses node/field access control"
-
-
-  - id: SA-DRUPAL-06
-    type: regex
-    target: "**/*.{php,module,install}"
-    pattern: "hash_salt.*=\\s*['\"]['\"]|error_level.*verbose|update_free_access.*TRUE"
-    severity: error
-    desc: "Drupal settings.php misconfiguration — empty hash_salt, verbose errors, or update access"
-
-
-  # === JOOMLA SECURITY ===
-  - id: SA-JOOMLA-01
-    type: regex
-    target: "**/*.php"
-    pattern: "->where\\s*\\(.*[\"'].*\\.\\s*\\$|setQuery\\s*\\(\\s*[\"'].*\\$|->where\\s*\\(\\s*[\"'].*\\$"
-    severity: error
-    desc: "Joomla database query with string concatenation — SQL injection risk"
-
-
-  - id: SA-JOOMLA-02
-    type: regex
-    target: "**/*.php"
-    pattern: "->get\\s*\\([^,)]+\\s*,\\s*[^,)]*\\s*,\\s*['\"]RAW['\"]|\\$_GET\\s*\\[|\\$_POST\\s*\\[|\\$_REQUEST\\s*\\["
-    severity: error
-    desc: "JInput RAW filter or direct superglobal access — unvalidated input"
-
-
-  - id: SA-JOOMLA-03
-    type: regex
-    target: "**/*.php"
-    pattern: "extends\\s+BaseController[^{]*\\{[^}]*function\\s+(delete|save|publish)"
-    severity: warning
-    desc: "Controller state-changing method — verify authorise() and checkToken() are present"
-
-
-  - id: SA-JOOMLA-04
-    type: regex
-    target: "**/*.php"
-    pattern: "\\$error_reporting\\s*=\\s*['\"]maximum['\"]|\\$debug\\s*=\\s*1|\\$secret\\s*=\\s*['\"]joomla['\"]"
-    severity: error
-    desc: "Joomla configuration.php misconfiguration — debug enabled or weak secret"
-
-
-  # === ANDROID SDK SECURITY ===
-  - id: SA-ANDROID-01
-    type: regex
-    target: "**/AndroidManifest.xml"
-    pattern: "android:exported\\s*=\\s*\"true\""
-    severity: warning
-    desc: "Exported component — verify intent-filter restrictions and permission guards"
-
-
-  - id: SA-ANDROID-02
-    type: regex
-    target: "**/*.{kt,java}"
-    pattern: "rawQuery\\s*\\(\\s*\"[^\"]*\\+\\s*\\w+|rawQuery\\s*\\(\\s*\"[^\"]*\\$\\{?"
-    severity: error
-    desc: "SQL injection in ContentProvider — use parameterized selectionArgs instead of concatenation"
-
-
-  - id: SA-ANDROID-03
-    type: regex
-    target: "**/*.{kt,java}"
-    pattern: "addJavascriptInterface\\s*\\("
-    severity: error
-    desc: "WebView JavaScript interface — verify API level >= 17 and restrict to trusted origins"
-
-
-  - id: SA-ANDROID-04
-    type: regex
-    target: "**/*.{kt,java}"
-    pattern: "getSharedPreferences\\s*\\([^)]*\\)[\\s\\S]{0,80}(password|token|secret|key|credential)|MODE_WORLD_READABLE"
-    severity: error
-    desc: "Sensitive data in SharedPreferences — use EncryptedSharedPreferences"
-
-
-  - id: SA-ANDROID-05
-    type: regex
-    target: "**/AndroidManifest.xml"
-    pattern: "usesCleartextTraffic\\s*=\\s*\"true\"|cleartextTrafficPermitted\\s*=\\s*\"true\""
-    severity: error
-    desc: "Cleartext traffic allowed — enforce HTTPS via NetworkSecurityConfig"
-
-
-  - id: SA-ANDROID-06
-    type: regex
-    target: "**/AndroidManifest.xml"
-    pattern: "android:debuggable\\s*=\\s*\"true\""
-    severity: error
-    desc: "Debug mode enabled in manifest — must be false for release builds"
-
-
-  - id: SA-ANDROID-07
-    type: regex
-    target: "**/*.{kt,java}"
-    pattern: "registerReceiver\\s*\\(\\s*\\w+\\s*,\\s*\\w+\\s*\\)\\s*$"
-    severity: warning
-    desc: "Broadcast receiver registered without permission — add permission parameter"
-
-
-  - id: SA-ANDROID-08
-    type: regex
-    target: "**/*.{kt,java}"
-    pattern: "new\\s+Random\\s*\\(|java\\.util\\.Random|kotlin\\.random\\.Random"
-    severity: warning
-    desc: "Insecure random number generator — use java.security.SecureRandom for tokens"
-
-
-  - id: SA-ANDROID-09
-    type: regex
-    target: "**/*.{kt,java}"
-    pattern: "SecretKeySpec\\s*\\(\\s*\"[^\"]+\"\\.toByteArray|private\\s+(static\\s+)?final\\s+byte\\[\\]\\s+\\w*(KEY|key|SECRET|secret)"
-    severity: error
-    desc: "Hardcoded encryption key — use Android Keystore for key management"
-
-
-  - id: SA-ANDROID-10
-    type: regex
-    target: "**/*.{kt,java}"
-    pattern: "Log\\.(d|v|i)\\s*\\(\\s*\"[^\"]*\"\\s*,\\s*[^)]*?(password|token|secret|key|credential|session)"
-    severity: warning
-    desc: "Sensitive data in log output — strip debug logs in release builds"
-
-
-  # === IOS SDK SECURITY ===
-  - id: SA-IOS-01
-    type: regex
-    target: "**/*.swift"
-    pattern: "kSecAttrAccessibleAlways[^T]|kSecAttrAccessibleAlways\\b(?!ThisDeviceOnly)"
-    severity: error
-    desc: "Insecure Keychain accessibility — use kSecAttrAccessibleWhenUnlockedThisDeviceOnly"
-
-
-  - id: SA-IOS-02
-    type: regex
-    target: "**/Info.plist"
-    pattern: "NSAllowsArbitraryLoads[\\s\\S]{0,30}<true"
-    severity: error
-    desc: "App Transport Security disabled — enforce HTTPS connections"
-
-
-  - id: SA-IOS-03
-    type: regex
-    target: "**/*.{swift,m}"
-    pattern: "UIWebView"
-    severity: error
-    desc: "Deprecated UIWebView usage — migrate to WKWebView"
-
-
-  - id: SA-IOS-04
-    type: regex
-    target: "**/*.{swift,m}"
-    pattern: "UIPasteboard\\.general\\.(string|setString|setItems|setValue)[\\s\\S]{0,60}(token|password|secret|key|credential|session)"
-    severity: warning
-    desc: "Sensitive data on general pasteboard — use UIPasteboard.withUniqueName()"
-
-
-  - id: SA-IOS-05
-    type: regex
-    target: "**/*.{swift,m}"
-    pattern: "UserDefaults\\.(standard\\.)?set\\s*\\([^,]+,\\s*forKey:\\s*\"(token|password|secret|key|credential|session|auth)|NSUserDefaults.*set(Object|Value).*forKey.*@\"(token|password|secret)"
-    severity: error
-    desc: "Sensitive data in UserDefaults/NSUserDefaults — use Keychain instead"
-
-
-  - id: SA-IOS-06
-    type: regex
-    target: "**/*.{swift,m}"
-    pattern: "application\\s*\\(\\s*_\\s+app.*open\\s+url:\\s*URL|openURL:\\s*\\(NSURL\\s*\\*\\)"
-    severity: warning
-    desc: "URL scheme handler — verify source app validation and parameter sanitization"
-
-
-  - id: SA-IOS-07
-    type: regex
-    target: "**/*.{swift,m}"
-    pattern: "arc4random\\s*\\(|arc4random_uniform\\s*\\([\\s\\S]{0,80}(token|key|secret|session|nonce)"
-    severity: error
-    desc: "Insecure random for security tokens — use SecRandomCopyBytes"
-
-
-  - id: SA-IOS-08
-    type: regex
-    target: "**/*.{swift,m}"
-    pattern: "CC_MD5\\s*\\(|CC_SHA1\\s*\\(|CC_MD5_DIGEST_LENGTH"
-    severity: warning
-    desc: "Weak hash algorithm (MD5/SHA-1) — use SHA-256 via CryptoKit"
-
-
-  - id: SA-IOS-09
-    type: regex
-    target: "**/*.pbxproj"
-    pattern: "GCC_GENERATE_POSITION_DEPENDENT_CODE\\s*=\\s*YES|CLANG_ENABLE_OBJC_ARC\\s*=\\s*NO"
-    severity: error
-    desc: "Missing binary protections (PIE/ARC) — enable in Xcode build settings"
-
-
-  - id: SA-IOS-10
-    type: regex
-    target: "**/*.{swift,m}"
-    pattern: "NSLog\\s*\\(\\s*@?\"[^\"]*%([@dfs])[^\"]*\"\\s*,\\s*[^)]*?(password|token|secret|key|credential|session)"
-    severity: warning
-    desc: "Sensitive data in NSLog — use os_log with .private annotation"
-

--- a/skills/security-audit/scripts/scanners/android.sh
+++ b/skills/security-audit/scripts/scanners/android.sh
@@ -36,7 +36,7 @@ scan_android() {
     local results=""
     for dir in "${SCAN_DIRS[@]}"; do
         local matches
-        matches=$(grep -rn -E "$pattern" "$dir" --include="*.kt" --include="*.java" 2>/dev/null || true)
+        matches=$(grep -rn -P "$pattern" "$dir" --include="*.kt" --include="*.java" 2>/dev/null || true)
         if [[ -n "$matches" ]]; then
             results+="$matches"$'\n'
         fi
@@ -47,14 +47,14 @@ scan_android() {
 # Helper: grep manifest
 scan_manifest() {
     local pattern="$1"
-    grep -n -E "$pattern" "$MANIFEST" 2>/dev/null || true
+    grep -n -P "$pattern" "$MANIFEST" 2>/dev/null || true
 }
 
 # Helper: grep gradle files
 scan_gradle() {
     local pattern="$1"
     local limit="${2:-5}"
-    grep -rn -E "$pattern" "$PROJECT_DIR" --include="*.gradle" --include="*.gradle.kts" 2>/dev/null | head -"$limit" || true
+    grep -rn -P "$pattern" "$PROJECT_DIR" --include="*.gradle" --include="*.gradle.kts" 2>/dev/null | head -"$limit" || true
 }
 
 echo "--- Android Security Scanner ---"

--- a/skills/security-audit/scripts/scanners/android.sh
+++ b/skills/security-audit/scripts/scanners/android.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# Android Security Scanner Module
+# Scans Android projects for common vulnerability patterns
+# Part of security-audit-skill multi-language scanning
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+ERRORS=0
+WARNINGS=0
+
+# Auto-detect: Android project must have AndroidManifest.xml
+MANIFEST=$(find "$PROJECT_DIR" -name "AndroidManifest.xml" -not -path "*/build/*" 2>/dev/null | head -1)
+if [[ -z "$MANIFEST" ]]; then
+    echo "No AndroidManifest.xml found — not an Android project"
+    exit 0
+fi
+
+MANIFEST_DIR=$(dirname "$MANIFEST")
+
+# Auto-detect source directories
+SCAN_DIRS=()
+for dir in app/src/main src/main src app; do
+    if [[ -d "$PROJECT_DIR/$dir" ]]; then
+        SCAN_DIRS+=("$PROJECT_DIR/$dir")
+    fi
+done
+if [[ ${#SCAN_DIRS[@]} -eq 0 ]]; then
+    SCAN_DIRS=("$PROJECT_DIR")
+fi
+
+# Helper: grep across Android source directories (Kotlin + Java)
+scan_android() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    local results=""
+    for dir in "${SCAN_DIRS[@]}"; do
+        local matches
+        matches=$(grep -rn -E "$pattern" "$dir" --include="*.kt" --include="*.java" 2>/dev/null || true)
+        if [[ -n "$matches" ]]; then
+            results+="$matches"$'\n'
+        fi
+    done
+    echo "$results" | grep -v '^$' | head -"$limit"
+}
+
+# Helper: grep manifest
+scan_manifest() {
+    local pattern="$1"
+    grep -n -E "$pattern" "$MANIFEST" 2>/dev/null || true
+}
+
+# Helper: grep gradle files
+scan_gradle() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    grep -rn -E "$pattern" "$PROJECT_DIR" --include="*.gradle" --include="*.gradle.kts" 2>/dev/null | head -"$limit" || true
+}
+
+echo "--- Android Security Scanner ---"
+echo "Manifest: $MANIFEST"
+echo "Scanning: ${SCAN_DIRS[*]}"
+echo ""
+
+# === SA-ANDROID-01: Exported components ===
+echo "=== Checking for Exported Components ==="
+EXPORTED=$(scan_manifest 'android:exported\s*=\s*"true"')
+if [[ -n "$EXPORTED" ]]; then
+    echo "WARNING: Exported components found (SA-ANDROID-01):"
+    echo "$EXPORTED" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No explicitly exported components detected"
+fi
+
+# === SA-ANDROID-02: SQL injection in ContentProvider ===
+echo ""
+echo "=== Checking for SQL Injection in ContentProvider ==="
+SQLI=$(scan_android 'rawQuery\s*\(\s*"[^"]*\+\s*\w+|rawQuery\s*\(\s*"[^"]*\$\{?' 10)
+if [[ -n "$SQLI" ]]; then
+    echo "ERROR: SQL injection in rawQuery found (SA-ANDROID-02):"
+    echo "$SQLI" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No SQL injection patterns detected"
+fi
+
+# === SA-ANDROID-03: WebView JavaScript interface ===
+echo ""
+echo "=== Checking for WebView JavaScript Interface ==="
+JSIF=$(scan_android 'addJavascriptInterface\s*\(' 10)
+if [[ -n "$JSIF" ]]; then
+    echo "ERROR: addJavascriptInterface usage found (SA-ANDROID-03):"
+    echo "$JSIF" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No addJavascriptInterface usage detected"
+fi
+
+# === SA-ANDROID-04: SharedPreferences with sensitive data ===
+echo ""
+echo "=== Checking for Insecure SharedPreferences ==="
+WORLD_READ=$(scan_android 'MODE_WORLD_READABLE' 10)
+if [[ -n "$WORLD_READ" ]]; then
+    echo "ERROR: MODE_WORLD_READABLE SharedPreferences found (SA-ANDROID-04):"
+    echo "$WORLD_READ" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No MODE_WORLD_READABLE usage detected"
+fi
+
+# === SA-ANDROID-05: Cleartext traffic ===
+echo ""
+echo "=== Checking for Cleartext Traffic ==="
+CLEARTEXT=$(scan_manifest 'usesCleartextTraffic\s*=\s*"true"')
+if [[ -n "$CLEARTEXT" ]]; then
+    echo "ERROR: Cleartext traffic allowed (SA-ANDROID-05):"
+    echo "$CLEARTEXT"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No cleartext traffic flag detected"
+fi
+
+# === SA-ANDROID-06: Debug mode ===
+echo ""
+echo "=== Checking for Debug Mode ==="
+DEBUG_MANIFEST=$(scan_manifest 'android:debuggable\s*=\s*"true"')
+DEBUG_GRADLE=$(scan_gradle 'debuggable\s+true')
+if [[ -n "$DEBUG_MANIFEST" ]] || [[ -n "$DEBUG_GRADLE" ]]; then
+    echo "ERROR: Debug mode enabled (SA-ANDROID-06):"
+    [[ -n "$DEBUG_MANIFEST" ]] && echo "$DEBUG_MANIFEST"
+    [[ -n "$DEBUG_GRADLE" ]] && echo "$DEBUG_GRADLE"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No debug mode enabled"
+fi
+
+# === SA-ANDROID-07: Insecure broadcast receivers ===
+echo ""
+echo "=== Checking for Insecure Broadcast Receivers ==="
+RECV=$(scan_android 'registerReceiver\s*\(\s*\w+\s*,\s*\w+\s*\)\s*$' 10)
+if [[ -n "$RECV" ]]; then
+    echo "WARNING: Broadcast receiver without permission found (SA-ANDROID-07):"
+    echo "$RECV" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No unprotected broadcast receivers detected"
+fi
+
+# === SA-ANDROID-08: Insecure random ===
+echo ""
+echo "=== Checking for Insecure Random ==="
+RAND=$(scan_android 'new\s+Random\s*\(|java\.util\.Random|kotlin\.random\.Random' 10)
+if [[ -n "$RAND" ]]; then
+    echo "WARNING: Insecure random usage found (SA-ANDROID-08):"
+    echo "$RAND" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No insecure Random usage detected"
+fi
+
+# === SA-ANDROID-09: Hardcoded encryption keys ===
+echo ""
+echo "=== Checking for Hardcoded Keys ==="
+HARDKEY=$(scan_android 'SecretKeySpec\s*\(\s*"[^"]+"|private\s+(static\s+)?final\s+byte\[\]\s+\w*(KEY|key|SECRET|secret)' 10)
+if [[ -n "$HARDKEY" ]]; then
+    echo "ERROR: Hardcoded encryption key found (SA-ANDROID-09):"
+    echo "$HARDKEY" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No hardcoded encryption keys detected"
+fi
+
+# === SA-ANDROID-10: Sensitive data in logs ===
+echo ""
+echo "=== Checking for Sensitive Log Output ==="
+LOGS=$(scan_android 'Log\.(d|v|i)\s*\(\s*"[^"]*"\s*,\s*[^)]*?(password|token|secret|key|credential|session)' 10)
+if [[ -n "$LOGS" ]]; then
+    echo "WARNING: Sensitive data in logs found (SA-ANDROID-10):"
+    echo "$LOGS" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No sensitive log output detected"
+fi
+
+# === SA-ANDROID-11: Signing config with hardcoded passwords ===
+echo ""
+echo "=== Checking for Hardcoded Signing Credentials ==="
+SIGN=$(scan_gradle 'storePassword\s+["'"'"'][^"'"'"']+["'"'"']|keyPassword\s+["'"'"'][^"'"'"']+["'"'"']')
+if [[ -n "$SIGN" ]]; then
+    echo "ERROR: Hardcoded signing credentials found (SA-ANDROID-11):"
+    echo "$SIGN" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No hardcoded signing credentials detected"
+fi
+
+# === Summary ===
+echo ""
+echo "--- Android Security Scan Summary ---"
+echo "Errors: $ERRORS"
+echo "Warnings: $WARNINGS"
+
+if [[ "$ERRORS" -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/skills/security-audit/scripts/scanners/aws.sh
+++ b/skills/security-audit/scripts/scanners/aws.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# AWS Security Scanner Module
+# Scans AWS infrastructure files for common vulnerability patterns
+# Part of security-audit-skill cloud security references
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+ERRORS=0
+WARNINGS=0
+
+# Helper: grep across IaC files (*.tf, *.json, *.yaml, *.yml)
+scan_iac() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    grep -rn -E "$pattern" "$PROJECT_DIR" \
+        --include="*.tf" --include="*.json" --include="*.yaml" --include="*.yml" \
+        2>/dev/null | head -"$limit" || true
+}
+
+# Helper: count matches
+scan_iac_count() {
+    local pattern="$1"
+    grep -rc -E "$pattern" "$PROJECT_DIR" \
+        --include="*.tf" --include="*.json" --include="*.yaml" --include="*.yml" \
+        2>/dev/null | awk -F: '{s+=$2} END {print s+0}' || echo "0"
+}
+
+echo "=== AWS Security Scan ==="
+echo "Scanning: $PROJECT_DIR"
+echo ""
+
+# SA-AWS-01: IAM wildcard actions
+count=$(scan_iac_count '"Action"\s*:\s*"\*"|"Action"\s*:\s*\[\s*"\*"\s*\]')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-AWS-01: Found $count IAM policy(ies) with wildcard Action (*)"
+    scan_iac '"Action"\s*:\s*"\*"|"Action"\s*:\s*\[\s*"\*"\s*\]'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-AWS-03: Overly permissive trust policies
+count=$(scan_iac_count '"Principal"\s*:\s*\{\s*"AWS"\s*:\s*"\*"\s*\}|"Principal"\s*:\s*"\*"')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-AWS-03: Found $count overly permissive trust policy(ies) (Principal: *)"
+    scan_iac '"Principal"\s*:\s*\{\s*"AWS"\s*:\s*"\*"\s*\}|"Principal"\s*:\s*"\*"'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-AWS-05: Public S3 buckets
+count=$(scan_iac_count 'acl\s*=\s*"public-read"|acl\s*=\s*"public-read-write"')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-AWS-05: Found $count S3 bucket(s) with public ACL"
+    scan_iac 'acl\s*=\s*"public-read"|acl\s*=\s*"public-read-write"'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-AWS-06: S3 public access block disabled
+count=$(scan_iac_count 'block_public_acls\s*=\s*false|block_public_policy\s*=\s*false|restrict_public_buckets\s*=\s*false')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-AWS-06: Found $count S3 public access block(s) disabled"
+    scan_iac 'block_public_acls\s*=\s*false|block_public_policy\s*=\s*false|restrict_public_buckets\s*=\s*false'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-AWS-08: AdministratorAccess on roles
+count=$(scan_iac_count 'policy_arn\s*=\s*"arn:aws:iam::aws:policy/AdministratorAccess"|policy_arn\s*=\s*"arn:aws:iam::aws:policy/PowerUserAccess"')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-AWS-08: Found $count role(s) with AdministratorAccess/PowerUserAccess"
+    scan_iac 'policy_arn\s*=\s*"arn:aws:iam::aws:policy/AdministratorAccess"|policy_arn\s*=\s*"arn:aws:iam::aws:policy/PowerUserAccess"'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-AWS-09: Open security groups (0.0.0.0/0)
+count=$(scan_iac_count 'cidr_blocks\s*=\s*\[\s*"0\.0\.0\.0/0"\s*\]|CidrIp:\s*["\x27]?0\.0\.0\.0/0')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-AWS-09: Found $count security group rule(s) open to 0.0.0.0/0"
+    scan_iac 'cidr_blocks\s*=\s*\[\s*"0\.0\.0\.0/0"\s*\]|CidrIp:\s*["\x27]?0\.0\.0\.0/0'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-AWS-10: KMS key rotation disabled
+count=$(scan_iac_count 'enable_key_rotation\s*=\s*false')
+if [[ "$count" -gt 0 ]]; then
+    echo "[WARNING] SA-AWS-10: Found $count KMS key(s) with rotation disabled"
+    scan_iac 'enable_key_rotation\s*=\s*false'
+    WARNINGS=$((WARNINGS + count))
+    echo ""
+fi
+
+# SA-AWS-11: CloudTrail misconfiguration
+count=$(scan_iac_count 'is_multi_region_trail\s*=\s*false|enable_log_file_validation\s*=\s*false')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-AWS-11: Found $count CloudTrail misconfiguration(s)"
+    scan_iac 'is_multi_region_trail\s*=\s*false|enable_log_file_validation\s*=\s*false'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-AWS-12: Hardcoded passwords
+count=$(scan_iac_count 'password\s*=\s*"[^"]+"|master_password\s*=\s*"[^"]+"')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-AWS-12: Found $count hardcoded password(s) in IaC files"
+    scan_iac 'password\s*=\s*"[^"]+"|master_password\s*=\s*"[^"]+"'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-AWS-13: RDS publicly accessible
+count=$(scan_iac_count 'publicly_accessible\s*=\s*true')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-AWS-13: Found $count RDS instance(s) publicly accessible"
+    scan_iac 'publicly_accessible\s*=\s*true'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-AWS-14: RDS unencrypted storage
+count=$(scan_iac_count 'storage_encrypted\s*=\s*false')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-AWS-14: Found $count RDS instance(s) with unencrypted storage"
+    scan_iac 'storage_encrypted\s*=\s*false'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+echo "=== AWS Scan Summary ==="
+echo "Errors:   $ERRORS"
+echo "Warnings: $WARNINGS"
+
+if [[ "$ERRORS" -gt 0 ]]; then
+    exit 1
+fi

--- a/skills/security-audit/scripts/scanners/aws.sh
+++ b/skills/security-audit/scripts/scanners/aws.sh
@@ -13,7 +13,7 @@ WARNINGS=0
 scan_iac() {
     local pattern="$1"
     local limit="${2:-5}"
-    grep -rn -E "$pattern" "$PROJECT_DIR" \
+    grep -rn -P "$pattern" "$PROJECT_DIR" \
         --include="*.tf" --include="*.json" --include="*.yaml" --include="*.yml" \
         2>/dev/null | head -"$limit" || true
 }

--- a/skills/security-audit/scripts/scanners/azure.sh
+++ b/skills/security-audit/scripts/scanners/azure.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Azure Security Scanner Module
+# Scans Azure infrastructure files for common vulnerability patterns
+# Part of security-audit-skill cloud security references
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+ERRORS=0
+WARNINGS=0
+
+# Helper: grep across IaC files (*.tf, *.json, *.yaml, *.yml, *.bicep)
+scan_iac() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    grep -rn -E "$pattern" "$PROJECT_DIR" \
+        --include="*.tf" --include="*.json" --include="*.yaml" --include="*.yml" --include="*.bicep" \
+        2>/dev/null | head -"$limit" || true
+}
+
+# Helper: count matches
+scan_iac_count() {
+    local pattern="$1"
+    grep -rc -E "$pattern" "$PROJECT_DIR" \
+        --include="*.tf" --include="*.json" --include="*.yaml" --include="*.yml" --include="*.bicep" \
+        2>/dev/null | awk -F: '{s+=$2} END {print s+0}' || echo "0"
+}
+
+echo "=== Azure Security Scan ==="
+echo "Scanning: $PROJECT_DIR"
+echo ""
+
+# SA-AZURE-01: Owner/Contributor role assignments
+count=$(scan_iac_count 'role_definition_name\s*=\s*"(Owner|Contributor)"|8e3af657-a8ff-443c-a75c-2fe8c4bcb635|b24988ac-6180-42a0-ab88-20f7382dd24c')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-AZURE-01: Found $count Owner/Contributor role assignment(s)"
+    scan_iac 'role_definition_name\s*=\s*"(Owner|Contributor)"|8e3af657-a8ff-443c-a75c-2fe8c4bcb635|b24988ac-6180-42a0-ab88-20f7382dd24c'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-AZURE-03: Public blob access
+count=$(scan_iac_count 'allow_nested_items_to_be_public\s*=\s*true|allow_blob_public_access\s*=\s*true|allowBlobPublicAccess.*true|container_access_type\s*=\s*"(blob|container)"')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-AZURE-03: Found $count storage resource(s) with public blob access"
+    scan_iac 'allow_nested_items_to_be_public\s*=\s*true|allow_blob_public_access\s*=\s*true|allowBlobPublicAccess.*true|container_access_type\s*=\s*"(blob|container)"'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-AZURE-04: Anonymous function auth
+count=$(scan_iac_count 'authLevel.*anonymous|"authLevel"\s*:\s*"anonymous"')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-AZURE-04: Found $count Azure Function(s) with anonymous auth level"
+    scan_iac 'authLevel.*anonymous|"authLevel"\s*:\s*"anonymous"'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-AZURE-06: Open NSG inbound rules
+count=$(scan_iac_count 'source_address_prefix\s*=\s*"\*"|sourceAddressPrefix.*"\*"|"sourceAddressPrefix"\s*:\s*"\*"')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-AZURE-06: Found $count NSG rule(s) open to * (all sources)"
+    scan_iac 'source_address_prefix\s*=\s*"\*"|sourceAddressPrefix.*"\*"|"sourceAddressPrefix"\s*:\s*"\*"'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-AZURE-07: Missing purge protection
+count=$(scan_iac_count 'purge_protection_enabled\s*=\s*false|enablePurgeProtection:\s*false|"enablePurgeProtection"\s*:\s*false')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-AZURE-07: Found $count Key Vault(s) without purge protection"
+    scan_iac 'purge_protection_enabled\s*=\s*false|enablePurgeProtection:\s*false|"enablePurgeProtection"\s*:\s*false'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-AZURE-08: Access policies instead of RBAC
+count=$(scan_iac_count 'enable_rbac_authorization\s*=\s*false|access_policy\s*\{')
+if [[ "$count" -gt 0 ]]; then
+    echo "[WARNING] SA-AZURE-08: Found $count Key Vault(s) using access policies instead of RBAC"
+    scan_iac 'enable_rbac_authorization\s*=\s*false|access_policy\s*\{'
+    WARNINGS=$((WARNINGS + count))
+    echo ""
+fi
+
+# SA-AZURE-10: SQL public network access
+count=$(scan_iac_count 'public_network_access_enabled\s*=\s*true|start_ip_address\s*=\s*"0\.0\.0\.0"')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-AZURE-10: Found $count Azure SQL resource(s) with public network access"
+    scan_iac 'public_network_access_enabled\s*=\s*true|start_ip_address\s*=\s*"0\.0\.0\.0"'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+echo "=== Azure Scan Summary ==="
+echo "Errors:   $ERRORS"
+echo "Warnings: $WARNINGS"
+
+if [[ "$ERRORS" -gt 0 ]]; then
+    exit 1
+fi

--- a/skills/security-audit/scripts/scanners/azure.sh
+++ b/skills/security-audit/scripts/scanners/azure.sh
@@ -13,7 +13,7 @@ WARNINGS=0
 scan_iac() {
     local pattern="$1"
     local limit="${2:-5}"
-    grep -rn -E "$pattern" "$PROJECT_DIR" \
+    grep -rn -P "$pattern" "$PROJECT_DIR" \
         --include="*.tf" --include="*.json" --include="*.yaml" --include="*.yml" --include="*.bicep" \
         2>/dev/null | head -"$limit" || true
 }

--- a/skills/security-audit/scripts/scanners/common.sh
+++ b/skills/security-audit/scripts/scanners/common.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Common utilities for scanner modules
+# Sourced by individual scanner scripts
+
+# scan_files: grep across directories for a pattern in files matching a glob
+# Usage: scan_files DIRS_ARRAY PATTERN INCLUDE_GLOB [LIMIT]
+scan_files() {
+    local -n dirs=$1
+    local pattern="$2"
+    local include="$3"
+    local limit="${4:-5}"
+    local results=""
+    for dir in "${dirs[@]}"; do
+        local matches
+        matches=$(grep -rn -E "$pattern" "$dir" --include="$include" 2>/dev/null || true)
+        if [[ -n "$matches" ]]; then
+            results+="$matches"$'\n'
+        fi
+    done
+    echo "$results" | grep -v '^$' | head -"$limit"
+}
+
+# scan_files_count: count matches across directories
+# Usage: scan_files_count DIRS_ARRAY PATTERN INCLUDE_GLOB
+scan_files_count() {
+    local -n dirs=$1
+    local pattern="$2"
+    local include="$3"
+    local total=0
+    for dir in "${dirs[@]}"; do
+        local count
+        count=$(grep -rn -E "$pattern" "$dir" --include="$include" 2>/dev/null | wc -l || echo "0")
+        total=$((total + count))
+    done
+    echo "$total"
+}

--- a/skills/security-audit/scripts/scanners/common.sh
+++ b/skills/security-audit/scripts/scanners/common.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 # Common utilities for scanner modules
 # Sourced by individual scanner scripts
+#
+# Requires Bash 4+ (uses the `local -n` nameref below). On macOS /bin/bash
+# is typically 3.2 — install GNU bash via Homebrew and invoke scanners with
+# `/opt/homebrew/bin/bash` (or symlink into PATH).
+
+# Fail fast with a clear message if sourced under Bash 3.x.
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "ERROR: scripts/scanners/common.sh requires Bash 4+ (current: $BASH_VERSION)" >&2
+    echo "  macOS ships Bash 3.2 as /bin/bash; install GNU bash via Homebrew" >&2
+    echo "  and run the dispatcher with 'bash scripts/security-audit-dispatcher.sh …'" >&2
+    echo "  using that newer binary." >&2
+    return 1 2>/dev/null || exit 1
+fi
 
 # scan_files: grep across directories for a pattern in files matching a glob
 # Usage: scan_files DIRS_ARRAY PATTERN INCLUDE_GLOB [LIMIT]
@@ -12,7 +25,7 @@ scan_files() {
     local results=""
     for dir in "${dirs[@]}"; do
         local matches
-        matches=$(grep -rn -E "$pattern" "$dir" --include="$include" 2>/dev/null || true)
+        matches=$(grep -rn -P "$pattern" "$dir" --include="$include" 2>/dev/null || true)
         if [[ -n "$matches" ]]; then
             results+="$matches"$'\n'
         fi
@@ -29,7 +42,7 @@ scan_files_count() {
     local total=0
     for dir in "${dirs[@]}"; do
         local count
-        count=$(grep -rn -E "$pattern" "$dir" --include="$include" 2>/dev/null | wc -l || echo "0")
+        count=$(grep -rn -P "$pattern" "$dir" --include="$include" 2>/dev/null | wc -l || echo "0")
         total=$((total + count))
     done
     echo "$total"

--- a/skills/security-audit/scripts/scanners/csharp.sh
+++ b/skills/security-audit/scripts/scanners/csharp.sh
@@ -24,7 +24,7 @@ scan_csharp() {
     local results=""
     for dir in "${SCAN_DIRS[@]}"; do
         local matches
-        matches=$(grep -rn -E "$pattern" "$dir" --include="*.cs" 2>/dev/null || true)
+        matches=$(grep -rn -P "$pattern" "$dir" --include="*.cs" 2>/dev/null || true)
         if [[ -n "$matches" ]]; then
             results+="$matches"$'\n'
         fi
@@ -38,7 +38,7 @@ scan_csharp_count() {
     local total=0
     for dir in "${SCAN_DIRS[@]}"; do
         local count
-        count=$(grep -rn -E "$pattern" "$dir" --include="*.cs" 2>/dev/null | wc -l || echo "0")
+        count=$(grep -rn -P "$pattern" "$dir" --include="*.cs" 2>/dev/null | wc -l || echo "0")
         total=$((total + count))
     done
     echo "$total"

--- a/skills/security-audit/scripts/scanners/csharp.sh
+++ b/skills/security-audit/scripts/scanners/csharp.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# C# Security Scanner Module
+# Scans C# / .NET projects for common vulnerability patterns
+# Part of security-audit-skill multi-language scanning
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+ERRORS=0
+WARNINGS=0
+
+# Auto-detect C# source directories
+SCAN_DIRS=()
+for dir in src app Controllers Services; do
+    if [[ -d "$PROJECT_DIR/$dir" ]]; then
+        SCAN_DIRS+=("$PROJECT_DIR/$dir")
+    fi
+done
+
+# Helper: grep across all C# source directories
+scan_csharp() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    local results=""
+    for dir in "${SCAN_DIRS[@]}"; do
+        local matches
+        matches=$(grep -rn -E "$pattern" "$dir" --include="*.cs" 2>/dev/null || true)
+        if [[ -n "$matches" ]]; then
+            results+="$matches"$'\n'
+        fi
+    done
+    echo "$results" | grep -v '^$' | head -"$limit"
+}
+
+# Helper: count matches across all C# source directories
+scan_csharp_count() {
+    local pattern="$1"
+    local total=0
+    for dir in "${SCAN_DIRS[@]}"; do
+        local count
+        count=$(grep -rn -E "$pattern" "$dir" --include="*.cs" 2>/dev/null | wc -l || echo "0")
+        total=$((total + count))
+    done
+    echo "$total"
+}
+
+echo "--- C# Security Scanner ---"
+if [[ ${#SCAN_DIRS[@]} -eq 0 ]]; then
+    echo "No C# source directories found (looked for src/, app/, Controllers/, Services/)"
+    exit 0
+fi
+echo "Scanning: ${SCAN_DIRS[*]}"
+echo ""
+
+# === SA-CS-01: BinaryFormatter deserialization ===
+echo "=== Checking for Insecure Deserialization ==="
+BF=$(scan_csharp 'new\s+BinaryFormatter\s*\(' 10)
+if [[ -n "$BF" ]]; then
+    echo "ERROR: BinaryFormatter usage found (SA-CS-01):"
+    echo "$BF" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No BinaryFormatter usage detected"
+fi
+
+# === SA-CS-02: NetDataContractSerializer ===
+NDCS=$(scan_csharp 'new\s+NetDataContractSerializer\s*\(' 10)
+if [[ -n "$NDCS" ]]; then
+    echo "ERROR: NetDataContractSerializer usage found (SA-CS-02):"
+    echo "$NDCS" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No NetDataContractSerializer usage detected"
+fi
+
+# === SA-CS-03: SQL injection via FromSqlRaw ===
+echo ""
+echo "=== Checking for SQL Injection ==="
+SQL=$(scan_csharp 'FromSqlRaw\s*\(\s*\$' 10)
+if [[ -n "$SQL" ]]; then
+    echo "ERROR: FromSqlRaw with interpolation found (SA-CS-03):"
+    echo "$SQL" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No FromSqlRaw interpolation detected"
+fi
+
+# === SA-CS-04: XXE via XmlDocument ===
+echo ""
+echo "=== Checking for XXE Vulnerabilities ==="
+XXE=$(scan_csharp 'new\s+XmlDocument\s*\(' 10)
+if [[ -n "$XXE" ]]; then
+    SECURED=$(scan_csharp_count 'XmlResolver\s*=\s*null')
+    if [[ "$SECURED" -eq 0 ]]; then
+        echo "WARNING: XmlDocument without XmlResolver=null (SA-CS-04):"
+        echo "$XXE" | head -5
+        WARNINGS=$((WARNINGS + 1))
+    else
+        echo "OK: XmlDocument with XmlResolver=null detected"
+    fi
+else
+    echo "OK: No XmlDocument usage detected"
+fi
+
+# === SA-CS-05: Command injection via Process.Start ===
+echo ""
+echo "=== Checking for Command Injection ==="
+CMD=$(scan_csharp 'Process\.Start\s*\(' 10)
+if [[ -n "$CMD" ]]; then
+    SHELL_EXEC=$(scan_csharp_count 'UseShellExecute\s*=\s*true')
+    if [[ "$SHELL_EXEC" -gt 0 ]]; then
+        echo "ERROR: Process.Start with UseShellExecute=true (SA-CS-05):"
+        echo "$CMD" | head -5
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "WARNING: Process.Start found — verify UseShellExecute=false (SA-CS-05):"
+        echo "$CMD" | head -5
+        WARNINGS=$((WARNINGS + 1))
+    fi
+else
+    echo "OK: No Process.Start usage detected"
+fi
+
+# === SA-CS-06: Weak hash MD5 ===
+echo ""
+echo "=== Checking for Weak Cryptography ==="
+MD5=$(scan_csharp 'MD5\.Create\s*\(' 10)
+if [[ -n "$MD5" ]]; then
+    echo "WARNING: MD5 usage found (SA-CS-06):"
+    echo "$MD5" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No MD5 usage detected"
+fi
+
+# === SA-CS-07: Weak hash SHA-1 ===
+SHA1=$(scan_csharp 'SHA1\.Create\s*\(' 10)
+if [[ -n "$SHA1" ]]; then
+    echo "WARNING: SHA-1 usage found (SA-CS-07):"
+    echo "$SHA1" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No SHA-1 usage detected"
+fi
+
+# === SA-CS-08: Insecure random ===
+RAND=$(scan_csharp 'new\s+Random\s*\(' 10)
+if [[ -n "$RAND" ]]; then
+    echo "WARNING: System.Random usage found (SA-CS-08):"
+    echo "$RAND" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No insecure Random usage detected"
+fi
+
+# === SA-CS-09: DES cryptography ===
+DES=$(scan_csharp 'DESCryptoServiceProvider' 10)
+if [[ -n "$DES" ]]; then
+    echo "ERROR: DES usage found (SA-CS-09):"
+    echo "$DES" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No DES usage detected"
+fi
+
+# === SA-CS-10: CORS AllowAnyOrigin ===
+echo ""
+echo "=== Checking for CORS Misconfiguration ==="
+CORS=$(scan_csharp 'AllowAnyOrigin\s*\(' 10)
+if [[ -n "$CORS" ]]; then
+    echo "ERROR: AllowAnyOrigin found (SA-CS-10):"
+    echo "$CORS" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No AllowAnyOrigin detected"
+fi
+
+# === SA-CS-11: LDAP injection ===
+echo ""
+echo "=== Checking for LDAP Injection ==="
+LDAP=$(scan_csharp 'DirectorySearcher\s*\(\s*\$' 10)
+if [[ -n "$LDAP" ]]; then
+    echo "ERROR: LDAP injection pattern found (SA-CS-11):"
+    echo "$LDAP" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No LDAP injection patterns detected"
+fi
+
+# === SA-CS-12: UseShellExecute=true ===
+SHELL=$(scan_csharp 'UseShellExecute\s*=\s*true' 10)
+if [[ -n "$SHELL" ]]; then
+    echo "WARNING: UseShellExecute=true found (SA-CS-12):"
+    echo "$SHELL" | head -5
+    WARNINGS=$((WARNINGS + 1))
+fi
+
+# === Summary ===
+echo ""
+echo "--- C# Security Scan Summary ---"
+echo "Errors: $ERRORS"
+echo "Warnings: $WARNINGS"
+
+if [[ "$ERRORS" -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/skills/security-audit/scripts/scanners/drupal.sh
+++ b/skills/security-audit/scripts/scanners/drupal.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# Drupal Security Scanner Module
+# Detects Drupal projects via sites/default/settings.php
+# Scans for common Drupal-specific vulnerability patterns
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+ERRORS=0
+WARNINGS=0
+
+# Auto-detect Drupal project
+DRUPAL_DETECTED=false
+if [[ -f "$PROJECT_DIR/sites/default/settings.php" ]] || [[ -f "$PROJECT_DIR/core/lib/Drupal.php" ]]; then
+    DRUPAL_DETECTED=true
+fi
+
+if [[ "$DRUPAL_DETECTED" != "true" ]]; then
+    echo "--- Drupal Security Scanner ---"
+    echo "No Drupal installation detected (looked for sites/default/settings.php, core/lib/Drupal.php)"
+    exit 0
+fi
+
+# Determine scan directories
+SCAN_DIRS=()
+for dir in modules/custom themes/custom src; do
+    if [[ -d "$PROJECT_DIR/$dir" ]]; then
+        SCAN_DIRS+=("$PROJECT_DIR/$dir")
+    fi
+done
+# Also check sites/default for settings.php
+if [[ -d "$PROJECT_DIR/sites/default" ]]; then
+    SCAN_DIRS+=("$PROJECT_DIR/sites/default")
+fi
+
+if [[ ${#SCAN_DIRS[@]} -eq 0 ]]; then
+    echo "--- Drupal Security Scanner ---"
+    echo "No custom module/theme directories found (looked for modules/custom/, themes/custom/, src/)"
+    exit 0
+fi
+
+# Helper: grep across Drupal source directories
+scan_drupal() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    local results=""
+    for dir in "${SCAN_DIRS[@]}"; do
+        local matches
+        matches=$(grep -rn -E "$pattern" "$dir" --include="*.php" --include="*.module" --include="*.install" 2>/dev/null || true)
+        if [[ -n "$matches" ]]; then
+            results+="$matches"$'\n'
+        fi
+    done
+    echo "$results" | grep -v '^$' | head -"$limit"
+}
+
+scan_drupal_count() {
+    local pattern="$1"
+    local total=0
+    for dir in "${SCAN_DIRS[@]}"; do
+        local count
+        count=$(grep -rn -E "$pattern" "$dir" --include="*.php" --include="*.module" --include="*.install" 2>/dev/null | wc -l || echo "0")
+        total=$((total + count))
+    done
+    echo "$total"
+}
+
+echo "--- Drupal Security Scanner ---"
+echo "Scanning: ${SCAN_DIRS[*]}"
+echo ""
+
+# === SA-DRUPAL-01: SQL injection ===
+echo "=== Checking for SQL Injection ==="
+# shellcheck disable=SC2016
+SQLI=$(scan_drupal 'db_query\s*\(\s*["\x27].*\$|->query\s*\(\s*["\x27].*\$' 10)
+if [[ -n "$SQLI" ]]; then
+    echo "ERROR: Database queries with string interpolation found:"
+    echo "$SQLI" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No obvious SQL injection patterns detected"
+fi
+
+# === SA-DRUPAL-02/03: XSS via #markup ===
+echo ""
+echo "=== Checking for XSS via #markup ==="
+# shellcheck disable=SC2016
+MARKUP_XSS=$(scan_drupal '#markup.*\$' 10 | grep -v 'Html::escape\|Xss::filter\|check_plain\|->t(' || true)
+if [[ -n "$MARKUP_XSS" ]]; then
+    echo "ERROR: Render array #markup with unescaped variables:"
+    echo "$MARKUP_XSS" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No obvious #markup XSS patterns detected"
+fi
+
+# === SA-DRUPAL-05: Entity query without accessCheck ===
+echo ""
+echo "=== Checking for Missing Entity Access Checks ==="
+ENTITY_QUERY_COUNT=$(scan_drupal_count 'entityQuery\s*\(')
+ACCESS_CHECK_COUNT=$(scan_drupal_count 'accessCheck\s*\(\s*TRUE\s*\)')
+if [[ "$ENTITY_QUERY_COUNT" -gt 0 && "$ACCESS_CHECK_COUNT" -eq 0 ]]; then
+    echo "ERROR: entityQuery() calls found but no accessCheck(TRUE) detected"
+    ERRORS=$((ERRORS + 1))
+elif [[ "$ENTITY_QUERY_COUNT" -gt "$ACCESS_CHECK_COUNT" ]]; then
+    echo "WARNING: $ENTITY_QUERY_COUNT entityQuery() calls but only $ACCESS_CHECK_COUNT accessCheck(TRUE) calls"
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: Entity queries appear to have access checks"
+fi
+
+# === SA-DRUPAL-06: settings.php misconfiguration ===
+echo ""
+echo "=== Checking settings.php Configuration ==="
+if [[ -f "$PROJECT_DIR/sites/default/settings.php" ]]; then
+    EMPTY_SALT=$(grep -n "hash_salt.*=\s*['\"]['\"]" "$PROJECT_DIR/sites/default/settings.php" 2>/dev/null || true)
+    if [[ -n "$EMPTY_SALT" ]]; then
+        echo "ERROR: Empty hash_salt in settings.php"
+        ERRORS=$((ERRORS + 1))
+    fi
+
+    VERBOSE_ERRORS=$(grep -n "error_level.*verbose" "$PROJECT_DIR/sites/default/settings.php" 2>/dev/null || true)
+    if [[ -n "$VERBOSE_ERRORS" ]]; then
+        echo "WARNING: Verbose error reporting enabled"
+        WARNINGS=$((WARNINGS + 1))
+    fi
+
+    UPDATE_ACCESS=$(grep -n "update_free_access.*TRUE" "$PROJECT_DIR/sites/default/settings.php" 2>/dev/null || true)
+    if [[ -n "$UPDATE_ACCESS" ]]; then
+        echo "ERROR: update_free_access is TRUE — allows unauthenticated access to update.php"
+        ERRORS=$((ERRORS + 1))
+    fi
+
+    TRUSTED_HOST=$(grep -n "trusted_host_patterns" "$PROJECT_DIR/sites/default/settings.php" 2>/dev/null || true)
+    if [[ -z "$TRUSTED_HOST" ]]; then
+        echo "WARNING: No trusted_host_patterns configured — HTTP Host header attacks possible"
+        WARNINGS=$((WARNINGS + 1))
+    fi
+else
+    echo "OK: settings.php not in scan path"
+fi
+
+echo ""
+echo "--- Drupal Scanner Summary ---"
+echo "Errors: $ERRORS | Warnings: $WARNINGS"
+
+if [[ "$ERRORS" -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/skills/security-audit/scripts/scanners/drupal.sh
+++ b/skills/security-audit/scripts/scanners/drupal.sh
@@ -46,7 +46,7 @@ scan_drupal() {
     local results=""
     for dir in "${SCAN_DIRS[@]}"; do
         local matches
-        matches=$(grep -rn -E "$pattern" "$dir" --include="*.php" --include="*.module" --include="*.install" 2>/dev/null || true)
+        matches=$(grep -rn -P "$pattern" "$dir" --include="*.php" --include="*.module" --include="*.install" 2>/dev/null || true)
         if [[ -n "$matches" ]]; then
             results+="$matches"$'\n'
         fi
@@ -59,7 +59,7 @@ scan_drupal_count() {
     local total=0
     for dir in "${SCAN_DIRS[@]}"; do
         local count
-        count=$(grep -rn -E "$pattern" "$dir" --include="*.php" --include="*.module" --include="*.install" 2>/dev/null | wc -l || echo "0")
+        count=$(grep -rn -P "$pattern" "$dir" --include="*.php" --include="*.module" --include="*.install" 2>/dev/null | wc -l || echo "0")
         total=$((total + count))
     done
     echo "$total"

--- a/skills/security-audit/scripts/scanners/gcp.sh
+++ b/skills/security-audit/scripts/scanners/gcp.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# GCP Security Scanner Module
+# Scans GCP infrastructure files for common vulnerability patterns
+# Part of security-audit-skill cloud security references
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+ERRORS=0
+WARNINGS=0
+
+# Helper: grep across IaC files (*.tf, *.json, *.yaml, *.yml)
+scan_iac() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    grep -rn -E "$pattern" "$PROJECT_DIR" \
+        --include="*.tf" --include="*.json" --include="*.yaml" --include="*.yml" \
+        2>/dev/null | head -"$limit" || true
+}
+
+# Helper: count matches
+scan_iac_count() {
+    local pattern="$1"
+    grep -rc -E "$pattern" "$PROJECT_DIR" \
+        --include="*.tf" --include="*.json" --include="*.yaml" --include="*.yml" \
+        2>/dev/null | awk -F: '{s+=$2} END {print s+0}' || echo "0"
+}
+
+echo "=== GCP Security Scan ==="
+echo "Scanning: $PROJECT_DIR"
+echo ""
+
+# SA-GCP-01: Primitive roles (Owner/Editor)
+count=$(scan_iac_count 'role\s*=\s*"roles/(owner|editor)"|"roles/(owner|editor)"')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-GCP-01: Found $count primitive role assignment(s) (Owner/Editor)"
+    scan_iac 'role\s*=\s*"roles/(owner|editor)"|"roles/(owner|editor)"'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-GCP-02: Service account key files
+count=$(scan_iac_count 'resource\s+"google_service_account_key"|google_service_account_key\s*\{')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-GCP-02: Found $count service account key resource(s)"
+    scan_iac 'resource\s+"google_service_account_key"|google_service_account_key\s*\{'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-GCP-03: allUsers / allAuthenticatedUsers
+count=$(scan_iac_count '"allUsers"|"allAuthenticatedUsers"|member\s*=\s*"allUsers"|member\s*=\s*"allAuthenticatedUsers"')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-GCP-03: Found $count allUsers/allAuthenticatedUsers binding(s)"
+    scan_iac '"allUsers"|"allAuthenticatedUsers"|member\s*=\s*"allUsers"|member\s*=\s*"allAuthenticatedUsers"'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-GCP-04: Public storage buckets
+count=$(scan_iac_count 'google_storage_bucket_iam.*(allUsers|allAuthenticatedUsers)|predefinedAcl:\s*public')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-GCP-04: Found $count public Cloud Storage bucket(s)"
+    scan_iac 'google_storage_bucket_iam.*(allUsers|allAuthenticatedUsers)|predefinedAcl:\s*public'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-GCP-05: Uniform bucket-level access disabled
+count=$(scan_iac_count 'uniform_bucket_level_access\s*=\s*false')
+if [[ "$count" -gt 0 ]]; then
+    echo "[WARNING] SA-GCP-05: Found $count bucket(s) without uniform bucket-level access"
+    scan_iac 'uniform_bucket_level_access\s*=\s*false'
+    WARNINGS=$((WARNINGS + count))
+    echo ""
+fi
+
+# SA-GCP-06: Secrets in Cloud Functions env vars
+count=$(scan_iac_count 'environment_variables\s*=\s*\{[^}]*(PASSWORD|SECRET|API_KEY|TOKEN|PRIVATE_KEY)\s*=\s*"[^"]+"')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-GCP-06: Found $count Cloud Function(s) with hardcoded secrets in env vars"
+    scan_iac 'environment_variables\s*=\s*\{[^}]*(PASSWORD|SECRET|API_KEY|TOKEN|PRIVATE_KEY)\s*=\s*"[^"]+"'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-GCP-07: allUsers Cloud Functions invoker
+count=$(scan_iac_count 'cloudfunctions\.invoker.*allUsers|allUsers.*cloudfunctions\.invoker')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-GCP-07: Found $count Cloud Function(s) invocable by allUsers"
+    scan_iac 'cloudfunctions\.invoker.*allUsers|allUsers.*cloudfunctions\.invoker'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-GCP-08: Open VPC firewall (0.0.0.0/0)
+count=$(scan_iac_count 'source_ranges\s*=\s*\[\s*"0\.0\.0\.0/0"\s*\]|sourceRanges:.*0\.0\.0\.0/0')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-GCP-08: Found $count VPC firewall rule(s) open to 0.0.0.0/0"
+    scan_iac 'source_ranges\s*=\s*\[\s*"0\.0\.0\.0/0"\s*\]|sourceRanges:.*0\.0\.0\.0/0'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-GCP-09: KMS key accessible by allUsers
+count=$(scan_iac_count 'google_kms_crypto_key_iam.*(allUsers|allAuthenticatedUsers)')
+if [[ "$count" -gt 0 ]]; then
+    echo "[ERROR] SA-GCP-09: Found $count KMS key(s) accessible by allUsers"
+    scan_iac 'google_kms_crypto_key_iam.*(allUsers|allAuthenticatedUsers)'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-GCP-10: Audit log exemptions
+count=$(scan_iac_count 'exempted_members\s*=\s*\[')
+if [[ "$count" -gt 0 ]]; then
+    echo "[WARNING] SA-GCP-10: Found $count audit log exemption(s)"
+    scan_iac 'exempted_members\s*=\s*\['
+    WARNINGS=$((WARNINGS + count))
+    echo ""
+fi
+
+echo "=== GCP Scan Summary ==="
+echo "Errors:   $ERRORS"
+echo "Warnings: $WARNINGS"
+
+if [[ "$ERRORS" -gt 0 ]]; then
+    exit 1
+fi

--- a/skills/security-audit/scripts/scanners/gcp.sh
+++ b/skills/security-audit/scripts/scanners/gcp.sh
@@ -13,7 +13,7 @@ WARNINGS=0
 scan_iac() {
     local pattern="$1"
     local limit="${2:-5}"
-    grep -rn -E "$pattern" "$PROJECT_DIR" \
+    grep -rn -P "$pattern" "$PROJECT_DIR" \
         --include="*.tf" --include="*.json" --include="*.yaml" --include="*.yml" \
         2>/dev/null | head -"$limit" || true
 }

--- a/skills/security-audit/scripts/scanners/go.sh
+++ b/skills/security-audit/scripts/scanners/go.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+# Go Security Scanner Module
+# Scans Go projects for common vulnerability patterns
+# Excludes vendor/ directory
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+ERRORS=0
+WARNINGS=0
+
+# Auto-detect Go source directories
+SCAN_DIRS=()
+for dir in . cmd pkg internal api; do
+    if [[ -d "$PROJECT_DIR/$dir" ]]; then
+        SCAN_DIRS+=("$PROJECT_DIR/$dir")
+    fi
+done
+
+# If no standard dirs found, scan the project root
+if [[ ${#SCAN_DIRS[@]} -eq 0 ]]; then
+    SCAN_DIRS+=("$PROJECT_DIR")
+fi
+
+# Helper: grep across all Go source directories, excluding vendor/
+scan_go() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    local results=""
+    for dir in "${SCAN_DIRS[@]}"; do
+        local matches
+        matches=$(grep -rn -E "$pattern" "$dir" --include="*.go" --exclude-dir=vendor --exclude-dir=.git 2>/dev/null || true)
+        if [[ -n "$matches" ]]; then
+            results+="$matches"$'\n'
+        fi
+    done
+    echo "$results" | grep -v '^$' | head -"$limit"
+}
+
+# Helper: count matches across all Go source directories
+scan_go_count() {
+    local pattern="$1"
+    local total=0
+    for dir in "${SCAN_DIRS[@]}"; do
+        local count
+        count=$(grep -rn -E "$pattern" "$dir" --include="*.go" --exclude-dir=vendor --exclude-dir=.git 2>/dev/null | wc -l || echo "0")
+        total=$((total + count))
+    done
+    echo "$total"
+}
+
+echo "--- Go Security Scanner ---"
+if [[ $(find "${SCAN_DIRS[@]}" -name "*.go" -not -path "*/vendor/*" 2>/dev/null | head -1 | wc -l) -eq 0 ]]; then
+    echo "No Go source files found"
+    exit 0
+fi
+echo "Scanning: ${SCAN_DIRS[*]}"
+echo ""
+
+# === Check for unsafe package usage ===
+echo "=== Checking for unsafe Package Usage ==="
+UNSAFE=$(scan_go 'unsafe\.(Pointer|Sizeof|Slice|String|Offsetof|Alignof)' 10)
+if [[ -n "$UNSAFE" ]]; then
+    echo "WARNING: unsafe package usage found — audit required:"
+    echo "$UNSAFE" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No unsafe package usage detected"
+fi
+
+# === Check for text/template (XSS risk) ===
+echo ""
+echo "=== Checking for text/template Usage ==="
+TEXT_TMPL=$(scan_go '"text/template"')
+if [[ -n "$TEXT_TMPL" ]]; then
+    echo "ERROR: text/template import found — use html/template for HTML output:"
+    echo "$TEXT_TMPL"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No text/template imports detected"
+fi
+
+# === Check for SQL injection patterns ===
+echo ""
+echo "=== Checking for SQL Injection Patterns ==="
+SQL_CONCAT=$(scan_go '(Sprintf|"\s*\+).*(SELECT|INSERT|UPDATE|DELETE)' 5)
+if [[ -n "$SQL_CONCAT" ]]; then
+    echo "ERROR: SQL string concatenation found:"
+    echo "$SQL_CONCAT"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No SQL string concatenation detected"
+fi
+
+# === Check for command injection ===
+echo ""
+echo "=== Checking for Command Injection ==="
+CMD_INJECT=$(scan_go 'exec\.Command\s*\(\s*"(sh|bash|cmd|powershell)"')
+if [[ -n "$CMD_INJECT" ]]; then
+    echo "ERROR: Shell invocation via exec.Command:"
+    echo "$CMD_INJECT"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No shell invocation patterns detected"
+fi
+
+# === Check for InsecureSkipVerify ===
+echo ""
+echo "=== Checking for Insecure TLS Configuration ==="
+TLS_SKIP=$(scan_go 'InsecureSkipVerify\s*:\s*true')
+if [[ -n "$TLS_SKIP" ]]; then
+    echo "ERROR: TLS certificate verification disabled:"
+    echo "$TLS_SKIP"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No InsecureSkipVerify found"
+fi
+
+# === Check for math/rand usage ===
+echo ""
+echo "=== Checking for Insecure Randomness ==="
+MATH_RAND=$(scan_go '"math/rand"')
+if [[ -n "$MATH_RAND" ]]; then
+    echo "WARNING: math/rand imported — use crypto/rand for security-sensitive values:"
+    echo "$MATH_RAND"
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No math/rand imports detected"
+fi
+
+# === Check for hardcoded secrets ===
+echo ""
+echo "=== Checking for Hardcoded Secrets ==="
+SECRETS=$(scan_go '(password|secret|apiKey|token)\s*[:=]\s*"[^"]{8,}"' 10)
+if [[ -n "$SECRETS" ]]; then
+    echo "ERROR: Potential hardcoded credentials found:"
+    echo "$SECRETS" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No obvious hardcoded secrets detected"
+fi
+
+# === Check for SSRF patterns ===
+echo ""
+echo "=== Checking for SSRF Patterns ==="
+SSRF=$(scan_go 'http\.(Get|Post|Head)\s*\(.*\b(r\.|req\.|request\.|URL)')
+if [[ -n "$SSRF" ]]; then
+    echo "ERROR: HTTP request with user-controlled URL:"
+    echo "$SSRF"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No obvious SSRF patterns detected"
+fi
+
+# === Check for path traversal ===
+echo ""
+echo "=== Checking for Path Traversal ==="
+PATH_TRAV=$(scan_go 'filepath\.Join\s*\(.*\b(r\.|req\.|request\.|URL)')
+if [[ -n "$PATH_TRAV" ]]; then
+    echo "WARNING: filepath.Join with user input:"
+    echo "$PATH_TRAV"
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No obvious path traversal patterns detected"
+fi
+
+# === Check for weak TLS versions ===
+echo ""
+echo "=== Checking for Weak TLS Versions ==="
+WEAK_TLS=$(scan_go 'VersionTLS1[01]\b')
+if [[ -n "$WEAK_TLS" ]]; then
+    echo "ERROR: Weak TLS version configured:"
+    echo "$WEAK_TLS"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No weak TLS versions detected"
+fi
+
+# === Check for unstructured logging ===
+echo ""
+echo "=== Checking Logging Practices ==="
+UNSTRUCTURED=$(scan_go_count 'log\.(Print|Fatal|Panic)(f|ln)?\s*\(')
+STRUCTURED=$(scan_go_count 'slog\.(Info|Warn|Error|Debug)\s*\(')
+if [[ "$UNSTRUCTURED" -gt 0 && "$STRUCTURED" -eq 0 ]]; then
+    echo "WARNING: Only unstructured logging found ($UNSTRUCTURED calls) — consider log/slog"
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: Logging practices look acceptable"
+fi
+
+# === Check dependencies for vulnerabilities ===
+echo ""
+echo "=== Checking Dependencies ==="
+if [[ -f "$PROJECT_DIR/go.sum" ]]; then
+    if command -v govulncheck &> /dev/null; then
+        VULN_OUTPUT=$(cd "$PROJECT_DIR" && govulncheck ./... 2>&1 || true)
+        if echo "$VULN_OUTPUT" | grep -q "Vulnerability"; then
+            echo "WARNING: Vulnerable dependencies found:"
+            echo "$VULN_OUTPUT" | head -20
+            WARNINGS=$((WARNINGS + 1))
+        else
+            echo "OK: No known vulnerable dependencies"
+        fi
+    else
+        echo "INFO: govulncheck not available — install with: go install golang.org/x/vuln/cmd/govulncheck@latest"
+    fi
+else
+    echo "INFO: No go.sum found — skipping dependency check"
+fi
+
+# === Output results for dispatcher ===
+echo ""
+echo "--- Go Scanner Results ---"
+echo "Errors: $ERRORS"
+echo "Warnings: $WARNINGS"
+
+# Exit with error count for dispatcher to aggregate
+exit "$ERRORS"

--- a/skills/security-audit/scripts/scanners/go.sh
+++ b/skills/security-audit/scripts/scanners/go.sh
@@ -29,7 +29,7 @@ scan_go() {
     local results=""
     for dir in "${SCAN_DIRS[@]}"; do
         local matches
-        matches=$(grep -rn -E "$pattern" "$dir" --include="*.go" --exclude-dir=vendor --exclude-dir=.git 2>/dev/null || true)
+        matches=$(grep -rn -P "$pattern" "$dir" --include="*.go" --exclude-dir=vendor --exclude-dir=.git 2>/dev/null || true)
         if [[ -n "$matches" ]]; then
             results+="$matches"$'\n'
         fi
@@ -43,7 +43,7 @@ scan_go_count() {
     local total=0
     for dir in "${SCAN_DIRS[@]}"; do
         local count
-        count=$(grep -rn -E "$pattern" "$dir" --include="*.go" --exclude-dir=vendor --exclude-dir=.git 2>/dev/null | wc -l || echo "0")
+        count=$(grep -rn -P "$pattern" "$dir" --include="*.go" --exclude-dir=vendor --exclude-dir=.git 2>/dev/null | wc -l || echo "0")
         total=$((total + count))
     done
     echo "$total"

--- a/skills/security-audit/scripts/scanners/ios.sh
+++ b/skills/security-audit/scripts/scanners/ios.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# iOS Security Scanner Module
+# Scans iOS projects for common vulnerability patterns
+# Part of security-audit-skill multi-language scanning
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+ERRORS=0
+WARNINGS=0
+
+# Auto-detect: iOS project must have Info.plist or *.xcodeproj
+INFO_PLIST=$(find "$PROJECT_DIR" -name "Info.plist" -not -path "*/build/*" -not -path "*/Pods/*" -not -path "*/DerivedData/*" 2>/dev/null | head -1)
+XCODEPROJ=$(find "$PROJECT_DIR" -name "*.xcodeproj" -not -path "*/Pods/*" 2>/dev/null | head -1)
+
+if [[ -z "$INFO_PLIST" ]] && [[ -z "$XCODEPROJ" ]]; then
+    echo "No Info.plist or .xcodeproj found — not an iOS project"
+    exit 0
+fi
+
+# Auto-detect source directories
+SCAN_DIRS=()
+for dir in Sources src App app; do
+    if [[ -d "$PROJECT_DIR/$dir" ]]; then
+        SCAN_DIRS+=("$PROJECT_DIR/$dir")
+    fi
+done
+if [[ ${#SCAN_DIRS[@]} -eq 0 ]]; then
+    SCAN_DIRS=("$PROJECT_DIR")
+fi
+
+# Helper: grep across Swift and Objective-C files
+scan_ios() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    local results=""
+    for dir in "${SCAN_DIRS[@]}"; do
+        local matches
+        matches=$(grep -rn -E "$pattern" "$dir" --include="*.swift" --include="*.m" --include="*.mm" 2>/dev/null || true)
+        if [[ -n "$matches" ]]; then
+            results+="$matches"$'\n'
+        fi
+    done
+    echo "$results" | grep -v '^$' | head -"$limit"
+}
+
+# Helper: grep Info.plist
+scan_plist() {
+    local pattern="$1"
+    if [[ -n "$INFO_PLIST" ]]; then
+        grep -n -E "$pattern" "$INFO_PLIST" 2>/dev/null || true
+    fi
+}
+
+# Helper: grep pbxproj files
+scan_pbxproj() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    grep -rn -E "$pattern" "$PROJECT_DIR" --include="*.pbxproj" 2>/dev/null | head -"$limit" || true
+}
+
+echo "--- iOS Security Scanner ---"
+[[ -n "$INFO_PLIST" ]] && echo "Info.plist: $INFO_PLIST"
+[[ -n "$XCODEPROJ" ]] && echo "Xcode project: $XCODEPROJ"
+echo "Scanning: ${SCAN_DIRS[*]}"
+echo ""
+
+# === SA-IOS-01: Insecure Keychain accessibility ===
+echo "=== Checking for Insecure Keychain Accessibility ==="
+KEYCHAIN=$(scan_ios 'kSecAttrAccessibleAlways[^T]|kSecAttrAccessibleAlways$' 10)
+if [[ -n "$KEYCHAIN" ]]; then
+    echo "ERROR: kSecAttrAccessibleAlways usage found (SA-IOS-01):"
+    echo "$KEYCHAIN" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No insecure Keychain accessibility detected"
+fi
+
+# === SA-IOS-02: App Transport Security disabled ===
+echo ""
+echo "=== Checking for ATS Configuration ==="
+ATS=$(scan_plist 'NSAllowsArbitraryLoads')
+if [[ -n "$ATS" ]]; then
+    ATS_TRUE=$(scan_plist 'NSAllowsArbitraryLoads' | grep -A1 'NSAllowsArbitraryLoads' | grep -i 'true' || true)
+    if [[ -n "$ATS_TRUE" ]]; then
+        echo "ERROR: NSAllowsArbitraryLoads is true (SA-IOS-02):"
+        echo "$ATS"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "OK: NSAllowsArbitraryLoads present but not set to true"
+    fi
+else
+    echo "OK: No ATS override detected"
+fi
+
+# === SA-IOS-03: UIWebView usage ===
+echo ""
+echo "=== Checking for Deprecated UIWebView ==="
+UIWEBVIEW=$(scan_ios 'UIWebView' 10)
+if [[ -n "$UIWEBVIEW" ]]; then
+    echo "ERROR: Deprecated UIWebView usage found (SA-IOS-03):"
+    echo "$UIWEBVIEW" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No UIWebView usage detected"
+fi
+
+# === SA-IOS-04: Pasteboard with sensitive data ===
+echo ""
+echo "=== Checking for Pasteboard Sensitive Data ==="
+PASTE=$(scan_ios 'UIPasteboard\.general\.(string|setString|setItems|setValue)' 10)
+if [[ -n "$PASTE" ]]; then
+    echo "WARNING: General pasteboard usage found — review for sensitive data (SA-IOS-04):"
+    echo "$PASTE" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No general pasteboard usage detected"
+fi
+
+# === SA-IOS-05: UserDefaults for sensitive data ===
+echo ""
+echo "=== Checking for Sensitive Data in UserDefaults ==="
+DEFAULTS=$(scan_ios 'UserDefaults\.(standard\.)?set\s*\([^,]+,\s*forKey:\s*"(token|password|secret|key|credential|session|auth)' 10)
+NSDEFAULTS=$(scan_ios 'NSUserDefaults.*set(Object|Value).*forKey.*@"(token|password|secret)' 10)
+if [[ -n "$DEFAULTS" ]] || [[ -n "$NSDEFAULTS" ]]; then
+    echo "ERROR: Sensitive data in UserDefaults (SA-IOS-05):"
+    [[ -n "$DEFAULTS" ]] && echo "$DEFAULTS" | head -5
+    [[ -n "$NSDEFAULTS" ]] && echo "$NSDEFAULTS" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No sensitive UserDefaults usage detected"
+fi
+
+# === SA-IOS-06: URL scheme handlers ===
+echo ""
+echo "=== Checking for URL Scheme Handlers ==="
+URLSCHEME=$(scan_ios 'application\s*\(\s*_\s+app.*open\s+url:\s*URL|openURL:\s*\(NSURL\s*\*\)' 10)
+if [[ -n "$URLSCHEME" ]]; then
+    echo "WARNING: URL scheme handler found — verify validation (SA-IOS-06):"
+    echo "$URLSCHEME" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No URL scheme handlers detected"
+fi
+
+# === SA-IOS-07: Insecure random ===
+echo ""
+echo "=== Checking for Insecure Random ==="
+RAND=$(scan_ios 'arc4random\s*\(|arc4random_uniform\s*\(' 10)
+if [[ -n "$RAND" ]]; then
+    echo "WARNING: arc4random usage found — review for security context (SA-IOS-07):"
+    echo "$RAND" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No arc4random usage detected"
+fi
+
+# === SA-IOS-08: Weak hash algorithms ===
+echo ""
+echo "=== Checking for Weak Hash Algorithms ==="
+WEAKHASH=$(scan_ios 'CC_MD5\s*\(|CC_SHA1\s*\(|CC_MD5_DIGEST_LENGTH' 10)
+if [[ -n "$WEAKHASH" ]]; then
+    echo "WARNING: Weak hash algorithm found (SA-IOS-08):"
+    echo "$WEAKHASH" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No weak hash algorithms detected"
+fi
+
+# === SA-IOS-09: Binary protection settings ===
+echo ""
+echo "=== Checking for Binary Protection Settings ==="
+NO_PIE=$(scan_pbxproj 'GCC_GENERATE_POSITION_DEPENDENT_CODE\s*=\s*YES')
+NO_ARC=$(scan_pbxproj 'CLANG_ENABLE_OBJC_ARC\s*=\s*NO')
+if [[ -n "$NO_PIE" ]] || [[ -n "$NO_ARC" ]]; then
+    echo "ERROR: Missing binary protections (SA-IOS-09):"
+    [[ -n "$NO_PIE" ]] && echo "  PIE disabled: $NO_PIE"
+    [[ -n "$NO_ARC" ]] && echo "  ARC disabled: $NO_ARC"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: Binary protections appear enabled"
+fi
+
+# === SA-IOS-10: Sensitive data in NSLog ===
+echo ""
+echo "=== Checking for Sensitive NSLog Output ==="
+NSLOG=$(scan_ios 'NSLog\s*\(\s*@?"[^"]*%[@dfs][^"]*"\s*,\s*[^)]*?(password|token|secret|key|credential|session)' 10)
+PRINT=$(scan_ios 'print\s*\(\s*"[^"]*\\?\(\s*(password|token|secret|key|credential|session)' 10)
+if [[ -n "$NSLOG" ]] || [[ -n "$PRINT" ]]; then
+    echo "WARNING: Sensitive data in log output (SA-IOS-10):"
+    [[ -n "$NSLOG" ]] && echo "$NSLOG" | head -5
+    [[ -n "$PRINT" ]] && echo "$PRINT" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No sensitive log output detected"
+fi
+
+# === Summary ===
+echo ""
+echo "--- iOS Security Scan Summary ---"
+echo "Errors: $ERRORS"
+echo "Warnings: $WARNINGS"
+
+if [[ "$ERRORS" -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/skills/security-audit/scripts/scanners/ios.sh
+++ b/skills/security-audit/scripts/scanners/ios.sh
@@ -36,7 +36,7 @@ scan_ios() {
     local results=""
     for dir in "${SCAN_DIRS[@]}"; do
         local matches
-        matches=$(grep -rn -E "$pattern" "$dir" --include="*.swift" --include="*.m" --include="*.mm" 2>/dev/null || true)
+        matches=$(grep -rn -P "$pattern" "$dir" --include="*.swift" --include="*.m" --include="*.mm" 2>/dev/null || true)
         if [[ -n "$matches" ]]; then
             results+="$matches"$'\n'
         fi
@@ -48,7 +48,7 @@ scan_ios() {
 scan_plist() {
     local pattern="$1"
     if [[ -n "$INFO_PLIST" ]]; then
-        grep -n -E "$pattern" "$INFO_PLIST" 2>/dev/null || true
+        grep -n -P "$pattern" "$INFO_PLIST" 2>/dev/null || true
     fi
 }
 
@@ -56,7 +56,7 @@ scan_plist() {
 scan_pbxproj() {
     local pattern="$1"
     local limit="${2:-5}"
-    grep -rn -E "$pattern" "$PROJECT_DIR" --include="*.pbxproj" 2>/dev/null | head -"$limit" || true
+    grep -rn -P "$pattern" "$PROJECT_DIR" --include="*.pbxproj" 2>/dev/null | head -"$limit" || true
 }
 
 echo "--- iOS Security Scanner ---"

--- a/skills/security-audit/scripts/scanners/java.sh
+++ b/skills/security-audit/scripts/scanners/java.sh
@@ -24,7 +24,7 @@ scan_java() {
     local results=""
     for dir in "${SCAN_DIRS[@]}"; do
         local matches
-        matches=$(grep -rn -E "$pattern" "$dir" --include="*.java" 2>/dev/null || true)
+        matches=$(grep -rn -P "$pattern" "$dir" --include="*.java" 2>/dev/null || true)
         if [[ -n "$matches" ]]; then
             results+="$matches"$'\n'
         fi
@@ -38,7 +38,7 @@ scan_java_count() {
     local total=0
     for dir in "${SCAN_DIRS[@]}"; do
         local count
-        count=$(grep -rn -E "$pattern" "$dir" --include="*.java" 2>/dev/null | wc -l || echo "0")
+        count=$(grep -rn -P "$pattern" "$dir" --include="*.java" 2>/dev/null | wc -l || echo "0")
         total=$((total + count))
     done
     echo "$total"

--- a/skills/security-audit/scripts/scanners/java.sh
+++ b/skills/security-audit/scripts/scanners/java.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+# Java Security Scanner Module
+# Scans Java projects for common vulnerability patterns
+# Part of security-audit-skill multi-language scanning
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+ERRORS=0
+WARNINGS=0
+
+# Auto-detect Java source directories
+SCAN_DIRS=()
+for dir in src app; do
+    if [[ -d "$PROJECT_DIR/$dir" ]]; then
+        SCAN_DIRS+=("$PROJECT_DIR/$dir")
+    fi
+done
+
+# Helper: grep across all Java source directories
+scan_java() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    local results=""
+    for dir in "${SCAN_DIRS[@]}"; do
+        local matches
+        matches=$(grep -rn -E "$pattern" "$dir" --include="*.java" 2>/dev/null || true)
+        if [[ -n "$matches" ]]; then
+            results+="$matches"$'\n'
+        fi
+    done
+    echo "$results" | grep -v '^$' | head -"$limit"
+}
+
+# Helper: count matches across all Java source directories
+scan_java_count() {
+    local pattern="$1"
+    local total=0
+    for dir in "${SCAN_DIRS[@]}"; do
+        local count
+        count=$(grep -rn -E "$pattern" "$dir" --include="*.java" 2>/dev/null | wc -l || echo "0")
+        total=$((total + count))
+    done
+    echo "$total"
+}
+
+echo "--- Java Security Scanner ---"
+if [[ ${#SCAN_DIRS[@]} -eq 0 ]]; then
+    echo "No Java source directories found (looked for src/ and app/)"
+    exit 0
+fi
+echo "Scanning: ${SCAN_DIRS[*]}"
+echo ""
+
+# === SA-JAVA-01: ObjectInputStream deserialization ===
+echo "=== Checking for Insecure Deserialization ==="
+OIS=$(scan_java 'new\s+ObjectInputStream\s*\(' 10)
+if [[ -n "$OIS" ]]; then
+    echo "ERROR: ObjectInputStream usage found (SA-JAVA-01):"
+    echo "$OIS" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No ObjectInputStream usage detected"
+fi
+
+# === SA-JAVA-02: XMLDecoder deserialization ===
+XMLDEC=$(scan_java 'new\s+XMLDecoder\s*\(' 10)
+if [[ -n "$XMLDEC" ]]; then
+    echo "ERROR: XMLDecoder usage found (SA-JAVA-02):"
+    echo "$XMLDEC" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No XMLDecoder usage detected"
+fi
+
+# === SA-JAVA-03: JNDI injection ===
+echo ""
+echo "=== Checking for JNDI Injection ==="
+JNDI=$(scan_java 'InitialContext\s*\(\s*\)' 10)
+if [[ -n "$JNDI" ]]; then
+    JNDI_LOOKUP=$(scan_java '\.lookup\s*\(' 10)
+    if [[ -n "$JNDI_LOOKUP" ]]; then
+        echo "ERROR: JNDI lookup with InitialContext found (SA-JAVA-03):"
+        echo "$JNDI_LOOKUP" | head -5
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "OK: InitialContext found but no dynamic lookup detected"
+    fi
+else
+    echo "OK: No JNDI InitialContext usage detected"
+fi
+
+# === SA-JAVA-04: Reflection abuse ===
+echo ""
+echo "=== Checking for Reflection Abuse ==="
+REFLECT=$(scan_java 'Class\.forName\s*\(' 10)
+if [[ -n "$REFLECT" ]]; then
+    echo "WARNING: Class.forName usage found (SA-JAVA-04):"
+    echo "$REFLECT" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No Class.forName usage detected"
+fi
+
+# === SA-JAVA-05: SQL injection in JDBC ===
+echo ""
+echo "=== Checking for SQL Injection ==="
+SQL_CONCAT=$(scan_java '(createStatement|executeQuery|executeUpdate)\s*\([^)]*\+' 10)
+if [[ -n "$SQL_CONCAT" ]]; then
+    echo "ERROR: JDBC string concatenation found (SA-JAVA-05):"
+    echo "$SQL_CONCAT" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No JDBC string concatenation detected"
+fi
+
+# === SA-JAVA-06: XXE via DocumentBuilderFactory ===
+echo ""
+echo "=== Checking for XXE Vulnerabilities ==="
+XXE=$(scan_java 'DocumentBuilderFactory\.newInstance\s*\(' 10)
+if [[ -n "$XXE" ]]; then
+    SECURED=$(scan_java_count 'disallow-doctype-decl|external-general-entities')
+    if [[ "$SECURED" -eq 0 ]]; then
+        echo "WARNING: XML parsing without XXE protection (SA-JAVA-06):"
+        echo "$XXE" | head -5
+        WARNINGS=$((WARNINGS + 1))
+    else
+        echo "OK: XML parsing with security features detected"
+    fi
+else
+    echo "OK: No DocumentBuilderFactory usage detected"
+fi
+
+# === SA-JAVA-07: Command injection via Runtime.exec ===
+echo ""
+echo "=== Checking for Command Injection ==="
+CMD=$(scan_java 'Runtime\.getRuntime\s*\(\s*\)\.exec\s*\(' 10)
+if [[ -n "$CMD" ]]; then
+    echo "ERROR: Runtime.exec usage found (SA-JAVA-07):"
+    echo "$CMD" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No Runtime.exec usage detected"
+fi
+
+# === SA-JAVA-08: Weak hash algorithms ===
+echo ""
+echo "=== Checking for Weak Cryptography ==="
+WEAK_HASH=$(scan_java 'getInstance\s*\(\s*"(MD5|SHA-1)"\s*\)' 10)
+if [[ -n "$WEAK_HASH" ]]; then
+    echo "WARNING: Weak hash algorithm usage found (SA-JAVA-08):"
+    echo "$WEAK_HASH" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No weak hash algorithm usage detected"
+fi
+
+# === SA-JAVA-09: Insecure random ===
+INSECURE_RAND=$(scan_java 'new\s+Random\s*\(' 10)
+if [[ -n "$INSECURE_RAND" ]]; then
+    echo "WARNING: java.util.Random usage found (SA-JAVA-09):"
+    echo "$INSECURE_RAND" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No insecure Random usage detected"
+fi
+
+# === SA-JAVA-10: Weak cipher ===
+WEAK_CIPHER=$(scan_java 'Cipher\.getInstance\s*\(\s*"(DES|.*ECB)' 10)
+if [[ -n "$WEAK_CIPHER" ]]; then
+    echo "ERROR: Weak cipher usage found (SA-JAVA-10):"
+    echo "$WEAK_CIPHER" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No weak cipher usage detected"
+fi
+
+# === SA-JAVA-11: SSRF via openConnection ===
+echo ""
+echo "=== Checking for SSRF Patterns ==="
+SSRF=$(scan_java '(openConnection|openStream)\s*\(\s*\)' 10)
+if [[ -n "$SSRF" ]]; then
+    echo "WARNING: URL.openConnection/openStream found (SA-JAVA-11):"
+    echo "$SSRF" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No SSRF-prone URL patterns detected"
+fi
+
+# === SA-JAVA-12: Path traversal ===
+echo ""
+echo "=== Checking for Path Traversal ==="
+PATH_TRAV=$(scan_java 'new\s+File\s*\(\s*[^)]*\+\s*(request|req|param|input|args)' 10)
+if [[ -n "$PATH_TRAV" ]]; then
+    echo "WARNING: File path from user input found (SA-JAVA-12):"
+    echo "$PATH_TRAV" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No path traversal patterns detected"
+fi
+
+# === Summary ===
+echo ""
+echo "--- Java Security Scan Summary ---"
+echo "Errors: $ERRORS"
+echo "Warnings: $WARNINGS"
+
+if [[ "$ERRORS" -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/skills/security-audit/scripts/scanners/javascript.sh
+++ b/skills/security-audit/scripts/scanners/javascript.sh
@@ -32,7 +32,7 @@ scan_js() {
     for dir in "${SCAN_DIRS[@]}"; do
         local matches
         # shellcheck disable=SC2086
-        matches=$(grep -rn -E "$pattern" "$dir" $JS_INCLUDES --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=build --exclude-dir=.next --exclude-dir=coverage 2>/dev/null || true)
+        matches=$(grep -rn -P "$pattern" "$dir" $JS_INCLUDES --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=build --exclude-dir=.next --exclude-dir=coverage 2>/dev/null || true)
         if [[ -n "$matches" ]]; then
             results+="$matches"$'\n'
         fi
@@ -47,7 +47,7 @@ scan_js_count() {
     for dir in "${SCAN_DIRS[@]}"; do
         local count
         # shellcheck disable=SC2086
-        count=$(grep -rn -E "$pattern" "$dir" $JS_INCLUDES --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=build --exclude-dir=.next --exclude-dir=coverage 2>/dev/null | wc -l || echo "0")
+        count=$(grep -rn -P "$pattern" "$dir" $JS_INCLUDES --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=build --exclude-dir=.next --exclude-dir=coverage 2>/dev/null | wc -l || echo "0")
         total=$((total + count))
     done
     echo "$total"

--- a/skills/security-audit/scripts/scanners/javascript.sh
+++ b/skills/security-audit/scripts/scanners/javascript.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+# JavaScript/TypeScript Security Scanner Module
+# Scans JS/TS projects for common vulnerability patterns
+# Modeled after php.sh scanner architecture
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+ERRORS=0
+WARNINGS=0
+
+# Auto-detect JS/TS source directories
+SCAN_DIRS=()
+for dir in src lib app pages components; do
+    if [[ -d "$PROJECT_DIR/$dir" ]]; then
+        SCAN_DIRS+=("$PROJECT_DIR/$dir")
+    fi
+done
+
+# If no standard directories found, scan project root (excluding node_modules)
+if [[ ${#SCAN_DIRS[@]} -eq 0 ]]; then
+    SCAN_DIRS=("$PROJECT_DIR")
+fi
+
+JS_INCLUDES="--include=*.js --include=*.ts --include=*.jsx --include=*.tsx --include=*.mjs --include=*.cjs"
+
+# Helper: grep across all JS/TS source directories
+scan_js() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    local results=""
+    for dir in "${SCAN_DIRS[@]}"; do
+        local matches
+        # shellcheck disable=SC2086
+        matches=$(grep -rn -E "$pattern" "$dir" $JS_INCLUDES --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=build --exclude-dir=.next --exclude-dir=coverage 2>/dev/null || true)
+        if [[ -n "$matches" ]]; then
+            results+="$matches"$'\n'
+        fi
+    done
+    echo "$results" | grep -v '^$' | head -"$limit"
+}
+
+# Helper: count matches across all JS/TS source directories
+scan_js_count() {
+    local pattern="$1"
+    local total=0
+    for dir in "${SCAN_DIRS[@]}"; do
+        local count
+        # shellcheck disable=SC2086
+        count=$(grep -rn -E "$pattern" "$dir" $JS_INCLUDES --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=build --exclude-dir=.next --exclude-dir=coverage 2>/dev/null | wc -l || echo "0")
+        total=$((total + count))
+    done
+    echo "$total"
+}
+
+echo "--- JavaScript/TypeScript Security Scanner ---"
+echo "Scanning: ${SCAN_DIRS[*]}"
+echo ""
+
+# === Check for eval() usage (SA-JS-01) ===
+echo "=== Checking for eval() Usage ==="
+EVAL_HITS=$(scan_js 'eval\(' 10)
+if [[ -n "$EVAL_HITS" ]]; then
+    echo "ERROR: eval() usage detected (potential code injection):"
+    echo "$EVAL_HITS" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No eval() usage detected"
+fi
+
+# === Check for innerHTML assignment (SA-JS-02) ===
+echo ""
+echo "=== Checking for innerHTML Assignment ==="
+INNERHTML_HITS=$(scan_js '\.innerHTML\s*=' 10)
+if [[ -n "$INNERHTML_HITS" ]]; then
+    echo "ERROR: innerHTML assignment detected (potential DOM XSS):"
+    echo "$INNERHTML_HITS" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No innerHTML assignments detected"
+fi
+
+# === Check for document.write (SA-JS-03) ===
+echo ""
+echo "=== Checking for document.write() ==="
+DOCWRITE_HITS=$(scan_js 'document\.write\(' 10)
+if [[ -n "$DOCWRITE_HITS" ]]; then
+    echo "ERROR: document.write() detected (potential DOM XSS):"
+    echo "$DOCWRITE_HITS" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No document.write() usage detected"
+fi
+
+# === Check for __proto__ access (SA-JS-06) ===
+echo ""
+echo "=== Checking for Prototype Pollution Vectors ==="
+PROTO_HITS=$(scan_js '__proto__' 10)
+if [[ -n "$PROTO_HITS" ]]; then
+    echo "ERROR: __proto__ access detected (prototype pollution risk):"
+    echo "$PROTO_HITS" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No __proto__ access detected"
+fi
+
+# === Check for Math.random() in security context (SA-JS-05) ===
+echo ""
+echo "=== Checking for Insecure Randomness ==="
+RANDOM_HITS=$(scan_js 'Math\.random\(\)' 10)
+if [[ -n "$RANDOM_HITS" ]]; then
+    # Check if used for tokens/keys/secrets
+    SECURITY_RANDOM=$(echo "$RANDOM_HITS" | grep -iE '(token|key|secret|session|csrf|nonce|password|auth|id)' || true)
+    if [[ -n "$SECURITY_RANDOM" ]]; then
+        echo "ERROR: Math.random() used in security-sensitive context:"
+        echo "$SECURITY_RANDOM" | head -5
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "WARNING: Math.random() usage found (verify not used for security):"
+        echo "$RANDOM_HITS" | head -3
+        WARNINGS=$((WARNINGS + 1))
+    fi
+else
+    echo "OK: No Math.random() usage detected"
+fi
+
+# === Check for Function constructor (SA-JS-07) ===
+echo ""
+echo "=== Checking for Function Constructor ==="
+FUNC_HITS=$(scan_js 'new\s+Function\(' 10)
+if [[ -n "$FUNC_HITS" ]]; then
+    echo "ERROR: Function constructor detected (equivalent to eval):"
+    echo "$FUNC_HITS" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No Function constructor usage detected"
+fi
+
+# === Check for setTimeout/setInterval with string (SA-JS-08, SA-JS-15) ===
+echo ""
+echo "=== Checking for Implicit eval in Timers ==="
+TIMER_HITS=$(scan_js "setTimeout\(\s*['\"\`]" 10)
+INTERVAL_HITS=$(scan_js "setInterval\(\s*['\"\`]" 10)
+if [[ -n "$TIMER_HITS" || -n "$INTERVAL_HITS" ]]; then
+    echo "ERROR: Timer with string argument detected (implicit eval):"
+    [[ -n "$TIMER_HITS" ]] && echo "$TIMER_HITS" | head -3
+    [[ -n "$INTERVAL_HITS" ]] && echo "$INTERVAL_HITS" | head -3
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No string-form timer arguments detected"
+fi
+
+# === Check for postMessage without origin check (SA-JS-04) ===
+echo ""
+echo "=== Checking for postMessage Handlers ==="
+POSTMSG_HANDLERS=$(scan_js_count "addEventListener\(.message")
+if [[ "$POSTMSG_HANDLERS" -gt 0 ]]; then
+    ORIGIN_CHECKS=$(scan_js_count "event\.origin|e\.origin|msg\.origin")
+    if [[ "$ORIGIN_CHECKS" -eq 0 ]]; then
+        echo "WARNING: postMessage handler(s) found without origin validation"
+        WARNINGS=$((WARNINGS + 1))
+    else
+        echo "OK: postMessage handlers with origin checks detected"
+    fi
+else
+    echo "OK: No postMessage handlers detected"
+fi
+
+# === Check for outerHTML assignment (SA-JS-09) ===
+echo ""
+echo "=== Checking for outerHTML Assignment ==="
+OUTERHTML_HITS=$(scan_js '\.outerHTML\s*=' 10)
+if [[ -n "$OUTERHTML_HITS" ]]; then
+    echo "ERROR: outerHTML assignment detected (potential DOM XSS):"
+    echo "$OUTERHTML_HITS" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No outerHTML assignments detected"
+fi
+
+# === Check for debugger statements (SA-JS-10) ===
+echo ""
+echo "=== Checking for debugger Statements ==="
+DEBUGGER_HITS=$(scan_js '\bdebugger\b' 10)
+if [[ -n "$DEBUGGER_HITS" ]]; then
+    echo "WARNING: debugger statements found (must not ship to production):"
+    echo "$DEBUGGER_HITS" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No debugger statements detected"
+fi
+
+# === Check for wildcard postMessage (SA-JS-17) ===
+echo ""
+echo "=== Checking for Wildcard postMessage ==="
+WILDCARD_PM=$(scan_js "postMessage\([^,]+,\s*['\"]\\*['\"]" 10)
+if [[ -n "$WILDCARD_PM" ]]; then
+    echo "ERROR: postMessage with wildcard '*' origin:"
+    echo "$WILDCARD_PM" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No wildcard postMessage targets detected"
+fi
+
+# === Check for npm audit vulnerabilities ===
+echo ""
+echo "=== Checking Dependencies ==="
+if [[ -f "$PROJECT_DIR/package-lock.json" ]] || [[ -f "$PROJECT_DIR/yarn.lock" ]]; then
+    if command -v npm &> /dev/null && [[ -f "$PROJECT_DIR/package-lock.json" ]]; then
+        AUDIT_OUTPUT=$(cd "$PROJECT_DIR" && npm audit --json 2>/dev/null | head -50 || true)
+        VULN_COUNT=$(echo "$AUDIT_OUTPUT" | grep -o '"vulnerabilities"' | wc -l || echo "0")
+        if [[ "$VULN_COUNT" -gt 0 ]]; then
+            echo "WARNING: Vulnerable dependencies found (run 'npm audit' for details)"
+            WARNINGS=$((WARNINGS + 1))
+        else
+            echo "OK: No known vulnerable dependencies"
+        fi
+    else
+        echo "WARNING: npm not available or no package-lock.json for dependency audit"
+        WARNINGS=$((WARNINGS + 1))
+    fi
+else
+    echo "WARNING: No package-lock.json or yarn.lock found"
+    WARNINGS=$((WARNINGS + 1))
+fi
+
+# === Check TypeScript strict mode (SA-JS-19) ===
+echo ""
+echo "=== Checking TypeScript Strict Mode ==="
+if [[ -f "$PROJECT_DIR/tsconfig.json" ]]; then
+    STRICT_ENABLED=$(grep -c '"strict"\s*:\s*true' "$PROJECT_DIR/tsconfig.json" 2>/dev/null || echo "0")
+    STRICT_DISABLED=$(grep -c '"strict"\s*:\s*false' "$PROJECT_DIR/tsconfig.json" 2>/dev/null || echo "0")
+    if [[ "$STRICT_DISABLED" -gt 0 ]]; then
+        echo "WARNING: TypeScript strict mode is explicitly disabled"
+        WARNINGS=$((WARNINGS + 1))
+    elif [[ "$STRICT_ENABLED" -gt 0 ]]; then
+        echo "OK: TypeScript strict mode is enabled"
+    else
+        echo "WARNING: TypeScript strict mode not configured (defaults to false)"
+        WARNINGS=$((WARNINGS + 1))
+    fi
+else
+    echo "INFO: No tsconfig.json found (not a TypeScript project)"
+fi
+
+# === Output results for dispatcher ===
+echo ""
+echo "--- JavaScript/TypeScript Scanner Results ---"
+echo "Errors: $ERRORS"
+echo "Warnings: $WARNINGS"
+
+# Exit with error count for dispatcher to aggregate
+exit "$ERRORS"

--- a/skills/security-audit/scripts/scanners/joomla.sh
+++ b/skills/security-audit/scripts/scanners/joomla.sh
@@ -39,7 +39,7 @@ scan_joomla() {
     local results=""
     for dir in "${SCAN_DIRS[@]}"; do
         local matches
-        matches=$(grep -rn -E "$pattern" "$dir" --include="*.php" 2>/dev/null || true)
+        matches=$(grep -rn -P "$pattern" "$dir" --include="*.php" 2>/dev/null || true)
         if [[ -n "$matches" ]]; then
             results+="$matches"$'\n'
         fi

--- a/skills/security-audit/scripts/scanners/joomla.sh
+++ b/skills/security-audit/scripts/scanners/joomla.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Joomla Security Scanner Module
+# Detects Joomla projects via configuration.php
+# Scans for common Joomla-specific vulnerability patterns
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+ERRORS=0
+WARNINGS=0
+
+# Auto-detect Joomla project
+JOOMLA_DETECTED=false
+if [[ -f "$PROJECT_DIR/configuration.php" ]] && grep -q 'class JConfig' "$PROJECT_DIR/configuration.php" 2>/dev/null; then
+    JOOMLA_DETECTED=true
+fi
+
+if [[ "$JOOMLA_DETECTED" != "true" ]]; then
+    echo "--- Joomla Security Scanner ---"
+    echo "No Joomla installation detected (looked for configuration.php with JConfig class)"
+    exit 0
+fi
+
+# Determine scan directories
+SCAN_DIRS=()
+for dir in components administrator/components plugins modules templates; do
+    if [[ -d "$PROJECT_DIR/$dir" ]]; then
+        SCAN_DIRS+=("$PROJECT_DIR/$dir")
+    fi
+done
+
+# Include root for configuration.php
+SCAN_DIRS+=("$PROJECT_DIR")
+
+# Helper: grep across Joomla source directories
+scan_joomla() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    local results=""
+    for dir in "${SCAN_DIRS[@]}"; do
+        local matches
+        matches=$(grep -rn -E "$pattern" "$dir" --include="*.php" 2>/dev/null || true)
+        if [[ -n "$matches" ]]; then
+            results+="$matches"$'\n'
+        fi
+    done
+    echo "$results" | grep -v '^$' | head -"$limit"
+}
+
+echo "--- Joomla Security Scanner ---"
+echo "Scanning: ${SCAN_DIRS[*]}"
+echo ""
+
+# === SA-JOOMLA-01: SQL injection ===
+echo "=== Checking for SQL Injection ==="
+# shellcheck disable=SC2016
+SQLI=$(scan_joomla '->where\s*\(.*["\x27].*\.\s*\$|setQuery\s*\(\s*["\x27].*\$' 10)
+if [[ -n "$SQLI" ]]; then
+    echo "ERROR: Database queries with string concatenation found:"
+    echo "$SQLI" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No obvious SQL injection patterns detected"
+fi
+
+# === SA-JOOMLA-02: Input filtering ===
+echo ""
+echo "=== Checking for Unfiltered Input ==="
+# shellcheck disable=SC2016
+RAW_INPUT=$(scan_joomla "->get\s*\([^,)]+\s*,\s*[^,)]*\s*,\s*['\"]RAW['\"]" 10)
+SUPERGLOBALS=$(scan_joomla '\$_GET\s*\[|\$_POST\s*\[|\$_REQUEST\s*\[' 10)
+if [[ -n "$RAW_INPUT" || -n "$SUPERGLOBALS" ]]; then
+    echo "ERROR: Unfiltered input detected:"
+    [[ -n "$RAW_INPUT" ]] && echo "$RAW_INPUT" | head -5
+    [[ -n "$SUPERGLOBALS" ]] && echo "$SUPERGLOBALS" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: Input appears to use JInput filtering"
+fi
+
+# === SA-JOOMLA-04: configuration.php hardening ===
+echo ""
+echo "=== Checking configuration.php Hardening ==="
+if [[ -f "$PROJECT_DIR/configuration.php" ]]; then
+    DEBUG_ON=$(grep -n 'debug.*=.*1' "$PROJECT_DIR/configuration.php" 2>/dev/null || true)
+    if [[ -n "$DEBUG_ON" ]]; then
+        echo "WARNING: Debug mode enabled in configuration.php"
+        WARNINGS=$((WARNINGS + 1))
+    fi
+
+    WEAK_SECRET=$(grep -n "secret.*=.*'joomla'" "$PROJECT_DIR/configuration.php" 2>/dev/null || true)
+    if [[ -n "$WEAK_SECRET" ]]; then
+        echo "ERROR: Weak/default secret in configuration.php"
+        ERRORS=$((ERRORS + 1))
+    fi
+
+    MAX_ERRORS=$(grep -n "error_reporting.*=.*'maximum'" "$PROJECT_DIR/configuration.php" 2>/dev/null || true)
+    if [[ -n "$MAX_ERRORS" ]]; then
+        echo "WARNING: Maximum error reporting enabled in configuration.php"
+        WARNINGS=$((WARNINGS + 1))
+    fi
+
+    FTP_PASS=$(grep -n "ftp_pass.*=.*'[^']'" "$PROJECT_DIR/configuration.php" 2>/dev/null | grep -v "ftp_pass.*=.*''" || true)
+    if [[ -n "$FTP_PASS" ]]; then
+        echo "ERROR: FTP password stored in configuration.php"
+        ERRORS=$((ERRORS + 1))
+    fi
+else
+    echo "OK: configuration.php not found in scan path"
+fi
+
+echo ""
+echo "--- Joomla Scanner Summary ---"
+echo "Errors: $ERRORS | Warnings: $WARNINGS"
+
+if [[ "$ERRORS" -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/skills/security-audit/scripts/scanners/nodejs.sh
+++ b/skills/security-audit/scripts/scanners/nodejs.sh
@@ -1,0 +1,265 @@
+#!/bin/bash
+# Node.js Security Scanner Module
+# Scans Node.js/TypeScript projects for common vulnerability patterns
+# Part of the security-audit-skill scanner architecture
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+ERRORS=0
+WARNINGS=0
+
+# Auto-detect Node.js source directories
+SCAN_DIRS=()
+for dir in src lib server api routes controllers middleware services handlers; do
+    if [[ -d "$PROJECT_DIR/$dir" ]]; then
+        SCAN_DIRS+=("$PROJECT_DIR/$dir")
+    fi
+done
+
+# If no standard dirs found, check for .js/.ts files in project root
+if [[ ${#SCAN_DIRS[@]} -eq 0 ]]; then
+    if ls "$PROJECT_DIR"/*.{js,ts,mjs,cjs} 1>/dev/null 2>&1; then
+        SCAN_DIRS+=("$PROJECT_DIR")
+    fi
+fi
+
+# Helper: grep across all Node.js source directories
+scan_node() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    local results=""
+    for dir in "${SCAN_DIRS[@]}"; do
+        local matches
+        matches=$(grep -rn -E "$pattern" "$dir" --include="*.js" --include="*.ts" --include="*.mjs" --include="*.cjs" 2>/dev/null || true)
+        if [[ -n "$matches" ]]; then
+            results+="$matches"$'\n'
+        fi
+    done
+    echo "$results" | grep -v '^$' | head -"$limit"
+}
+
+# Helper: count matches across all Node.js source directories
+scan_node_count() {
+    local pattern="$1"
+    local total=0
+    for dir in "${SCAN_DIRS[@]}"; do
+        local count
+        count=$(grep -rn -E "$pattern" "$dir" --include="*.js" --include="*.ts" --include="*.mjs" --include="*.cjs" 2>/dev/null | wc -l || echo "0")
+        total=$((total + count))
+    done
+    echo "$total"
+}
+
+echo "--- Node.js Security Scanner ---"
+if [[ ${#SCAN_DIRS[@]} -eq 0 ]]; then
+    echo "No Node.js source directories found (looked for src/, lib/, server/, api/, routes/, controllers/, middleware/, services/, handlers/)"
+    exit 0
+fi
+echo "Scanning: ${SCAN_DIRS[*]}"
+echo ""
+
+# === Check for command injection via child_process.exec ===
+echo "=== Checking for Command Injection (child_process.exec) ==="
+CMD_INJECTION=$(scan_node 'child_process.*exec\(' 10)
+EXEC_CALLS=$(scan_node '\bexec(Sync)?\s*\(' 10 | grep -v 'execFile' || true)
+if [[ -n "$CMD_INJECTION" || -n "$EXEC_CALLS" ]]; then
+    echo "ERROR: Potential command injection via exec():"
+    [[ -n "$CMD_INJECTION" ]] && echo "$CMD_INJECTION"
+    [[ -n "$EXEC_CALLS" ]] && echo "$EXEC_CALLS"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No child_process.exec() calls detected"
+fi
+
+# === Check for path traversal via fs operations ===
+echo ""
+echo "=== Checking for Path Traversal (fs with user input) ==="
+# shellcheck disable=SC2016
+FS_USER=$(scan_node 'fs\.(readFile|writeFile|readdir|unlink|access|stat|createReadStream|createWriteStream)\s*\([^)]*req\.(query|params|body)' 10)
+if [[ -n "$FS_USER" ]]; then
+    echo "ERROR: fs operations with potential user input:"
+    echo "$FS_USER"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No obvious fs path traversal patterns detected"
+fi
+
+# === Check for vm/vm2 usage ===
+echo ""
+echo "=== Checking for vm/vm2 Sandbox Usage ==="
+VM_USAGE=$(scan_node "require\s*\(\s*['\"]vm2?['\"]\s*\)" 10)
+VM_IMPORT=$(scan_node "from\s+['\"]vm2?['\"]" 10)
+if [[ -n "$VM_USAGE" || -n "$VM_IMPORT" ]]; then
+    echo "ERROR: vm/vm2 module usage detected (not a security boundary):"
+    [[ -n "$VM_USAGE" ]] && echo "$VM_USAGE"
+    [[ -n "$VM_IMPORT" ]] && echo "$VM_IMPORT"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No vm/vm2 sandbox usage detected"
+fi
+
+# === Check for Buffer.allocUnsafe ===
+echo ""
+echo "=== Checking for Buffer.allocUnsafe ==="
+BUFFER_UNSAFE=$(scan_node 'Buffer\.(allocUnsafe|allocUnsafeSlow)\s*\(' 10)
+if [[ -n "$BUFFER_UNSAFE" ]]; then
+    echo "WARNING: Buffer.allocUnsafe usage (may leak memory contents):"
+    echo "$BUFFER_UNSAFE"
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No Buffer.allocUnsafe usage detected"
+fi
+
+# === Check for dynamic require ===
+echo ""
+echo "=== Checking for Dynamic require() ==="
+DYN_REQUIRE=$(scan_node 'require\s*\(\s*[^'"'"'"]\s*[+`]' 10)
+DYN_IMPORT=$(scan_node 'import\s*\(\s*[^'"'"'"]\s*[+`]' 10)
+if [[ -n "$DYN_REQUIRE" || -n "$DYN_IMPORT" ]]; then
+    echo "ERROR: Dynamic require/import with variable path:"
+    [[ -n "$DYN_REQUIRE" ]] && echo "$DYN_REQUIRE"
+    [[ -n "$DYN_IMPORT" ]] && echo "$DYN_IMPORT"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No dynamic require/import patterns detected"
+fi
+
+# === Check for http.createServer without timeouts ===
+echo ""
+echo "=== Checking for Insecure HTTP Server Configuration ==="
+HTTP_SERVER=$(scan_node 'http\.createServer\s*\(' 10)
+if [[ -n "$HTTP_SERVER" ]]; then
+    TIMEOUTS=$(scan_node_count '(headersTimeout|requestTimeout|keepAliveTimeout)\s*=')
+    if [[ "$TIMEOUTS" -eq 0 ]]; then
+        echo "WARNING: http.createServer without timeout configuration:"
+        echo "$HTTP_SERVER"
+        WARNINGS=$((WARNINGS + 1))
+    else
+        echo "OK: HTTP server with timeout configuration detected"
+    fi
+else
+    echo "OK: No bare http.createServer usage"
+fi
+
+# === Check for header injection ===
+echo ""
+echo "=== Checking for HTTP Header Injection ==="
+# shellcheck disable=SC2016
+HEADER_INJECT=$(scan_node 'res\.(setHeader|writeHead)\s*\([^)]*req\.(query|params|body|headers)' 10)
+if [[ -n "$HEADER_INJECT" ]]; then
+    echo "ERROR: User input in HTTP response headers:"
+    echo "$HEADER_INJECT"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No header injection patterns detected"
+fi
+
+# === Check for Math.random in security context ===
+echo ""
+echo "=== Checking for Insecure Randomness ==="
+MATH_RANDOM=$(scan_node 'Math\.random\s*\(' 10)
+if [[ -n "$MATH_RANDOM" ]]; then
+    echo "WARNING: Math.random() usage (not cryptographically secure):"
+    echo "$MATH_RANDOM" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No Math.random() usage detected"
+fi
+
+# === Check for weak crypto algorithms ===
+echo ""
+echo "=== Checking for Weak Crypto Algorithms ==="
+WEAK_CRYPTO=$(scan_node "createHash\s*\(\s*['\"]md5['\"]" 10)
+WEAK_SHA1=$(scan_node "createHash\s*\(\s*['\"]sha1['\"]" 10)
+if [[ -n "$WEAK_CRYPTO" || -n "$WEAK_SHA1" ]]; then
+    echo "WARNING: Weak cryptographic hash algorithms:"
+    [[ -n "$WEAK_CRYPTO" ]] && echo "$WEAK_CRYPTO"
+    [[ -n "$WEAK_SHA1" ]] && echo "$WEAK_SHA1"
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No weak crypto algorithms detected"
+fi
+
+# === Check for eval() usage ===
+echo ""
+echo "=== Checking for eval() Usage ==="
+EVAL_USAGE=$(scan_node '\beval\s*\(' 10)
+if [[ -n "$EVAL_USAGE" ]]; then
+    echo "ERROR: eval() usage detected:"
+    echo "$EVAL_USAGE"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No eval() usage detected"
+fi
+
+# === Check for new Function() constructor ===
+echo ""
+echo "=== Checking for new Function() Constructor ==="
+NEW_FUNC=$(scan_node 'new\s+Function\s*\(' 10)
+if [[ -n "$NEW_FUNC" ]]; then
+    echo "ERROR: new Function() constructor (equivalent to eval):"
+    echo "$NEW_FUNC"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No new Function() usage detected"
+fi
+
+# === Check for SSRF via fetch ===
+echo ""
+echo "=== Checking for SSRF Patterns ==="
+# shellcheck disable=SC2016
+SSRF_FETCH=$(scan_node 'fetch\s*\(\s*req\.(query|params|body)' 10)
+# shellcheck disable=SC2016
+SSRF_HTTP=$(scan_node 'https?\.(get|request)\s*\([^)]*req\.(query|params|body)' 10)
+if [[ -n "$SSRF_FETCH" || -n "$SSRF_HTTP" ]]; then
+    echo "ERROR: Potential SSRF — user input in outgoing request URL:"
+    [[ -n "$SSRF_FETCH" ]] && echo "$SSRF_FETCH"
+    [[ -n "$SSRF_HTTP" ]] && echo "$SSRF_HTTP"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No obvious SSRF patterns detected"
+fi
+
+# === Check for prototype pollution ===
+echo ""
+echo "=== Checking for Prototype Pollution ==="
+# shellcheck disable=SC2016
+PROTO_POLL=$(scan_node '__proto__|Object\.assign\s*\([^,]+,\s*req\.(body|query|params)' 10)
+if [[ -n "$PROTO_POLL" ]]; then
+    echo "ERROR: Potential prototype pollution:"
+    echo "$PROTO_POLL"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No obvious prototype pollution patterns detected"
+fi
+
+# === Check for npm audit ===
+echo ""
+echo "=== Checking Dependencies ==="
+if [[ -f "$PROJECT_DIR/package-lock.json" || -f "$PROJECT_DIR/yarn.lock" || -f "$PROJECT_DIR/pnpm-lock.yaml" ]]; then
+    if command -v npm &> /dev/null && [[ -f "$PROJECT_DIR/package-lock.json" ]]; then
+        AUDIT_OUTPUT=$(cd "$PROJECT_DIR" && npm audit --json 2>/dev/null | head -50 || true)
+        VULN_COUNT=$(echo "$AUDIT_OUTPUT" | grep -o '"vulnerabilities"' | wc -l || echo "0")
+        if [[ "$VULN_COUNT" -gt 0 ]]; then
+            echo "WARNING: Vulnerable dependencies found (run 'npm audit' for details)"
+            WARNINGS=$((WARNINGS + 1))
+        else
+            echo "OK: No known vulnerable dependencies"
+        fi
+    else
+        echo "INFO: Lock file found but npm not available for audit"
+    fi
+else
+    echo "WARNING: No lock file found (package-lock.json, yarn.lock, or pnpm-lock.yaml)"
+    WARNINGS=$((WARNINGS + 1))
+fi
+
+# === Output results for dispatcher ===
+echo ""
+echo "--- Node.js Scanner Results ---"
+echo "Errors: $ERRORS"
+echo "Warnings: $WARNINGS"
+
+# Exit with error count for dispatcher to aggregate
+exit "$ERRORS"

--- a/skills/security-audit/scripts/scanners/nodejs.sh
+++ b/skills/security-audit/scripts/scanners/nodejs.sh
@@ -31,7 +31,7 @@ scan_node() {
     local results=""
     for dir in "${SCAN_DIRS[@]}"; do
         local matches
-        matches=$(grep -rn -E "$pattern" "$dir" --include="*.js" --include="*.ts" --include="*.mjs" --include="*.cjs" 2>/dev/null || true)
+        matches=$(grep -rn -P "$pattern" "$dir" --include="*.js" --include="*.ts" --include="*.mjs" --include="*.cjs" 2>/dev/null || true)
         if [[ -n "$matches" ]]; then
             results+="$matches"$'\n'
         fi
@@ -45,7 +45,7 @@ scan_node_count() {
     local total=0
     for dir in "${SCAN_DIRS[@]}"; do
         local count
-        count=$(grep -rn -E "$pattern" "$dir" --include="*.js" --include="*.ts" --include="*.mjs" --include="*.cjs" 2>/dev/null | wc -l || echo "0")
+        count=$(grep -rn -P "$pattern" "$dir" --include="*.js" --include="*.ts" --include="*.mjs" --include="*.cjs" 2>/dev/null | wc -l || echo "0")
         total=$((total + count))
     done
     echo "$total"

--- a/skills/security-audit/scripts/scanners/php.sh
+++ b/skills/security-audit/scripts/scanners/php.sh
@@ -1,0 +1,472 @@
+#!/bin/bash
+# PHP Security Scanner Module
+# Invoked by security-audit-dispatcher.sh; also usable standalone.
+# Performs security checks on PHP projects (TYPO3, Symfony, Laravel, custom).
+# Scans src/ and Classes/ directories.
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+ERRORS=0
+WARNINGS=0
+
+# Auto-detect PHP source directories
+SCAN_DIRS=()
+for dir in src Classes; do
+    if [[ -d "$PROJECT_DIR/$dir" ]]; then
+        SCAN_DIRS+=("$PROJECT_DIR/$dir")
+    fi
+done
+
+# Helper: grep across all PHP source directories
+scan_php() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    local results=""
+    for dir in "${SCAN_DIRS[@]}"; do
+        local matches
+        matches=$(grep -rn -E "$pattern" "$dir" --include="*.php" 2>/dev/null || true)
+        if [[ -n "$matches" ]]; then
+            results+="$matches"$'\n'
+        fi
+    done
+    echo "$results" | grep -v '^$' | head -"$limit"
+}
+
+# Helper: count matches across all PHP source directories
+scan_php_count() {
+    local pattern="$1"
+    local total=0
+    for dir in "${SCAN_DIRS[@]}"; do
+        local count
+        count=$(grep -rn -E "$pattern" "$dir" --include="*.php" 2>/dev/null | wc -l || echo "0")
+        total=$((total + count))
+    done
+    echo "$total"
+}
+
+echo "--- PHP Security Scanner ---"
+echo "Directory: $PROJECT_DIR"
+if [[ ${#SCAN_DIRS[@]} -eq 0 ]]; then
+    echo "⚠️  No PHP source directories found (looked for src/ and Classes/)"
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "Scanning: ${SCAN_DIRS[*]}"
+fi
+echo ""
+
+# === Check for hardcoded secrets ===
+echo "=== Checking for Hardcoded Secrets ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    SECRETS=$(scan_php "(password|api_key|secret|token)\s*=\s*['\"][^'\"]+['\"]" 10 | grep -v "getenv\|env(" || true)
+    if [[ -n "$SECRETS" ]]; then
+        echo "⚠️  Potential hardcoded secrets found:"
+        echo "$SECRETS" | head -5
+        WARNINGS=$((WARNINGS + 1))
+    else
+        echo "✅ No obvious hardcoded secrets detected"
+    fi
+fi
+
+# === Check for SQL injection patterns ===
+# NOTE: This grep-based check only catches direct superglobal-to-query flows and
+# obvious string concatenation. It cannot track indirect data flows where user input
+# is assigned to a variable first. For deeper taint analysis, use PHPStan (level 9+)
+# with phpstan-strict-rules or Psalm with taint analysis (@psalm-taint-source).
+echo ""
+echo "=== Checking for SQL Injection Patterns ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    # Direct superglobal to database method call (dollar signs are regex literals)
+    # shellcheck disable=SC2016
+    SQL_VULN=$(scan_php '\$_(GET|POST|REQUEST|COOKIE).*->(query|execute|prepare)')
+    # String concatenation in SQL queries
+    SQL_CONCAT=$(scan_php '"(SELECT|INSERT|UPDATE|DELETE)\s.*\.\s*\$' 5)
+    if [[ -n "$SQL_VULN" || -n "$SQL_CONCAT" ]]; then
+        echo "🔴 Potential SQL injection patterns found:"
+        [[ -n "$SQL_VULN" ]] && echo "$SQL_VULN"
+        [[ -n "$SQL_CONCAT" ]] && echo "$SQL_CONCAT"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "✅ No obvious SQL injection patterns detected"
+    fi
+fi
+
+# === Check for XXE vulnerabilities ===
+echo ""
+echo "=== Checking for XXE Vulnerabilities ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    XXE_PATTERNS=$(scan_php "(simplexml_load_string|DOMDocument|XMLReader)" 10)
+    if [[ -n "$XXE_PATTERNS" ]]; then
+        # Check for secure flags (LIBXML_NONET, libxml_disable_entity_loader)
+        # WARNING: LIBXML_NOENT and LIBXML_DTDLOAD are NOT mitigations — they enable XXE
+        SECURED=$(scan_php_count "LIBXML_NONET|libxml_disable_entity_loader")
+        if [[ "$SECURED" -eq 0 ]]; then
+            echo "⚠️  XML parsing found without obvious XXE protection:"
+            echo "$XXE_PATTERNS" | head -5
+            WARNINGS=$((WARNINGS + 1))
+        else
+            echo "✅ XML parsing with security flags detected"
+        fi
+        # Check for dangerous flags that ENABLE XXE
+        DANGEROUS_FLAGS=$(scan_php "LIBXML_NOENT|LIBXML_DTDLOAD")
+        if [[ -n "$DANGEROUS_FLAGS" ]]; then
+            echo "🔴 DANGEROUS: LIBXML_NOENT/LIBXML_DTDLOAD found (these ENABLE XXE, not prevent it):"
+            echo "$DANGEROUS_FLAGS"
+            ERRORS=$((ERRORS + 1))
+        fi
+    else
+        echo "✅ No XML parsing detected"
+    fi
+fi
+
+# === Check for command injection ===
+echo ""
+echo "=== Checking for Command Injection ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    CMD_INJECTION=$(scan_php "(exec|system|passthru|shell_exec|proc_open|popen)\s*\(.*\\\$")
+    if [[ -n "$CMD_INJECTION" ]]; then
+        echo "🔴 Potential command injection found:"
+        echo "$CMD_INJECTION"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "✅ No obvious command injection patterns detected"
+    fi
+fi
+
+# === Check for dangerous functions ===
+echo ""
+echo "=== Checking for Dangerous Functions ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    DANGEROUS=$(scan_php "(eval|assert|create_function|preg_replace.*\/e|unserialize\s*\(\s*\\\$)")
+    if [[ -n "$DANGEROUS" ]]; then
+        echo "⚠️  Potentially dangerous functions found:"
+        echo "$DANGEROUS"
+        WARNINGS=$((WARNINGS + 1))
+    else
+        echo "✅ No obviously dangerous functions detected"
+    fi
+fi
+
+# === Check for file inclusion vulnerabilities ===
+echo ""
+echo "=== Checking for File Inclusion Vulnerabilities ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    INCLUDE_VULN=$(scan_php "(include|require|include_once|require_once)\s*\(\s*\\\$")
+    if [[ -n "$INCLUDE_VULN" ]]; then
+        echo "⚠️  Potential file inclusion vulnerabilities:"
+        echo "$INCLUDE_VULN"
+        WARNINGS=$((WARNINGS + 1))
+    else
+        echo "✅ No obvious file inclusion vulnerabilities"
+    fi
+fi
+
+# === Check for XSS patterns ===
+echo ""
+echo "=== Checking for XSS Patterns ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    XSS_PATTERNS=$(scan_php "echo\s+\\\$_(GET|POST|REQUEST)")
+    if [[ -n "$XSS_PATTERNS" ]]; then
+        echo "🔴 Potential XSS vulnerabilities:"
+        echo "$XSS_PATTERNS"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "✅ No obvious XSS patterns detected"
+    fi
+fi
+
+# === Check for insecure password hashing ===
+echo ""
+echo "=== Checking for Insecure Password Hashing ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    INSECURE_HASH=$(scan_php "(md5|sha1)\s*\(.*\\\$(password|passwd|pass|pwd)")
+    if [[ -n "$INSECURE_HASH" ]]; then
+        echo "🔴 Insecure password hashing detected (use password_hash with PASSWORD_ARGON2ID):"
+        echo "$INSECURE_HASH"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "✅ No insecure password hashing detected"
+    fi
+fi
+
+# === Check for insecure randomness ===
+echo ""
+echo "=== Checking for Insecure Randomness ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    INSECURE_RAND=$(scan_php "\b(rand|mt_rand|srand|mt_srand)\s*\(")
+    if [[ -n "$INSECURE_RAND" ]]; then
+        echo "⚠️  Insecure random functions found (use random_int/random_bytes):"
+        echo "$INSECURE_RAND"
+        WARNINGS=$((WARNINGS + 1))
+    else
+        echo "✅ No insecure random functions detected"
+    fi
+fi
+
+# === Check for path traversal ===
+echo ""
+echo "=== Checking for Path Traversal ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    PATH_TRAV=$(scan_php "(file_get_contents|fopen|readfile|file_put_contents)\s*\(.*\\\$_(GET|POST|REQUEST)")
+    if [[ -n "$PATH_TRAV" ]]; then
+        echo "🔴 Potential path traversal vulnerability:"
+        echo "$PATH_TRAV"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "✅ No obvious path traversal patterns detected"
+    fi
+fi
+
+# === Check for phpinfo() exposure ===
+echo ""
+echo "=== Checking for Information Disclosure ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    PHPINFO=$(scan_php "phpinfo\s*\(")
+    if [[ -n "$PHPINFO" ]]; then
+        echo "⚠️  phpinfo() calls found (remove in production):"
+        echo "$PHPINFO"
+        WARNINGS=$((WARNINGS + 1))
+    else
+        echo "✅ No phpinfo() exposure detected"
+    fi
+fi
+
+# === Check for missing strict_types ===
+echo ""
+echo "=== Checking for strict_types Declaration ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    TOTAL_PHP=0
+    STRICT_PHP=0
+    for dir in "${SCAN_DIRS[@]}"; do
+        local_total=$(find "$dir" -name "*.php" 2>/dev/null | wc -l || echo "0")
+        local_strict=$(grep -rl "declare(strict_types=1)" "$dir" --include="*.php" 2>/dev/null | wc -l || echo "0")
+        TOTAL_PHP=$((TOTAL_PHP + local_total))
+        STRICT_PHP=$((STRICT_PHP + local_strict))
+    done
+    if [[ "$TOTAL_PHP" -gt 0 ]]; then
+        PERCENT=$((STRICT_PHP * 100 / TOTAL_PHP))
+        if [[ "$PERCENT" -lt 50 ]]; then
+            echo "⚠️  Only $STRICT_PHP/$TOTAL_PHP PHP files ($PERCENT%) use declare(strict_types=1)"
+            WARNINGS=$((WARNINGS + 1))
+        else
+            echo "✅ $STRICT_PHP/$TOTAL_PHP PHP files ($PERCENT%) use strict_types"
+        fi
+    fi
+fi
+
+# === Check for composer vulnerabilities ===
+echo ""
+echo "=== Checking Dependencies ==="
+if [[ -f "$PROJECT_DIR/composer.lock" ]]; then
+    if command -v composer &> /dev/null; then
+        AUDIT_OUTPUT=$(cd "$PROJECT_DIR" && composer audit 2>&1 || true)
+        if echo "$AUDIT_OUTPUT" | grep -q "Found"; then
+            echo "⚠️  Vulnerable dependencies found:"
+            echo "$AUDIT_OUTPUT" | head -20
+            WARNINGS=$((WARNINGS + 1))
+        else
+            echo "✅ No known vulnerable dependencies"
+        fi
+    else
+        echo "⚠️  Composer not available for dependency audit"
+        WARNINGS=$((WARNINGS + 1))
+    fi
+else
+    echo "⚠️  No composer.lock found"
+    WARNINGS=$((WARNINGS + 1))
+fi
+
+# === Check security headers ===
+echo ""
+echo "=== Checking Security Headers ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    HEADERS=$(scan_php_count "X-Content-Type-Options|X-Frame-Options|Content-Security-Policy|Strict-Transport-Security")
+    if [[ "$HEADERS" -gt 0 ]]; then
+        echo "✅ Security headers configuration found ($HEADERS references)"
+    else
+        echo "⚠️  No security headers configuration detected"
+        WARNINGS=$((WARNINGS + 1))
+    fi
+fi
+
+# === Check for CSRF protection ===
+echo ""
+echo "=== Checking CSRF Protection ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    CSRF=$(scan_php_count "(csrf|_token|CsrfToken|FormProtection)")
+    if [[ "$CSRF" -gt 0 ]]; then
+        echo "✅ CSRF protection references found ($CSRF occurrences)"
+    else
+        echo "⚠️  No CSRF protection detected"
+        WARNINGS=$((WARNINGS + 1))
+    fi
+fi
+
+# === Check for SSRF patterns (CWE-918) ===
+echo ""
+echo "=== Checking for SSRF Patterns ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    # shellcheck disable=SC2016
+    SSRF_PATTERNS=$(scan_php '(file_get_contents|curl_init|curl_setopt.*CURLOPT_URL)\s*\([^)]*\$_(GET|POST|REQUEST)')
+    if [[ -n "$SSRF_PATTERNS" ]]; then
+        echo "🔴 Potential SSRF vulnerability (user-controlled URL in HTTP request):"
+        echo "$SSRF_PATTERNS"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "✅ No obvious SSRF patterns detected"
+    fi
+fi
+
+# === Check for IDOR patterns (CWE-639) ===
+echo ""
+echo "=== Checking for IDOR Patterns ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    # shellcheck disable=SC2016
+    IDOR_PATTERNS=$(scan_php '->find\(\s*\$_(GET|POST|REQUEST)\[')
+    if [[ -n "$IDOR_PATTERNS" ]]; then
+        echo "⚠️  Potential IDOR pattern (direct DB lookup with user-supplied ID without auth check):"
+        echo "$IDOR_PATTERNS"
+        WARNINGS=$((WARNINGS + 1))
+    else
+        echo "✅ No obvious IDOR patterns detected"
+    fi
+fi
+
+# === Check for type juggling (CWE-843) ===
+echo ""
+echo "=== Checking for Type Juggling ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    # shellcheck disable=SC2016
+    TYPE_JUGGLE=$(scan_php '==\s*\$_(GET|POST|REQUEST|COOKIE)')
+    if [[ -n "$TYPE_JUGGLE" ]]; then
+        echo "🔴 Loose comparison (==) with user input (type juggling risk):"
+        echo "$TYPE_JUGGLE"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "✅ No obvious type juggling patterns detected"
+    fi
+fi
+
+# === Check for PHAR deserialization (CWE-502) ===
+echo ""
+echo "=== Checking for PHAR Deserialization ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    PHAR_PATTERNS=$(scan_php 'phar://')
+    if [[ -n "$PHAR_PATTERNS" ]]; then
+        echo "🔴 phar:// stream wrapper found (triggers deserialization):"
+        echo "$PHAR_PATTERNS"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "✅ No phar:// usage detected"
+    fi
+fi
+
+# === Check for email header injection (CWE-93) ===
+echo ""
+echo "=== Checking for Email Header Injection ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    # shellcheck disable=SC2016
+    EMAIL_INJECT=$(scan_php '\bmail\s*\([^)]*\$_(GET|POST|REQUEST)')
+    if [[ -n "$EMAIL_INJECT" ]]; then
+        echo "🔴 mail() with user input (header injection risk):"
+        echo "$EMAIL_INJECT"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "✅ No email header injection patterns detected"
+    fi
+fi
+
+# === Check for LDAP injection (CWE-90) ===
+echo ""
+echo "=== Checking for LDAP Injection ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    # shellcheck disable=SC2016
+    LDAP_INJECT=$(scan_php 'ldap_(search|bind)\s*\([^)]*\$_(GET|POST|REQUEST)')
+    if [[ -n "$LDAP_INJECT" ]]; then
+        echo "🔴 LDAP operation with user input (injection risk):"
+        echo "$LDAP_INJECT"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "✅ No LDAP injection patterns detected"
+    fi
+fi
+
+# === Check for insecure token generation (CWE-330) ===
+echo ""
+echo "=== Checking for Insecure Token Generation ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    INSECURE_TOKEN=$(scan_php '(md5|sha1)\s*\(\s*(time|microtime|uniqid|rand|mt_rand)\s*\(')
+    if [[ -n "$INSECURE_TOKEN" ]]; then
+        echo "🔴 Predictable token generation (use random_bytes instead):"
+        echo "$INSECURE_TOKEN"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "✅ No insecure token generation detected"
+    fi
+fi
+
+# === Check for session fixation (CWE-384) ===
+echo ""
+echo "=== Checking for Session Fixation ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    # shellcheck disable=SC2016
+    SESSION_FIX=$(scan_php 'session_id\s*\(\s*\$_(GET|POST|REQUEST|COOKIE)')
+    if [[ -n "$SESSION_FIX" ]]; then
+        echo "🔴 Session ID set from user input (session fixation risk):"
+        echo "$SESSION_FIX"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "✅ No session fixation patterns detected"
+    fi
+fi
+
+# === Check for log injection (CWE-117) ===
+echo ""
+echo "=== Checking for Log Injection ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    # shellcheck disable=SC2016
+    LOG_INJECT=$(scan_php 'error_log\s*\([^)]*\$_(GET|POST|REQUEST|COOKIE)')
+    if [[ -n "$LOG_INJECT" ]]; then
+        echo "⚠️  Unsanitized user input in log calls (log injection risk):"
+        echo "$LOG_INJECT"
+        WARNINGS=$((WARNINGS + 1))
+    else
+        echo "✅ No log injection patterns detected"
+    fi
+fi
+
+# === Check for insecure cookie settings ===
+echo ""
+echo "=== Checking Cookie Security ==="
+if [[ ${#SCAN_DIRS[@]} -gt 0 ]]; then
+    INSECURE_COOKIES=$(scan_php "setcookie\s*\(" 10)
+    if [[ -n "$INSECURE_COOKIES" ]]; then
+        SECURE_COOKIES=$(scan_php_count "setcookie.*secure.*httponly|setcookie.*httponly.*secure|SameSite")
+        if [[ "$SECURE_COOKIES" -eq 0 ]]; then
+            echo "⚠️  setcookie() calls without secure flags (set Secure, HttpOnly, SameSite):"
+            echo "$INSECURE_COOKIES" | head -3
+            WARNINGS=$((WARNINGS + 1))
+        else
+            echo "✅ Cookie security flags detected"
+        fi
+    else
+        echo "✅ No direct setcookie() calls"
+    fi
+fi
+
+# === Summary ===
+echo ""
+echo "=== Summary ==="
+echo "Errors: $ERRORS"
+echo "Warnings: $WARNINGS"
+
+if [[ $ERRORS -gt 0 ]]; then
+    echo "❌ Security audit FAILED with $ERRORS error(s)"
+    exit 1
+elif [[ $WARNINGS -gt 3 ]]; then
+    echo "⚠️  Security audit completed with significant warnings"
+    exit 0
+else
+    echo "✅ Security audit PASSED"
+    exit 0
+fi

--- a/skills/security-audit/scripts/scanners/php.sh
+++ b/skills/security-audit/scripts/scanners/php.sh
@@ -25,7 +25,7 @@ scan_php() {
     local results=""
     for dir in "${SCAN_DIRS[@]}"; do
         local matches
-        matches=$(grep -rn -E "$pattern" "$dir" --include="*.php" 2>/dev/null || true)
+        matches=$(grep -rn -P "$pattern" "$dir" --include="*.php" 2>/dev/null || true)
         if [[ -n "$matches" ]]; then
             results+="$matches"$'\n'
         fi
@@ -39,7 +39,7 @@ scan_php_count() {
     local total=0
     for dir in "${SCAN_DIRS[@]}"; do
         local count
-        count=$(grep -rn -E "$pattern" "$dir" --include="*.php" 2>/dev/null | wc -l || echo "0")
+        count=$(grep -rn -P "$pattern" "$dir" --include="*.php" 2>/dev/null | wc -l || echo "0")
         total=$((total + count))
     done
     echo "$total"

--- a/skills/security-audit/scripts/scanners/python.sh
+++ b/skills/security-audit/scripts/scanners/python.sh
@@ -31,9 +31,9 @@ scan_py() {
         local matches
         if [[ "$dir" == "$PROJECT_DIR" ]]; then
             # Only scan .py files in root, not recursively (subdirs handled separately)
-            matches=$(grep -n -E "$pattern" "$dir"/*.py 2>/dev/null || true)
+            matches=$(grep -n -P "$pattern" "$dir"/*.py 2>/dev/null || true)
         else
-            matches=$(grep -rn -E "$pattern" "$dir" --include="*.py" 2>/dev/null || true)
+            matches=$(grep -rn -P "$pattern" "$dir" --include="*.py" 2>/dev/null || true)
         fi
         if [[ -n "$matches" ]]; then
             results+="$matches"$'\n'
@@ -49,9 +49,9 @@ scan_py_count() {
     for dir in "${SCAN_DIRS[@]}"; do
         local count
         if [[ "$dir" == "$PROJECT_DIR" ]]; then
-            count=$(grep -n -E "$pattern" "$dir"/*.py 2>/dev/null | wc -l || echo "0")
+            count=$(grep -n -P "$pattern" "$dir"/*.py 2>/dev/null | wc -l || echo "0")
         else
-            count=$(grep -rn -E "$pattern" "$dir" --include="*.py" 2>/dev/null | wc -l || echo "0")
+            count=$(grep -rn -P "$pattern" "$dir" --include="*.py" 2>/dev/null | wc -l || echo "0")
         fi
         total=$((total + count))
     done

--- a/skills/security-audit/scripts/scanners/python.sh
+++ b/skills/security-audit/scripts/scanners/python.sh
@@ -1,0 +1,277 @@
+#!/bin/bash
+# Python Security Scanner Module
+# Scans Python projects for common vulnerability patterns
+# Part of security-audit-skill Phase 4
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+ERRORS=0
+WARNINGS=0
+
+# Auto-detect Python source directories
+SCAN_DIRS=()
+for dir in src lib app; do
+    if [[ -d "$PROJECT_DIR/$dir" ]]; then
+        SCAN_DIRS+=("$PROJECT_DIR/$dir")
+    fi
+done
+
+# Also scan .py files in the project root
+if ls "$PROJECT_DIR"/*.py 1>/dev/null 2>&1; then
+    SCAN_DIRS+=("$PROJECT_DIR")
+fi
+
+# Helper: grep across all Python source directories
+scan_py() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    local results=""
+    for dir in "${SCAN_DIRS[@]}"; do
+        local matches
+        if [[ "$dir" == "$PROJECT_DIR" ]]; then
+            # Only scan .py files in root, not recursively (subdirs handled separately)
+            matches=$(grep -n -E "$pattern" "$dir"/*.py 2>/dev/null || true)
+        else
+            matches=$(grep -rn -E "$pattern" "$dir" --include="*.py" 2>/dev/null || true)
+        fi
+        if [[ -n "$matches" ]]; then
+            results+="$matches"$'\n'
+        fi
+    done
+    echo "$results" | grep -v '^$' | head -"$limit"
+}
+
+# Helper: count matches across all Python source directories
+scan_py_count() {
+    local pattern="$1"
+    local total=0
+    for dir in "${SCAN_DIRS[@]}"; do
+        local count
+        if [[ "$dir" == "$PROJECT_DIR" ]]; then
+            count=$(grep -n -E "$pattern" "$dir"/*.py 2>/dev/null | wc -l || echo "0")
+        else
+            count=$(grep -rn -E "$pattern" "$dir" --include="*.py" 2>/dev/null | wc -l || echo "0")
+        fi
+        total=$((total + count))
+    done
+    echo "$total"
+}
+
+echo "--- Python Security Scanner ---"
+if [[ ${#SCAN_DIRS[@]} -eq 0 ]]; then
+    echo "No Python source files found (looked for src/, lib/, app/, and *.py in project root)"
+    exit 0
+fi
+echo "Scanning: ${SCAN_DIRS[*]}"
+echo ""
+
+# === SA-PY-01: Insecure deserialization via pickle ===
+echo "=== Checking for Insecure Deserialization (pickle/shelve/marshal) ==="
+PICKLE_HITS=$(scan_py 'pickle\.(loads|load)\(' 10)
+SHELVE_HITS=$(scan_py 'shelve\.open\(' 5)
+MARSHAL_HITS=$(scan_py 'marshal\.loads\(' 5)
+if [[ -n "$PICKLE_HITS" ]]; then
+    echo "ERROR [SA-PY-01]: pickle.load/loads found — risk of arbitrary code execution:"
+    echo "$PICKLE_HITS"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No pickle.load/loads calls detected"
+fi
+if [[ -n "$SHELVE_HITS" ]]; then
+    echo "WARNING [SA-PY-17]: shelve.open found — uses pickle internally:"
+    echo "$SHELVE_HITS"
+    WARNINGS=$((WARNINGS + 1))
+fi
+if [[ -n "$MARSHAL_HITS" ]]; then
+    echo "WARNING [SA-PY-18]: marshal.loads found — insecure deserialization:"
+    echo "$MARSHAL_HITS"
+    WARNINGS=$((WARNINGS + 1))
+fi
+
+# === SA-PY-02/03: eval() / exec() code injection ===
+echo ""
+echo "=== Checking for eval()/exec() Code Injection ==="
+EVAL_HITS=$(scan_py 'eval\(' 10)
+EXEC_HITS=$(scan_py 'exec\(' 10)
+if [[ -n "$EVAL_HITS" ]]; then
+    echo "ERROR [SA-PY-02]: eval() calls found — risk of code injection:"
+    echo "$EVAL_HITS"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No eval() calls detected"
+fi
+if [[ -n "$EXEC_HITS" ]]; then
+    echo "ERROR [SA-PY-03]: exec() calls found — risk of code injection:"
+    echo "$EXEC_HITS"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No exec() calls detected"
+fi
+
+# === SA-PY-04/05/15: Command injection ===
+echo ""
+echo "=== Checking for Command Injection ==="
+SHELL_TRUE=$(scan_py 'subprocess\.\w+\(.*shell\s*=\s*True' 10)
+OS_SYSTEM=$(scan_py 'os\.system\(' 10)
+OS_POPEN=$(scan_py 'os\.popen\(' 10)
+if [[ -n "$SHELL_TRUE" ]]; then
+    echo "ERROR [SA-PY-04]: subprocess with shell=True found:"
+    echo "$SHELL_TRUE"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No subprocess shell=True calls detected"
+fi
+if [[ -n "$OS_SYSTEM" ]]; then
+    echo "ERROR [SA-PY-05]: os.system() calls found:"
+    echo "$OS_SYSTEM"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No os.system() calls detected"
+fi
+if [[ -n "$OS_POPEN" ]]; then
+    echo "ERROR [SA-PY-15]: os.popen() calls found:"
+    echo "$OS_POPEN"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No os.popen() calls detected"
+fi
+
+# === SA-PY-06: Unsafe YAML loading ===
+echo ""
+echo "=== Checking for Unsafe YAML Loading ==="
+YAML_LOAD=$(scan_py 'yaml\.load\(' 10)
+if [[ -n "$YAML_LOAD" ]]; then
+    # Check if safe_load is also used (might be a false positive context)
+    SAFE_COUNT=$(scan_py_count 'yaml\.safe_load')
+    echo "ERROR [SA-PY-06]: yaml.load() found — use yaml.safe_load() instead:"
+    echo "$YAML_LOAD"
+    ERRORS=$((ERRORS + 1))
+    if [[ "$SAFE_COUNT" -gt 0 ]]; then
+        echo "  Note: yaml.safe_load() also found ($SAFE_COUNT occurrences) — verify migration is complete"
+    fi
+else
+    echo "OK: No unsafe yaml.load() calls detected"
+fi
+
+# === SA-PY-07/08: SQL injection ===
+echo ""
+echo "=== Checking for SQL Injection Patterns ==="
+SQL_FSTRING=$(scan_py 'execute\(f"' 10)
+SQL_FORMAT=$(scan_py 'execute\(.*\.format\(' 10)
+if [[ -n "$SQL_FSTRING" ]]; then
+    echo "ERROR [SA-PY-07]: SQL query with f-string found:"
+    echo "$SQL_FSTRING"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No f-string SQL queries detected"
+fi
+if [[ -n "$SQL_FORMAT" ]]; then
+    echo "ERROR [SA-PY-08]: SQL query with .format() found:"
+    echo "$SQL_FORMAT"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No .format() SQL queries detected"
+fi
+
+# === SA-PY-09/10: Weak hashing ===
+echo ""
+echo "=== Checking for Weak Hash Algorithms ==="
+MD5_HITS=$(scan_py 'hashlib\.md5\(' 10)
+SHA1_HITS=$(scan_py 'hashlib\.sha1\(' 10)
+if [[ -n "$MD5_HITS" ]]; then
+    echo "WARNING [SA-PY-09]: hashlib.md5() found — weak for security use:"
+    echo "$MD5_HITS"
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No hashlib.md5() calls detected"
+fi
+if [[ -n "$SHA1_HITS" ]]; then
+    echo "WARNING [SA-PY-10]: hashlib.sha1() found — weak for security use:"
+    echo "$SHA1_HITS"
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No hashlib.sha1() calls detected"
+fi
+
+# === SA-PY-11: tempfile.mktemp race condition ===
+echo ""
+echo "=== Checking for tempfile Race Conditions ==="
+MKTEMP_HITS=$(scan_py 'tempfile\.mktemp\(' 10)
+if [[ -n "$MKTEMP_HITS" ]]; then
+    echo "ERROR [SA-PY-11]: tempfile.mktemp() found — use mkstemp() instead:"
+    echo "$MKTEMP_HITS"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No tempfile.mktemp() calls detected"
+fi
+
+# === SA-PY-12: Dynamic import abuse ===
+echo ""
+echo "=== Checking for Dynamic Import Abuse ==="
+IMPORT_HITS=$(scan_py '__import__\(' 10)
+if [[ -n "$IMPORT_HITS" ]]; then
+    echo "WARNING [SA-PY-12]: __import__() calls found — validate module names:"
+    echo "$IMPORT_HITS"
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No __import__() calls detected"
+fi
+
+# === SA-PY-13: XML parsing without defusedxml ===
+echo ""
+echo "=== Checking for Unsafe XML Parsing ==="
+XML_HITS=$(scan_py 'xml\.etree\.ElementTree' 10)
+if [[ -n "$XML_HITS" ]]; then
+    DEFUSED_COUNT=$(scan_py_count 'defusedxml')
+    if [[ "$DEFUSED_COUNT" -eq 0 ]]; then
+        echo "WARNING [SA-PY-13]: xml.etree.ElementTree used without defusedxml:"
+        echo "$XML_HITS"
+        WARNINGS=$((WARNINGS + 1))
+    else
+        echo "OK: defusedxml detected alongside standard XML library"
+    fi
+else
+    echo "OK: No standard library XML parsing detected"
+fi
+
+# === SA-PY-14: SSTI via Jinja2/Mako Template ===
+echo ""
+echo "=== Checking for Template Injection (SSTI) ==="
+TEMPLATE_HITS=$(scan_py 'Template\s*\(.*\w+.*\)' 10)
+if [[ -n "$TEMPLATE_HITS" ]]; then
+    echo "WARNING [SA-PY-14]: Template() with variable input found — risk of SSTI:"
+    echo "$TEMPLATE_HITS"
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No Template() with variable input detected"
+fi
+
+# === SA-PY-16: compile() with dynamic input ===
+echo ""
+echo "=== Checking for compile() Code Injection ==="
+COMPILE_HITS=$(scan_py 'compile\(.*,.*,' 10)
+if [[ -n "$COMPILE_HITS" ]]; then
+    echo "WARNING [SA-PY-16]: compile() with dynamic input found:"
+    echo "$COMPILE_HITS"
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No suspicious compile() calls detected"
+fi
+
+# === Summary ===
+echo ""
+echo "=========================================="
+echo "Python Security Scan Summary"
+echo "=========================================="
+echo "Errors:   $ERRORS"
+echo "Warnings: $WARNINGS"
+echo ""
+
+if [[ $ERRORS -gt 0 ]]; then
+    echo "FAIL: $ERRORS error(s) found — review and fix before deployment"
+else
+    echo "PASS: No critical security errors detected"
+fi
+
+exit "$ERRORS"

--- a/skills/security-audit/scripts/scanners/ruby.sh
+++ b/skills/security-audit/scripts/scanners/ruby.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# Ruby Security Scanner Module
+# Scans Ruby projects for common vulnerability patterns
+# Part of security-audit-skill modular scanner architecture
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+ERRORS=0
+WARNINGS=0
+
+# Auto-detect Ruby source directories
+SCAN_DIRS=()
+for dir in app lib config; do
+    if [[ -d "$PROJECT_DIR/$dir" ]]; then
+        SCAN_DIRS+=("$PROJECT_DIR/$dir")
+    fi
+done
+
+# Helper: grep across all Ruby source directories
+scan_ruby() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    local results=""
+    for dir in "${SCAN_DIRS[@]}"; do
+        local matches
+        matches=$(grep -rn -E "$pattern" "$dir" --include="*.rb" 2>/dev/null || true)
+        if [[ -n "$matches" ]]; then
+            results+="$matches"$'\n'
+        fi
+    done
+    echo "$results" | grep -v '^$' | head -"$limit"
+}
+
+# Helper: count matches across all Ruby source directories
+scan_ruby_count() {
+    local pattern="$1"
+    local total=0
+    for dir in "${SCAN_DIRS[@]}"; do
+        local count
+        count=$(grep -rn -E "$pattern" "$dir" --include="*.rb" 2>/dev/null | wc -l || echo "0")
+        total=$((total + count))
+    done
+    echo "$total"
+}
+
+echo "--- Ruby Security Scanner ---"
+if [[ ${#SCAN_DIRS[@]} -eq 0 ]]; then
+    echo "No Ruby source directories found (looked for app/, lib/, config/)"
+    exit 0
+fi
+echo "Scanning directories: ${SCAN_DIRS[*]}"
+echo ""
+
+# SA-RB-01: eval() code injection
+count=$(scan_ruby_count '\beval\s*\(')
+if [[ $count -gt 0 ]]; then
+    echo "[ERROR] SA-RB-01: Found $count eval() call(s) — potential code injection"
+    scan_ruby '\beval\s*\('
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-RB-02: send() method injection
+count=$(scan_ruby_count '\.send\s*\(')
+if [[ $count -gt 0 ]]; then
+    echo "[WARNING] SA-RB-02: Found $count send() call(s) — potential method injection"
+    scan_ruby '\.send\s*\('
+    WARNINGS=$((WARNINGS + count))
+    echo ""
+fi
+
+# SA-RB-03: system() command injection
+count=$(scan_ruby_count '\bsystem\s*\(')
+if [[ $count -gt 0 ]]; then
+    echo "[WARNING] SA-RB-03: Found $count system() call(s) — verify no user input in command"
+    scan_ruby '\bsystem\s*\('
+    WARNINGS=$((WARNINGS + count))
+    echo ""
+fi
+
+# SA-RB-03b: exec() command injection
+count=$(scan_ruby_count '\bexec\s*\(')
+if [[ $count -gt 0 ]]; then
+    echo "[WARNING] SA-RB-03b: Found $count exec() call(s) — verify no user input in command"
+    scan_ruby '\bexec\s*\('
+    WARNINGS=$((WARNINGS + count))
+    echo ""
+fi
+
+# SA-RB-04: Marshal.load insecure deserialization
+count=$(scan_ruby_count 'Marshal\.load\s*\(')
+if [[ $count -gt 0 ]]; then
+    echo "[ERROR] SA-RB-04: Found $count Marshal.load() call(s) — insecure deserialization"
+    scan_ruby 'Marshal\.load\s*\('
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-RB-05: YAML.load (not safe_load)
+count=$(scan_ruby_count 'YAML\.load\b[^_]')
+if [[ $count -gt 0 ]]; then
+    echo "[ERROR] SA-RB-05: Found $count YAML.load() call(s) — use YAML.safe_load instead"
+    scan_ruby 'YAML\.load\b[^_]'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-RB-06: ERB.new template injection
+count=$(scan_ruby_count 'ERB\.new\s*\(')
+if [[ $count -gt 0 ]]; then
+    echo "[WARNING] SA-RB-06: Found $count ERB.new() call(s) — audit for template injection"
+    scan_ruby 'ERB\.new\s*\('
+    WARNINGS=$((WARNINGS + count))
+    echo ""
+fi
+
+# SA-RB-07: find_by_sql SQL injection
+count=$(scan_ruby_count 'find_by_sql\s*\(')
+if [[ $count -gt 0 ]]; then
+    echo "[ERROR] SA-RB-07: Found $count find_by_sql() call(s) — risk of SQL injection"
+    scan_ruby 'find_by_sql\s*\('
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-RB-08: html_safe XSS bypass
+count=$(scan_ruby_count '\.html_safe\b')
+if [[ $count -gt 0 ]]; then
+    echo "[WARNING] SA-RB-08: Found $count html_safe call(s) — XSS escaping bypass"
+    scan_ruby '\.html_safe\b'
+    WARNINGS=$((WARNINGS + count))
+    echo ""
+fi
+
+# SA-RB-09: raw() XSS bypass
+count=$(scan_ruby_count '\braw\s*\(')
+if [[ $count -gt 0 ]]; then
+    echo "[WARNING] SA-RB-09: Found $count raw() call(s) — XSS escaping bypass"
+    scan_ruby '\braw\s*\('
+    WARNINGS=$((WARNINGS + count))
+    echo ""
+fi
+
+# SA-RB-10: Kernel.open pipe injection
+count=$(scan_ruby_count '\bKernel\.open\s*\(')
+if [[ $count -gt 0 ]]; then
+    echo "[ERROR] SA-RB-10: Found $count Kernel.open() call(s) — pipe injection / SSRF risk"
+    scan_ruby '\bKernel\.open\s*\('
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-RB-11: permit! mass assignment
+count=$(scan_ruby_count '\.permit!\b')
+if [[ $count -gt 0 ]]; then
+    echo "[ERROR] SA-RB-11: Found $count permit!() call(s) — mass assignment vulnerability"
+    scan_ruby '\.permit!\b'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+# SA-RB-12: MD5 weak cryptography
+count=$(scan_ruby_count 'Digest::MD5')
+if [[ $count -gt 0 ]]; then
+    echo "[WARNING] SA-RB-12: Found $count Digest::MD5 usage(s) — use SHA-256 or bcrypt"
+    scan_ruby 'Digest::MD5'
+    WARNINGS=$((WARNINGS + count))
+    echo ""
+fi
+
+# SA-RB-13: SHA1 weak cryptography
+count=$(scan_ruby_count 'Digest::SHA1')
+if [[ $count -gt 0 ]]; then
+    echo "[WARNING] SA-RB-13: Found $count Digest::SHA1 usage(s) — use SHA-256 or stronger"
+    scan_ruby 'Digest::SHA1'
+    WARNINGS=$((WARNINGS + count))
+    echo ""
+fi
+
+# SA-RB-14: backtick command execution with interpolation
+count=$(scan_ruby_count '`[^`]*#\{')
+if [[ $count -gt 0 ]]; then
+    echo "[ERROR] SA-RB-14: Found $count backtick command(s) with interpolation — command injection risk"
+    scan_ruby '`[^`]*#\{'
+    ERRORS=$((ERRORS + count))
+    echo ""
+fi
+
+echo "--- Ruby Security Scanner Summary ---"
+echo "Errors:   $ERRORS"
+echo "Warnings: $WARNINGS"
+echo "Total:    $((ERRORS + WARNINGS))"
+
+exit $ERRORS

--- a/skills/security-audit/scripts/scanners/ruby.sh
+++ b/skills/security-audit/scripts/scanners/ruby.sh
@@ -24,7 +24,7 @@ scan_ruby() {
     local results=""
     for dir in "${SCAN_DIRS[@]}"; do
         local matches
-        matches=$(grep -rn -E "$pattern" "$dir" --include="*.rb" 2>/dev/null || true)
+        matches=$(grep -rn -P "$pattern" "$dir" --include="*.rb" 2>/dev/null || true)
         if [[ -n "$matches" ]]; then
             results+="$matches"$'\n'
         fi
@@ -38,7 +38,7 @@ scan_ruby_count() {
     local total=0
     for dir in "${SCAN_DIRS[@]}"; do
         local count
-        count=$(grep -rn -E "$pattern" "$dir" --include="*.rb" 2>/dev/null | wc -l || echo "0")
+        count=$(grep -rn -P "$pattern" "$dir" --include="*.rb" 2>/dev/null | wc -l || echo "0")
         total=$((total + count))
     done
     echo "$total"

--- a/skills/security-audit/scripts/scanners/rust.sh
+++ b/skills/security-audit/scripts/scanners/rust.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+# Rust Security Scanner Module
+# Scans Rust projects for common vulnerability patterns
+# Excludes target/ directory
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+ERRORS=0
+WARNINGS=0
+
+# Auto-detect Rust source directories
+SCAN_DIRS=()
+for dir in src examples tests benches; do
+    if [[ -d "$PROJECT_DIR/$dir" ]]; then
+        SCAN_DIRS+=("$PROJECT_DIR/$dir")
+    fi
+done
+
+# Helper: grep across all Rust source directories, excluding target/
+scan_rs() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    local results=""
+    for dir in "${SCAN_DIRS[@]}"; do
+        local matches
+        matches=$(grep -rn -E "$pattern" "$dir" --include="*.rs" --exclude-dir=target --exclude-dir=.git 2>/dev/null || true)
+        if [[ -n "$matches" ]]; then
+            results+="$matches"$'\n'
+        fi
+    done
+    echo "$results" | grep -v '^$' | head -"$limit"
+}
+
+# Helper: count matches across all Rust source directories
+scan_rs_count() {
+    local pattern="$1"
+    local total=0
+    for dir in "${SCAN_DIRS[@]}"; do
+        local count
+        count=$(grep -rn -E "$pattern" "$dir" --include="*.rs" --exclude-dir=target --exclude-dir=.git 2>/dev/null | wc -l || echo "0")
+        total=$((total + count))
+    done
+    echo "$total"
+}
+
+echo "--- Rust Security Scanner ---"
+if [[ ${#SCAN_DIRS[@]} -eq 0 ]]; then
+    echo "No Rust source directories found (looked for src/, examples/, tests/, benches/)"
+    exit 0
+fi
+echo "Scanning: ${SCAN_DIRS[*]}"
+echo ""
+
+# === Check for unsafe blocks/fn/impl ===
+echo "=== Checking for unsafe Usage ==="
+UNSAFE_COUNT=$(scan_rs_count 'unsafe\s*\{|unsafe\s+fn\s|unsafe\s+impl\s')
+if [[ "$UNSAFE_COUNT" -gt 0 ]]; then
+    echo "WARNING: $UNSAFE_COUNT unsafe block/fn/impl found — audit required:"
+    scan_rs 'unsafe\s*\{|unsafe\s+fn\s|unsafe\s+impl\s' 5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No unsafe usage detected"
+fi
+
+# === Check for FFI boundaries ===
+echo ""
+echo "=== Checking for FFI Boundaries ==="
+FFI=$(scan_rs 'extern\s+"C"\s*\{|#\[no_mangle\]' 10)
+if [[ -n "$FFI" ]]; then
+    echo "WARNING: FFI boundaries found — audit for null checks and lifetime safety:"
+    echo "$FFI" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No FFI boundaries detected"
+fi
+
+# === Check for panic!/todo!/unimplemented! ===
+echo ""
+echo "=== Checking for Panic Macros ==="
+PANICS=$(scan_rs 'panic!\s*\(|todo!\s*\(|unimplemented!\s*\(' 10)
+if [[ -n "$PANICS" ]]; then
+    echo "WARNING: panic!/todo!/unimplemented! found — can cause DoS:"
+    echo "$PANICS" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No panic macros detected"
+fi
+
+# === Check for .unwrap()/.expect() ===
+echo ""
+echo "=== Checking for .unwrap()/.expect() ==="
+UNWRAP_COUNT=$(scan_rs_count '\.unwrap\(\)|\.expect\(\s*"')
+if [[ "$UNWRAP_COUNT" -gt 0 ]]; then
+    echo "WARNING: $UNWRAP_COUNT .unwrap()/.expect() calls found — use ? in production paths:"
+    scan_rs '\.unwrap\(\)|\.expect\(\s*"' 5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No .unwrap()/.expect() calls detected"
+fi
+
+# === Check for raw pointer casts ===
+echo ""
+echo "=== Checking for Raw Pointer Casts ==="
+RAW_PTR=$(scan_rs 'as\s+\*const\s|as\s+\*mut\s')
+if [[ -n "$RAW_PTR" ]]; then
+    echo "WARNING: Raw pointer casts found:"
+    echo "$RAW_PTR"
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No raw pointer casts detected"
+fi
+
+# === Check for SQL injection ===
+echo ""
+echo "=== Checking for SQL Injection Patterns ==="
+SQL_FMT=$(scan_rs 'sql_query\s*\(\s*format!|query.*&format!')
+if [[ -n "$SQL_FMT" ]]; then
+    echo "ERROR: SQL query with format! string:"
+    echo "$SQL_FMT"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No SQL injection patterns detected"
+fi
+
+# === Check for command injection ===
+echo ""
+echo "=== Checking for Command Injection ==="
+CMD_INJECT=$(scan_rs 'Command::new\s*\(\s*"(sh|bash|cmd|powershell)"')
+if [[ -n "$CMD_INJECT" ]]; then
+    echo "ERROR: Shell invocation via Command::new:"
+    echo "$CMD_INJECT"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No shell invocation patterns detected"
+fi
+
+# === Check for mem::forget / ManuallyDrop ===
+echo ""
+echo "=== Checking for Memory Leak Patterns ==="
+MEM_FORGET=$(scan_rs 'mem::forget\s*\(|ManuallyDrop::new\s*\(')
+if [[ -n "$MEM_FORGET" ]]; then
+    echo "WARNING: mem::forget/ManuallyDrop found — sensitive data may persist:"
+    echo "$MEM_FORGET"
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No mem::forget/ManuallyDrop patterns detected"
+fi
+
+# === Check for hardcoded secrets ===
+echo ""
+echo "=== Checking for Hardcoded Secrets ==="
+SECRETS=$(scan_rs '(password|secret|api_key|token)\s*[:=]\s*"[^"]{8,}"' 10)
+if [[ -n "$SECRETS" ]]; then
+    echo "ERROR: Potential hardcoded credentials found:"
+    echo "$SECRETS" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No obvious hardcoded secrets detected"
+fi
+
+# === Check for timing-unsafe comparisons ===
+echo ""
+echo "=== Checking for Timing-Unsafe Comparisons ==="
+TIMING=$(scan_rs '==\s*(token|secret|hmac|hash|key|password|mac|signature)')
+if [[ -n "$TIMING" ]]; then
+    echo "ERROR: Non-constant-time comparison of secret:"
+    echo "$TIMING"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No timing-unsafe comparisons detected"
+fi
+
+# === Check for transmute ===
+echo ""
+echo "=== Checking for transmute Usage ==="
+TRANSMUTE=$(scan_rs 'mem::transmute|std::mem::transmute')
+if [[ -n "$TRANSMUTE" ]]; then
+    echo "ERROR: transmute found — extremely dangerous, audit required:"
+    echo "$TRANSMUTE"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No transmute usage detected"
+fi
+
+# === Check dependencies with cargo audit ===
+echo ""
+echo "=== Checking Dependencies ==="
+if [[ -f "$PROJECT_DIR/Cargo.lock" ]]; then
+    if command -v cargo-audit &> /dev/null; then
+        AUDIT_OUTPUT=$(cd "$PROJECT_DIR" && cargo audit 2>&1 || true)
+        if echo "$AUDIT_OUTPUT" | grep -q "Vulnerability"; then
+            echo "WARNING: Vulnerable dependencies found:"
+            echo "$AUDIT_OUTPUT" | head -20
+            WARNINGS=$((WARNINGS + 1))
+        else
+            echo "OK: No known vulnerable dependencies"
+        fi
+    else
+        echo "INFO: cargo-audit not available — install with: cargo install cargo-audit"
+    fi
+else
+    echo "INFO: No Cargo.lock found — skipping dependency check"
+fi
+
+# === Output results for dispatcher ===
+echo ""
+echo "--- Rust Scanner Results ---"
+echo "Errors: $ERRORS"
+echo "Warnings: $WARNINGS"
+
+# Exit with error count for dispatcher to aggregate
+exit "$ERRORS"

--- a/skills/security-audit/scripts/scanners/rust.sh
+++ b/skills/security-audit/scripts/scanners/rust.sh
@@ -24,7 +24,7 @@ scan_rs() {
     local results=""
     for dir in "${SCAN_DIRS[@]}"; do
         local matches
-        matches=$(grep -rn -E "$pattern" "$dir" --include="*.rs" --exclude-dir=target --exclude-dir=.git 2>/dev/null || true)
+        matches=$(grep -rn -P "$pattern" "$dir" --include="*.rs" --exclude-dir=target --exclude-dir=.git 2>/dev/null || true)
         if [[ -n "$matches" ]]; then
             results+="$matches"$'\n'
         fi
@@ -38,7 +38,7 @@ scan_rs_count() {
     local total=0
     for dir in "${SCAN_DIRS[@]}"; do
         local count
-        count=$(grep -rn -E "$pattern" "$dir" --include="*.rs" --exclude-dir=target --exclude-dir=.git 2>/dev/null | wc -l || echo "0")
+        count=$(grep -rn -P "$pattern" "$dir" --include="*.rs" --exclude-dir=target --exclude-dir=.git 2>/dev/null | wc -l || echo "0")
         total=$((total + count))
     done
     echo "$total"

--- a/skills/security-audit/scripts/scanners/secrets.sh
+++ b/skills/security-audit/scripts/scanners/secrets.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Secrets Scanner Module
+# Scans projects for leaked secrets using TruffleHog and fallback regex patterns.
+#
+# Checks for: API keys, tokens, passwords, private keys, cloud credentials,
+# database connection strings, and other sensitive values in source code and git history.
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+ERRORS=0
+WARNINGS=0
+
+echo "--- Secrets Scanner ---"
+echo "Scanning: $PROJECT_DIR"
+echo ""
+
+# === TruffleHog (if available) ===
+if command -v trufflehog &>/dev/null; then
+    echo "=== TruffleHog Filesystem Scan ==="
+    TRUFFLEHOG_OUTPUT=$(trufflehog filesystem "$PROJECT_DIR" --no-update --json 2>/dev/null || true)
+    TRUFFLEHOG_COUNT=$(echo "$TRUFFLEHOG_OUTPUT" | grep -c '"SourceMetadata"' 2>/dev/null || echo "0")
+
+    if [[ "$TRUFFLEHOG_COUNT" -gt 0 ]]; then
+        echo "ERROR: TruffleHog found $TRUFFLEHOG_COUNT secret(s):"
+        echo "$TRUFFLEHOG_OUTPUT" | head -20
+        ERRORS=$((ERRORS + TRUFFLEHOG_COUNT))
+    else
+        echo "OK: TruffleHog found no secrets"
+    fi
+
+    # Also scan git history if it's a git repo
+    if [[ -d "$PROJECT_DIR/.git" ]]; then
+        echo ""
+        echo "=== TruffleHog Git History Scan ==="
+        GIT_OUTPUT=$(trufflehog git "file://$PROJECT_DIR" --no-update --json 2>/dev/null || true)
+        GIT_COUNT=$(echo "$GIT_OUTPUT" | grep -c '"SourceMetadata"' 2>/dev/null || echo "0")
+
+        if [[ "$GIT_COUNT" -gt 0 ]]; then
+            echo "ERROR: TruffleHog found $GIT_COUNT secret(s) in git history:"
+            echo "$GIT_OUTPUT" | head -20
+            ERRORS=$((ERRORS + GIT_COUNT))
+        else
+            echo "OK: No secrets in git history"
+        fi
+    fi
+else
+    echo "TruffleHog not installed — falling back to regex patterns"
+    echo "  Install: https://github.com/trufflesecurity/trufflehog#installation"
+    echo ""
+fi
+
+# === Fallback regex patterns (always run as defense-in-depth) ===
+echo ""
+echo "=== Regex-Based Secret Detection ==="
+
+# Patterns to search for
+declare -A SECRET_PATTERNS
+SECRET_PATTERNS=(
+    ["AWS Access Key"]='AKIA[0-9A-Z]{16}'
+    ["AWS Secret Key"]='[0-9a-zA-Z/+=]{40}'
+    ["GitHub Token"]='gh[ps]_[A-Za-z0-9_]{36,}'
+    ["GitHub OAuth"]='gho_[A-Za-z0-9_]{36,}'
+    ["GitLab Token"]='glpat-[A-Za-z0-9\-_]{20,}'
+    ["Slack Token"]='xox[baprs]-[0-9a-zA-Z\-]{10,}'
+    ["Slack Webhook"]='hooks\.slack\.com/services/T[0-9A-Z]{8,}/B[0-9A-Z]{8,}/[0-9a-zA-Z]{24}'
+    ["Private Key"]='-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----'
+    ["Generic API Key"]='[aA][pP][iI][-_]?[kK][eE][yY]\s*[:=]\s*['\''"][0-9a-zA-Z]{16,}['\''"]'
+    ["Generic Secret"]='[sS][eE][cC][rR][eE][tT]\s*[:=]\s*['\''"][0-9a-zA-Z]{16,}['\''"]'
+    ["Generic Password"]='[pP][aA][sS][sS][wW][oO][rR][dD]\s*[:=]\s*['\''"][^'\''\"]{8,}['\''"]'
+    ["JWT Token"]='eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}'
+    ["Stripe Key"]='[sr]k_(live|test)_[0-9a-zA-Z]{24,}'
+    ["SendGrid Key"]='SG\.[0-9a-zA-Z\-_]{22,}\.[0-9a-zA-Z\-_]{43,}'
+    ["Twilio Key"]='SK[0-9a-fA-F]{32}'
+    ["Database URL"]='(postgres|mysql|mongodb|redis)://[^:]+:[^@]+@[^/]+'
+    ["Heroku API Key"]='[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
+    ["Google API Key"]='AIza[0-9A-Za-z\-_]{35}'
+    ["Firebase Key"]='AAAA[A-Za-z0-9_-]{7}:[A-Za-z0-9_-]{140}'
+)
+
+# Directories and files to skip
+EXCLUDE_DIRS="node_modules|vendor|dist|build|\.git|target|\.next|coverage|__pycache__|\.cargo|\.nuget"
+EXCLUDE_FILES="\.(lock|sum|min\.js|min\.css|map|woff|woff2|ttf|eot|png|jpg|jpeg|gif|ico|svg|pdf)$"
+
+for name in "${!SECRET_PATTERNS[@]}"; do
+    pattern="${SECRET_PATTERNS[$name]}"
+    MATCHES=$(grep -rn -E "$pattern" "$PROJECT_DIR" \
+        --include="*.{js,ts,jsx,tsx,py,java,cs,go,rs,rb,php,yaml,yml,json,xml,env,cfg,conf,ini,toml,properties,sh,bash,zsh}" \
+        2>/dev/null | grep -vE "$EXCLUDE_DIRS" | grep -vE "$EXCLUDE_FILES" | grep -vE "\.(example|sample|template)" | head -5 || true)
+
+    if [[ -n "$MATCHES" ]]; then
+        echo "WARNING: Potential $name found:"
+        echo "$MATCHES" | head -3
+        WARNINGS=$((WARNINGS + 1))
+    fi
+done
+
+# === Check for .env files in repo ===
+echo ""
+echo "=== Environment Files ==="
+ENV_FILES=$(find "$PROJECT_DIR" -maxdepth 3 -name ".env" -o -name ".env.local" -o -name ".env.production" 2>/dev/null | grep -vE "$EXCLUDE_DIRS" || true)
+if [[ -n "$ENV_FILES" ]]; then
+    echo "WARNING: Environment files found (should not be in VCS):"
+    echo "$ENV_FILES"
+    WARNINGS=$((WARNINGS + 1))
+fi
+
+# === Check .gitignore for env exclusion ===
+if [[ -f "$PROJECT_DIR/.gitignore" ]]; then
+    if ! grep -q "\.env" "$PROJECT_DIR/.gitignore" 2>/dev/null; then
+        echo "WARNING: .gitignore does not exclude .env files"
+        WARNINGS=$((WARNINGS + 1))
+    fi
+fi
+
+# === Summary ===
+echo ""
+echo "--- Secrets Scanner Results ---"
+echo "Errors: $ERRORS"
+echo "Warnings: $WARNINGS"
+
+exit "$ERRORS"

--- a/skills/security-audit/scripts/scanners/secrets.sh
+++ b/skills/security-audit/scripts/scanners/secrets.sh
@@ -4,6 +4,17 @@
 #
 # Checks for: API keys, tokens, passwords, private keys, cloud credentials,
 # database connection strings, and other sensitive values in source code and git history.
+#
+# Requires Bash 4+ (uses associative arrays via `declare -A`). macOS /bin/bash
+# is 3.2 — install GNU bash via Homebrew and invoke via that newer binary.
+
+# Fail fast with a clear message under Bash 3.x.
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "ERROR: scripts/scanners/secrets.sh requires Bash 4+ (current: $BASH_VERSION)" >&2
+    echo "  macOS ships Bash 3.2 as /bin/bash; install GNU bash via Homebrew and" >&2
+    echo "  re-run the dispatcher under that binary." >&2
+    exit 1
+fi
 
 set -e
 
@@ -84,8 +95,16 @@ EXCLUDE_FILES="\.(lock|sum|min\.js|min\.css|map|woff|woff2|ttf|eot|png|jpg|jpeg|
 
 for name in "${!SECRET_PATTERNS[@]}"; do
     pattern="${SECRET_PATTERNS[$name]}"
-    MATCHES=$(grep -rn -E "$pattern" "$PROJECT_DIR" \
-        --include="*.{js,ts,jsx,tsx,py,java,cs,go,rs,rb,php,yaml,yml,json,xml,env,cfg,conf,ini,toml,properties,sh,bash,zsh}" \
+    # GNU/BSD grep --include does NOT support brace expansion; pass each
+    # extension as a separate --include flag.
+    MATCHES=$(grep -rn -P "$pattern" "$PROJECT_DIR" \
+        --include="*.js" --include="*.ts" --include="*.jsx" --include="*.tsx" \
+        --include="*.py" --include="*.java" --include="*.cs" --include="*.go" \
+        --include="*.rs" --include="*.rb" --include="*.php" \
+        --include="*.yaml" --include="*.yml" --include="*.json" --include="*.xml" \
+        --include="*.env" --include="*.cfg" --include="*.conf" --include="*.ini" \
+        --include="*.toml" --include="*.properties" \
+        --include="*.sh" --include="*.bash" --include="*.zsh" \
         2>/dev/null | grep -vE "$EXCLUDE_DIRS" | grep -vE "$EXCLUDE_FILES" | grep -vE "\.(example|sample|template)" | head -5 || true)
 
     if [[ -n "$MATCHES" ]]; then
@@ -98,7 +117,10 @@ done
 # === Check for .env files in repo ===
 echo ""
 echo "=== Environment Files ==="
-ENV_FILES=$(find "$PROJECT_DIR" -maxdepth 3 -name ".env" -o -name ".env.local" -o -name ".env.production" 2>/dev/null | grep -vE "$EXCLUDE_DIRS" || true)
+# Parenthesise the -name alternations so -maxdepth 3 applies to all of them
+# (without parens, -maxdepth binds only to the first -name and the others
+# search the whole tree).
+ENV_FILES=$(find "$PROJECT_DIR" -maxdepth 3 \( -name ".env" -o -name ".env.local" -o -name ".env.production" \) 2>/dev/null | grep -vE "$EXCLUDE_DIRS" || true)
 if [[ -n "$ENV_FILES" ]]; then
     echo "WARNING: Environment files found (should not be in VCS):"
     echo "$ENV_FILES"

--- a/skills/security-audit/scripts/scanners/wordpress.sh
+++ b/skills/security-audit/scripts/scanners/wordpress.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+# WordPress Security Scanner Module
+# Detects WordPress projects via wp-config.php / wp-content/
+# Scans for common WordPress-specific vulnerability patterns
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+ERRORS=0
+WARNINGS=0
+
+# Auto-detect WordPress project
+WP_DETECTED=false
+if [[ -f "$PROJECT_DIR/wp-config.php" ]] || [[ -d "$PROJECT_DIR/wp-content" ]]; then
+    WP_DETECTED=true
+fi
+
+if [[ "$WP_DETECTED" != "true" ]]; then
+    echo "--- WordPress Security Scanner ---"
+    echo "No WordPress installation detected (looked for wp-config.php, wp-content/)"
+    exit 0
+fi
+
+# Determine scan directories (plugins, themes, mu-plugins)
+SCAN_DIRS=()
+for dir in wp-content/plugins wp-content/themes wp-content/mu-plugins; do
+    if [[ -d "$PROJECT_DIR/$dir" ]]; then
+        SCAN_DIRS+=("$PROJECT_DIR/$dir")
+    fi
+done
+
+# Also scan root for wp-config.php checks
+SCAN_DIRS+=("$PROJECT_DIR")
+
+# Helper: grep across all WordPress source directories
+scan_wp() {
+    local pattern="$1"
+    local limit="${2:-5}"
+    local results=""
+    for dir in "${SCAN_DIRS[@]}"; do
+        local matches
+        matches=$(grep -rn -E "$pattern" "$dir" --include="*.php" 2>/dev/null || true)
+        if [[ -n "$matches" ]]; then
+            results+="$matches"$'\n'
+        fi
+    done
+    echo "$results" | grep -v '^$' | head -"$limit"
+}
+
+# Helper: count matches
+scan_wp_count() {
+    local pattern="$1"
+    local total=0
+    for dir in "${SCAN_DIRS[@]}"; do
+        local count
+        count=$(grep -rn -E "$pattern" "$dir" --include="*.php" 2>/dev/null | wc -l || echo "0")
+        total=$((total + count))
+    done
+    echo "$total"
+}
+
+echo "--- WordPress Security Scanner ---"
+echo "Scanning: ${SCAN_DIRS[*]}"
+echo ""
+
+# === SA-WP-01: SQL injection — $wpdb without prepare() ===
+echo "=== Checking for SQL Injection ($wpdb without prepare) ==="
+# shellcheck disable=SC2016
+SQLI=$(scan_wp '\$wpdb\s*->\s*(query|get_results|get_row|get_var|get_col)\s*\(\s*["\x27]' 10)
+if [[ -n "$SQLI" ]]; then
+    echo "ERROR: \$wpdb queries without \$wpdb->prepare() found:"
+    echo "$SQLI" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No obvious SQL injection patterns detected"
+fi
+
+# === SA-WP-03: Unescaped output ===
+echo ""
+echo "=== Checking for Unescaped Output (XSS) ==="
+UNESCAPED=$(scan_wp 'echo\s+\$' 10 | grep -v 'esc_html\|esc_attr\|esc_url\|wp_kses\|absint\|intval' || true)
+if [[ -n "$UNESCAPED" ]]; then
+    echo "WARNING: Potential unescaped output found:"
+    echo "$UNESCAPED" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No obvious unescaped output detected"
+fi
+
+# === SA-WP-04: REST API without permission_callback ===
+echo ""
+echo "=== Checking for REST API Permission Issues ==="
+REST_ISSUES=$(scan_wp 'register_rest_route' 20 | grep -v 'permission_callback' || true)
+REST_TRUE=$(scan_wp 'permission_callback.*__return_true' 10)
+if [[ -n "$REST_ISSUES" || -n "$REST_TRUE" ]]; then
+    echo "ERROR: REST API routes without proper permission_callback:"
+    [[ -n "$REST_ISSUES" ]] && echo "$REST_ISSUES" | head -5
+    [[ -n "$REST_TRUE" ]] && echo "$REST_TRUE" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: REST API routes appear to have permission callbacks"
+fi
+
+# === SA-WP-06: Missing nonce verification ===
+echo ""
+echo "=== Checking for Missing Nonce Verification ==="
+# shellcheck disable=SC2016
+POST_USAGE=$(scan_wp_count '\$_POST\[')
+NONCE_COUNT=$(scan_wp_count 'wp_verify_nonce|check_ajax_referer|check_admin_referer')
+if [[ "$POST_USAGE" -gt 0 && "$NONCE_COUNT" -eq 0 ]]; then
+    echo "ERROR: \$_POST usage found but no nonce verification detected"
+    ERRORS=$((ERRORS + 1))
+elif [[ "$POST_USAGE" -gt "$((NONCE_COUNT * 3))" ]]; then
+    echo "WARNING: \$_POST used $POST_USAGE times but only $NONCE_COUNT nonce checks found"
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: Nonce verification appears proportional to POST usage"
+fi
+
+# === SA-WP-07: Direct file upload handling ===
+echo ""
+echo "=== Checking for Unsafe File Uploads ==="
+UPLOADS=$(scan_wp 'move_uploaded_file\s*\(' 5)
+if [[ -n "$UPLOADS" ]]; then
+    echo "ERROR: Direct move_uploaded_file() usage — use wp_handle_upload():"
+    echo "$UPLOADS" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No direct file upload handling detected"
+fi
+
+# === SA-WP-08: wp-config.php hardening ===
+echo ""
+echo "=== Checking wp-config.php Hardening ==="
+if [[ -f "$PROJECT_DIR/wp-config.php" ]]; then
+    DEBUG_ON=$(grep -n 'WP_DEBUG.*true' "$PROJECT_DIR/wp-config.php" 2>/dev/null || true)
+    if [[ -n "$DEBUG_ON" ]]; then
+        echo "WARNING: WP_DEBUG is enabled:"
+        echo "$DEBUG_ON"
+        WARNINGS=$((WARNINGS + 1))
+    fi
+
+    DEFAULT_PREFIX=$(grep -n "table_prefix.*=.*'wp_'" "$PROJECT_DIR/wp-config.php" 2>/dev/null || true)
+    if [[ -n "$DEFAULT_PREFIX" ]]; then
+        echo "WARNING: Default table prefix wp_ detected"
+        WARNINGS=$((WARNINGS + 1))
+    fi
+
+    DEFAULT_SALTS=$(grep -n 'put your unique phrase here' "$PROJECT_DIR/wp-config.php" 2>/dev/null || true)
+    if [[ -n "$DEFAULT_SALTS" ]]; then
+        echo "ERROR: Default security salts detected — generate unique salts"
+        ERRORS=$((ERRORS + 1))
+    fi
+else
+    echo "OK: wp-config.php not in scan directory"
+fi
+
+# === SA-WP-02: unserialize with user input ===
+echo ""
+echo "=== Checking for Object Injection (unserialize) ==="
+# shellcheck disable=SC2016
+UNSERIALIZE=$(scan_wp 'unserialize\s*\(\s*\$' 5)
+if [[ -n "$UNSERIALIZE" ]]; then
+    echo "ERROR: unserialize() with variable input — potential object injection:"
+    echo "$UNSERIALIZE" | head -5
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: No unsafe unserialize() calls detected"
+fi
+
+echo ""
+echo "--- WordPress Scanner Summary ---"
+echo "Errors: $ERRORS | Warnings: $WARNINGS"
+
+if [[ "$ERRORS" -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/skills/security-audit/scripts/scanners/wordpress.sh
+++ b/skills/security-audit/scripts/scanners/wordpress.sh
@@ -39,7 +39,7 @@ scan_wp() {
     local results=""
     for dir in "${SCAN_DIRS[@]}"; do
         local matches
-        matches=$(grep -rn -E "$pattern" "$dir" --include="*.php" 2>/dev/null || true)
+        matches=$(grep -rn -P "$pattern" "$dir" --include="*.php" 2>/dev/null || true)
         if [[ -n "$matches" ]]; then
             results+="$matches"$'\n'
         fi
@@ -53,7 +53,7 @@ scan_wp_count() {
     local total=0
     for dir in "${SCAN_DIRS[@]}"; do
         local count
-        count=$(grep -rn -E "$pattern" "$dir" --include="*.php" 2>/dev/null | wc -l || echo "0")
+        count=$(grep -rn -P "$pattern" "$dir" --include="*.php" 2>/dev/null | wc -l || echo "0")
         total=$((total + count))
     done
     echo "$total"

--- a/skills/security-audit/scripts/security-audit-dispatcher.sh
+++ b/skills/security-audit/scripts/security-audit-dispatcher.sh
@@ -6,6 +6,9 @@
 #
 # The dispatcher checks for indicator files (package.json, requirements.txt, go.mod, etc.)
 # and runs only the scanner modules relevant to the detected stack.
+#
+# Requires Bash 4+ for associative arrays in scripts/scanners/secrets.sh
+# and scripts/scanners/common.sh.
 
 set -e
 
@@ -13,8 +16,7 @@ PROJECT_DIR="${1:-.}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCANNERS_DIR="$SCRIPT_DIR/scanners"
 
-TOTAL_ERRORS=0
-TOTAL_WARNINGS=0
+FAILED_SCANNERS=0
 SCANNERS_RUN=0
 
 echo "=== Security Audit Dispatcher ==="
@@ -25,12 +27,14 @@ echo ""
 DETECTED_SCANNERS=()
 
 # PHP: composer.json or *.php files
-if [[ -f "$PROJECT_DIR/composer.json" ]] || find "$PROJECT_DIR" -maxdepth 3 -name "*.php" -print -quit 2>/dev/null | grep -q .; then
+if [[ -f "$PROJECT_DIR/composer.json" ]] \
+  || find "$PROJECT_DIR" -maxdepth 3 -name "*.php" -print -quit 2>/dev/null | grep -q .; then
     DETECTED_SCANNERS+=("php")
 fi
 
 # Python: requirements.txt, pyproject.toml, setup.py, Pipfile
-if [[ -f "$PROJECT_DIR/requirements.txt" ]] || [[ -f "$PROJECT_DIR/pyproject.toml" ]] || [[ -f "$PROJECT_DIR/setup.py" ]] || [[ -f "$PROJECT_DIR/Pipfile" ]]; then
+if [[ -f "$PROJECT_DIR/requirements.txt" ]] || [[ -f "$PROJECT_DIR/pyproject.toml" ]] \
+  || [[ -f "$PROJECT_DIR/setup.py" ]] || [[ -f "$PROJECT_DIR/Pipfile" ]]; then
     DETECTED_SCANNERS+=("python")
 fi
 
@@ -40,19 +44,23 @@ if [[ -f "$PROJECT_DIR/package.json" ]]; then
 fi
 
 # Node.js: package.json with server-side indicators
-if [[ -f "$PROJECT_DIR/package.json" ]]; then
-    if grep -q '"express"\|"fastify"\|"koa"\|"hapi"\|"nestjs"\|"node"\|"server"' "$PROJECT_DIR/package.json" 2>/dev/null; then
-        DETECTED_SCANNERS+=("nodejs")
-    fi
+if [[ -f "$PROJECT_DIR/package.json" ]] \
+  && grep -q '"express"\|"fastify"\|"koa"\|"hapi"\|"nestjs"\|"node"\|"server"' \
+         "$PROJECT_DIR/package.json" 2>/dev/null; then
+    DETECTED_SCANNERS+=("nodejs")
 fi
 
 # Java: pom.xml, build.gradle, *.java files
-if [[ -f "$PROJECT_DIR/pom.xml" ]] || [[ -f "$PROJECT_DIR/build.gradle" ]] || [[ -f "$PROJECT_DIR/build.gradle.kts" ]]; then
+if [[ -f "$PROJECT_DIR/pom.xml" ]] || [[ -f "$PROJECT_DIR/build.gradle" ]] \
+  || [[ -f "$PROJECT_DIR/build.gradle.kts" ]]; then
     DETECTED_SCANNERS+=("java")
 fi
 
-# C#/.NET: *.csproj, *.sln
-if find "$PROJECT_DIR" -maxdepth 2 -name "*.csproj" -print -quit 2>/dev/null | grep -q . || [[ -f "$PROJECT_DIR/*.sln" ]]; then
+# C#/.NET: *.csproj, *.sln — use find so both unquoted-glob and literal-string
+# variants are covered. Previous `[[ -f "$PROJECT_DIR/*.sln" ]]` tested for a
+# literal file named "*.sln".
+if find "$PROJECT_DIR" -maxdepth 2 \( -name "*.csproj" -o -name "*.sln" \) \
+     -print -quit 2>/dev/null | grep -q .; then
     DETECTED_SCANNERS+=("csharp")
 fi
 
@@ -71,17 +79,60 @@ if [[ -f "$PROJECT_DIR/Gemfile" ]]; then
     DETECTED_SCANNERS+=("ruby")
 fi
 
+# Android: AndroidManifest.xml or build.gradle with android plugin
+if find "$PROJECT_DIR" -maxdepth 4 -name "AndroidManifest.xml" -print -quit 2>/dev/null | grep -q .; then
+    DETECTED_SCANNERS+=("android")
+fi
+
+# iOS: *.xcodeproj or *.xcworkspace or Info.plist at a typical location
+if find "$PROJECT_DIR" -maxdepth 3 \( -name "*.xcodeproj" -o -name "*.xcworkspace" \) \
+     -print -quit 2>/dev/null | grep -q .; then
+    DETECTED_SCANNERS+=("ios")
+fi
+
+# Terraform / IaC: *.tf anywhere
+if find "$PROJECT_DIR" -maxdepth 4 -name "*.tf" -print -quit 2>/dev/null | grep -q .; then
+    DETECTED_SCANNERS+=("aws")     # aws.sh also scans Terraform for AWS resources
+    DETECTED_SCANNERS+=("azure")   # same for Azure
+    DETECTED_SCANNERS+=("gcp")     # same for GCP
+fi
+
+# WordPress: wp-config.php or wp-content/ (themes / plugins with WordPress stack)
+if [[ -f "$PROJECT_DIR/wp-config.php" ]] \
+  || [[ -d "$PROJECT_DIR/wp-content" ]] \
+  || find "$PROJECT_DIR" -maxdepth 4 -name "wp-config.php" -print -quit 2>/dev/null | grep -q .; then
+    DETECTED_SCANNERS+=("wordpress")
+fi
+
+# Drupal: composer.json with drupal/core OR sites/default/settings.php
+if { [[ -f "$PROJECT_DIR/composer.json" ]] \
+     && grep -q '"drupal/core"' "$PROJECT_DIR/composer.json" 2>/dev/null; } \
+  || find "$PROJECT_DIR" -maxdepth 4 -name "settings.php" -path "*/sites/default/*" \
+       -print -quit 2>/dev/null | grep -q .; then
+    DETECTED_SCANNERS+=("drupal")
+fi
+
+# Joomla: configuration.php at top level + administrator/ directory
+if [[ -f "$PROJECT_DIR/configuration.php" ]] && [[ -d "$PROJECT_DIR/administrator" ]]; then
+    DETECTED_SCANNERS+=("joomla")
+fi
+
 if [[ ${#DETECTED_SCANNERS[@]} -eq 0 ]]; then
     echo "No supported languages/frameworks detected."
-    echo "Looked for: composer.json, package.json, requirements.txt, pyproject.toml,"
-    echo "  go.mod, Cargo.toml, Gemfile, pom.xml, build.gradle, *.csproj"
+    echo "Dispatcher recognises: composer.json, package.json, requirements.txt,"
+    echo "  pyproject.toml, go.mod, Cargo.toml, Gemfile, pom.xml, build.gradle,"
+    echo "  *.csproj / *.sln, AndroidManifest.xml, *.xcodeproj, *.tf, wp-config.php,"
+    echo "  drupal/core in composer.json, Joomla configuration.php + administrator/."
     exit 0
 fi
 
 echo "Detected languages/frameworks: ${DETECTED_SCANNERS[*]}"
 echo ""
 
-# Run each detected scanner
+# Run each detected scanner. Scanner modules may exit with a non-zero error
+# count (their `ERRORS` counter), which is not a standard 0/1 exit contract.
+# We therefore count FAILED scanners (any non-zero exit), not the raw exit
+# code (which can overflow the 0-255 exit-code space if summed).
 for scanner in "${DETECTED_SCANNERS[@]}"; do
     SCANNER_SCRIPT="$SCANNERS_DIR/${scanner}.sh"
     if [[ -f "$SCANNER_SCRIPT" ]]; then
@@ -92,7 +143,9 @@ for scanner in "${DETECTED_SCANNERS[@]}"; do
         bash "$SCANNER_SCRIPT" "$PROJECT_DIR"
         SCANNER_EXIT=$?
         set -e
-        TOTAL_ERRORS=$((TOTAL_ERRORS + SCANNER_EXIT))
+        if [[ $SCANNER_EXIT -ne 0 ]]; then
+            FAILED_SCANNERS=$((FAILED_SCANNERS + 1))
+        fi
         SCANNERS_RUN=$((SCANNERS_RUN + 1))
         echo ""
     else
@@ -102,7 +155,7 @@ for scanner in "${DETECTED_SCANNERS[@]}"; do
     fi
 done
 
-# Always run secrets scanner regardless of detected languages
+# Always run secrets scanner regardless of detected languages.
 echo "========================================"
 echo "Running secrets scanner..."
 echo "========================================"
@@ -112,7 +165,9 @@ if [[ -f "$SECRETS_SCRIPT" ]]; then
     bash "$SECRETS_SCRIPT" "$PROJECT_DIR"
     SCANNER_EXIT=$?
     set -e
-    TOTAL_ERRORS=$((TOTAL_ERRORS + SCANNER_EXIT))
+    if [[ $SCANNER_EXIT -ne 0 ]]; then
+        FAILED_SCANNERS=$((FAILED_SCANNERS + 1))
+    fi
     SCANNERS_RUN=$((SCANNERS_RUN + 1))
     echo ""
 fi
@@ -120,12 +175,12 @@ fi
 # === Summary ===
 echo "========================================"
 echo "=== Dispatcher Summary ==="
-echo "Scanners run: $SCANNERS_RUN"
-echo "Total errors: $TOTAL_ERRORS"
+echo "Scanners run:    $SCANNERS_RUN"
+echo "Scanners failed: $FAILED_SCANNERS"
 echo "========================================"
 
-if [[ $TOTAL_ERRORS -gt 0 ]]; then
-    echo "Security audit FAILED with $TOTAL_ERRORS error(s)"
+if [[ $FAILED_SCANNERS -gt 0 ]]; then
+    echo "Security audit FAILED ($FAILED_SCANNERS scanner(s) reported findings)"
     exit 1
 else
     echo "Security audit PASSED"

--- a/skills/security-audit/scripts/security-audit-dispatcher.sh
+++ b/skills/security-audit/scripts/security-audit-dispatcher.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# Security Audit Dispatcher
+# Auto-detects languages/frameworks in a project and invokes relevant scanner modules.
+#
+# Usage: ./scripts/security-audit-dispatcher.sh /path/to/project
+#
+# The dispatcher checks for indicator files (package.json, requirements.txt, go.mod, etc.)
+# and runs only the scanner modules relevant to the detected stack.
+
+set -e
+
+PROJECT_DIR="${1:-.}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCANNERS_DIR="$SCRIPT_DIR/scanners"
+
+TOTAL_ERRORS=0
+TOTAL_WARNINGS=0
+SCANNERS_RUN=0
+
+echo "=== Security Audit Dispatcher ==="
+echo "Project: $PROJECT_DIR"
+echo ""
+
+# Detect languages/frameworks and collect scanner list
+DETECTED_SCANNERS=()
+
+# PHP: composer.json or *.php files
+if [[ -f "$PROJECT_DIR/composer.json" ]] || find "$PROJECT_DIR" -maxdepth 3 -name "*.php" -print -quit 2>/dev/null | grep -q .; then
+    DETECTED_SCANNERS+=("php")
+fi
+
+# Python: requirements.txt, pyproject.toml, setup.py, Pipfile
+if [[ -f "$PROJECT_DIR/requirements.txt" ]] || [[ -f "$PROJECT_DIR/pyproject.toml" ]] || [[ -f "$PROJECT_DIR/setup.py" ]] || [[ -f "$PROJECT_DIR/Pipfile" ]]; then
+    DETECTED_SCANNERS+=("python")
+fi
+
+# JavaScript/TypeScript: package.json
+if [[ -f "$PROJECT_DIR/package.json" ]]; then
+    DETECTED_SCANNERS+=("javascript")
+fi
+
+# Node.js: package.json with server-side indicators
+if [[ -f "$PROJECT_DIR/package.json" ]]; then
+    if grep -q '"express"\|"fastify"\|"koa"\|"hapi"\|"nestjs"\|"node"\|"server"' "$PROJECT_DIR/package.json" 2>/dev/null; then
+        DETECTED_SCANNERS+=("nodejs")
+    fi
+fi
+
+# Java: pom.xml, build.gradle, *.java files
+if [[ -f "$PROJECT_DIR/pom.xml" ]] || [[ -f "$PROJECT_DIR/build.gradle" ]] || [[ -f "$PROJECT_DIR/build.gradle.kts" ]]; then
+    DETECTED_SCANNERS+=("java")
+fi
+
+# C#/.NET: *.csproj, *.sln
+if find "$PROJECT_DIR" -maxdepth 2 -name "*.csproj" -print -quit 2>/dev/null | grep -q . || [[ -f "$PROJECT_DIR/*.sln" ]]; then
+    DETECTED_SCANNERS+=("csharp")
+fi
+
+# Go: go.mod
+if [[ -f "$PROJECT_DIR/go.mod" ]]; then
+    DETECTED_SCANNERS+=("go")
+fi
+
+# Rust: Cargo.toml
+if [[ -f "$PROJECT_DIR/Cargo.toml" ]]; then
+    DETECTED_SCANNERS+=("rust")
+fi
+
+# Ruby: Gemfile
+if [[ -f "$PROJECT_DIR/Gemfile" ]]; then
+    DETECTED_SCANNERS+=("ruby")
+fi
+
+if [[ ${#DETECTED_SCANNERS[@]} -eq 0 ]]; then
+    echo "No supported languages/frameworks detected."
+    echo "Looked for: composer.json, package.json, requirements.txt, pyproject.toml,"
+    echo "  go.mod, Cargo.toml, Gemfile, pom.xml, build.gradle, *.csproj"
+    exit 0
+fi
+
+echo "Detected languages/frameworks: ${DETECTED_SCANNERS[*]}"
+echo ""
+
+# Run each detected scanner
+for scanner in "${DETECTED_SCANNERS[@]}"; do
+    SCANNER_SCRIPT="$SCANNERS_DIR/${scanner}.sh"
+    if [[ -f "$SCANNER_SCRIPT" ]]; then
+        echo "========================================"
+        echo "Running $scanner scanner..."
+        echo "========================================"
+        set +e
+        bash "$SCANNER_SCRIPT" "$PROJECT_DIR"
+        SCANNER_EXIT=$?
+        set -e
+        TOTAL_ERRORS=$((TOTAL_ERRORS + SCANNER_EXIT))
+        SCANNERS_RUN=$((SCANNERS_RUN + 1))
+        echo ""
+    else
+        echo "Scanner module not yet available: $scanner (skipping)"
+        echo "  To add: create $SCANNERS_DIR/${scanner}.sh"
+        echo ""
+    fi
+done
+
+# Always run secrets scanner regardless of detected languages
+echo "========================================"
+echo "Running secrets scanner..."
+echo "========================================"
+SECRETS_SCRIPT="$SCANNERS_DIR/secrets.sh"
+if [[ -f "$SECRETS_SCRIPT" ]]; then
+    set +e
+    bash "$SECRETS_SCRIPT" "$PROJECT_DIR"
+    SCANNER_EXIT=$?
+    set -e
+    TOTAL_ERRORS=$((TOTAL_ERRORS + SCANNER_EXIT))
+    SCANNERS_RUN=$((SCANNERS_RUN + 1))
+    echo ""
+fi
+
+# === Summary ===
+echo "========================================"
+echo "=== Dispatcher Summary ==="
+echo "Scanners run: $SCANNERS_RUN"
+echo "Total errors: $TOTAL_ERRORS"
+echo "========================================"
+
+if [[ $TOTAL_ERRORS -gt 0 ]]; then
+    echo "Security audit FAILED with $TOTAL_ERRORS error(s)"
+    exit 1
+else
+    echo "Security audit PASSED"
+    exit 0
+fi


### PR DESCRIPTION
## Summary

Option **B** from the offline roadmap: turn this skill from a PHP/TYPO3-only auditor into a multi-language, indicator-file-driven dispatcher. The reference guides landed in #43–#54 become **enforceable**, not just documentation.

After this PR: **422 checkpoints (up from 113)**, **20 scanner scripts** (dispatcher + 19 per-ecosystem modules), **17 ecosystems detected** automatically (PHP, Python, JS/TS, Node.js, Java, C#, Go, Rust, Ruby, WordPress, Drupal, Joomla, Terraform-driven AWS/Azure/GCP, Android, iOS, plus an always-on secrets scan).

## What changed

### 1. Scanner architecture

- **`scripts/security-audit-dispatcher.sh`** — auto-detects the stack from indicator files (`composer.json`, `requirements.txt`, `go.mod`, `*.tf`, `AndroidManifest.xml`, `*.xcodeproj`, `wp-config.php`, `drupal/core` in composer, Joomla's `configuration.php + administrator/`, …) and runs only the matching `scripts/scanners/*.sh`. Always also runs `secrets.sh`.
- **`scripts/scanners/`** (19 modules): `common.sh`, `secrets.sh`, `php.sh`, `python.sh`, `javascript.sh`, `nodejs.sh`, `java.sh`, `csharp.sh`, `go.sh`, `rust.sh`, `ruby.sh`, `wordpress.sh`, `drupal.sh`, `joomla.sh`, `aws.sh`, `azure.sh`, `gcp.sh`, `android.sh`, `ios.sh`.

`scripts/scanners/php.sh` is derived from our existing `scripts/security-audit.sh` — keeping our richer emoji output, the PHPStan/Psalm taint-analysis note, and the explicit "no SCAN_DIRS" warning that the fork had pared down. The standalone `scripts/security-audit.sh` and `scripts/github-security-audit.sh` entry points are untouched for backward compatibility; the dispatcher is additive.

### 2. Checkpoints YAML

| Metric | Before | After |
|---|---|---|
| `mechanical:` entries | 68 | **377** |
| `llm_reviews:` entries | 45 | 45 |
| **Total** | **113** | **422** |

309 net-new `mechanical:` checkpoints added. Per-language, per-framework, cloud, mobile, CMS, IaC, API, and frontend coverage:

`SA-PY-*` (18), `SA-JS-*` (16), `SA-NODE-*` (15), `SA-RB-*` (15), `SA-RS-*` (12), `SA-JAVA-*` (12), `SA-GO-*` (12), `SA-CS-*` (12), `SA-AWS-*` (12), `SA-AZURE-*` / `SA-GCP-*` / `SA-IOS-*` / `SA-ANDROID-*` / `SA-WP-*` / `SA-IAC-*` (10 each), `SA-VUE-*` / `SA-SPRING-*` / `SA-REACT-*` / `SA-RAILS-*` / `SA-NEXT-*` / `SA-DOTNET-*` / `SA-DJANGO-*` / `SA-ANG-*` (8 each), plus smaller `SA-NUXT-*`, `SA-NEST-*`, `SA-BLAZOR-*`, `SA-FASTAPI-*`, `SA-EXPRESS-*`, `SA-FE-*`, `SA-FLASK-*`, `SA-API-*`, `SA-GIN-*`, `SA-JOOMLA-*`, `SA-DRUPAL-*` blocks.

**Overlap reconciliation**: 31 IDs were present in both upstream YAMLs. 30 are byte-identical. Only `SA-SAST-02` diverged — our definition (pattern `semgrep|opengrep`, from v2.6 commit `c9a83c4`) is the updated one and is kept; fork's older `semgrep`-only version was dropped.

### 3. SKILL.md

- Verification section leads with the dispatcher; falls back to `security-audit.sh` for PHP-only; `github-security-audit.sh` unchanged.
- Compressed Quick Patterns, Security Checklist, and GitHub Actions sections to keep the file at **500 words** exactly (the `validate-skill.sh` cap).
- 17-ecosystem claim now matches the dispatcher's actual detection set (9 languages + 5 cloud/IaC + 3 CMS).

## Review history (15 threads + 1 CI failure, all resolved)

**CI**:
- yamllint `empty-lines` at `checkpoints.yaml:3915` — the import script left consecutive blanks. Collapsed.

**Structural bug**:
- **The import script targeted `^llm:` but our file uses `llm_reviews:`** — 309 fork-imported `mechanical`-schema entries landed *after* the LLM section instead of within `mechanical:`. Moved them back. This was the root cause of the Copilot "schema mismatch" comment.

**Checkpoint logic**:
- `SA-IAC-01` inverted logic (Dockerfile with *no* `USER` directive was passing — it means the container runs as root, should fail). Rewrote as a per-file loop.
- `SA-IAC-09` / `SA-IAC-10` relied on bash globstar (`**/*.tf`), off by default. Switched to `grep --include='*.tf' .`.

**Dispatcher**:
- Coverage gap: detection added for Android, iOS, Terraform-driven AWS/Azure/GCP, WordPress, Drupal, Joomla — scanners for those existed but could never fire.
- `.sln` detection tested for a literal filename `*.sln` because the glob was inside a quoted `[[ -f "*.sln" ]]`. Now uses `find … \( -name '*.csproj' -o -name '*.sln' \)`.
- Summary counted failed scanners (any non-zero exit) instead of summing scanner exit codes — previous approach could overflow the 0–255 exit-code space.

**Scanner scripts**:
- **POSIX ERE `\s`/`\b` portability** — all 18 scanner modules switched from `grep -rn -E` to `grep -rn -P` (PCRE). Escapes now work as expected; on images without GNU grep, `-P` errors out cleanly instead of silently missing findings.
- **Bash 4+ requirements** — `common.sh` (uses `local -n` nameref) and `secrets.sh` (uses `declare -A`) now gate with `BASH_VERSINFO[0] < 4` and emit a clear error pointing at the Homebrew bash fix for macOS.
- `secrets.sh --include='*.{js,ts,…}'` expanded into 23 separate `--include` flags (GNU/BSD grep don't brace-expand inside `--include`).
- `secrets.sh find -maxdepth` precedence — wrapped `-name` alternations in `\( … \)` so `-maxdepth 3` applies to all of them.

## Skill-creator validation

| Check | Result |
|---|---|
| `validate-skill.sh` | **0 errors, 0 warnings** |
| yamllint `-d relaxed` | 0 errors (line-length warnings only) |
| YAML parses | `mechanical: 377, llm_reviews: 45` |
| SKILL.md word count | **500** (at cap) |
| Dispatcher smoke test | detects PHP + secrets on this repo, exits 0 |
| `scripts/scanners/php.sh` standalone | 0 errors / 2 warnings (pre-existing) |

## Provenance

Imported from [evandervecht/security-audit-skill](https://github.com/evandervecht/security-audit-skill) — dual-licensed MIT + CC-BY-SA-4.0 fork by [E van der Vecht](mailto:evandervecht@schubergphilis.com). Attribution in commit messages and a banner comment in `checkpoints.yaml`.

## Test plan

- [x] CI green (`Skill Validation` — word-count + yamllint + shellcheck + markdownlint)
- [x] `python3 -c "import yaml; yaml.safe_load(open('skills/security-audit/checkpoints.yaml'))"` (confirmed)
- [x] Dispatcher smoke test against this repo (confirmed)
- [x] `scripts/scanners/php.sh` standalone (confirmed)
- [x] SKILL.md ≤500 words (confirmed)

## Out of scope (follow-up)

- **`cve-database.md` import** — now that `SA-*` checkpoint cross-references resolve, the fork's CVE catalog is ready to import. Separate PR.