### PR TITLE
feat(references): import cve-database.md (CVE→checkpoint catalog, 113 CVEs)

### DIFF
--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -34,7 +34,7 @@ Security audit patterns (OWASP Top 10, LLM Top 10 2025, CWE Top 25 2025, CVSS v4
 - **API & Frontend**: api-security, frontend-security
 - **AI Agent**: llm-security (OWASP LLM Top 10 2025)
 - **Shared**: framework-security
-- **Modern Threats**: modern-attacks, cve-patterns
+- **Threats**: modern-attacks, cve-patterns, cve-database
 - **DevSecOps**: ci-security-pipeline, supply-chain-security, automated-scanning, gha-security
 - **Incident**: supply-chain-incident-response
 

--- a/skills/security-audit/references/cve-database.md
+++ b/skills/security-audit/references/cve-database.md
@@ -1,0 +1,1126 @@
+# CVE Database -- Checkpoint Mapping
+
+Maps known CVEs to detection checkpoints for automated correlation during security audits.
+
+## How to Use
+
+When a checkpoint fires, check this mapping to see if the detected pattern is associated with a known CVE. This enriches findings with authoritative vulnerability identifiers and CVSS scores.
+
+Cross-reference with:
+- `owasp-top10.md` for OWASP category context
+- `cwe-top25.md` for weakness taxonomy
+- `cvss-scoring.md` for scoring methodology
+
+---
+
+## Critical/High-Severity CVEs
+
+### Java
+
+#### Log4Shell (CVE-2021-44228)
+- **CVSS:** 10.0 (Critical)
+- **Affected:** Java (Log4j 2.0-beta9 through 2.14.1)
+- **CWE:** CWE-502 (Deserialization), CWE-917 (Expression Language Injection)
+- **Related Checkpoints:** SA-JAVA-03 (JNDI lookup)
+- **Detection:** `InitialContext().lookup` with user-controlled input; `${jndi:ldap://` in log messages
+- **Remediation:** Upgrade to Log4j 2.17.1+, set `log4j2.formatMsgNoLookups=true`
+
+#### Log4Shell bypass (CVE-2021-45046)
+- **CVSS:** 9.0 (Critical)
+- **Affected:** Java (Log4j 2.15.0)
+- **CWE:** CWE-917 (Expression Language Injection)
+- **Related Checkpoints:** SA-JAVA-03 (JNDI lookup)
+- **Detection:** Thread context map patterns with crafted JNDI lookups
+- **Remediation:** Upgrade to Log4j 2.17.1+; the 2.15.0 fix was incomplete
+
+#### Log4j RCE via deserialization (CVE-2021-44832)
+- **CVSS:** 6.6 (Medium)
+- **Affected:** Java (Log4j 2.0-beta7 through 2.17.0)
+- **CWE:** CWE-502 (Deserialization)
+- **Related Checkpoints:** SA-JAVA-03 (JNDI lookup), SA-JAVA-01 (ObjectInputStream)
+- **Detection:** JDBC Appender with JNDI data source configuration
+- **Remediation:** Upgrade to Log4j 2.17.1+
+
+#### Apache Struts RCE (CVE-2017-5638)
+- **CVSS:** 10.0 (Critical)
+- **Affected:** Java (Apache Struts 2.3.x before 2.3.32, 2.5.x before 2.5.10.1)
+- **CWE:** CWE-20 (Improper Input Validation)
+- **Related Checkpoints:** SA-JAVA-07 (Runtime.exec), SA-JAVA-04 (Class.forName)
+- **Detection:** OGNL expressions in `Content-Type` header; `%{...}` patterns in Struts configuration
+- **Remediation:** Upgrade Struts to 2.3.32+ or 2.5.10.1+
+
+#### Oracle WebLogic deserialization (CVE-2019-2725)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Java (Oracle WebLogic Server 10.3.6.0, 12.1.3.0)
+- **CWE:** CWE-502 (Deserialization of Untrusted Data)
+- **Related Checkpoints:** SA-JAVA-01 (ObjectInputStream deserialization)
+- **Detection:** `ObjectInputStream` with T3/IIOP protocol deserialization
+- **Remediation:** Apply Oracle Critical Patch Update, restrict T3 protocol access
+
+#### Spring4Shell (CVE-2022-22965)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Java (Spring Framework 5.3.0-5.3.17, 5.2.0-5.2.19, JDK 9+)
+- **CWE:** CWE-94 (Code Injection)
+- **Related Checkpoints:** SA-SPRING-07 (@ModelAttribute mass assignment), SA-SPRING-02 (SpEL injection)
+- **Detection:** `@ModelAttribute` binding to entity with class loader path; `class.module.classLoader` parameter
+- **Remediation:** Upgrade to Spring Framework 5.3.18+ or 5.2.20+
+
+#### Spring Cloud Function SpEL injection (CVE-2022-22963)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Java (Spring Cloud Function 3.1.6, 3.2.2, older)
+- **CWE:** CWE-917 (Expression Language Injection)
+- **Related Checkpoints:** SA-SPRING-02 (SpEL injection)
+- **Detection:** `spring.cloud.function.routing-expression` header with SpEL payload
+- **Remediation:** Upgrade to Spring Cloud Function 3.1.7+ or 3.2.3+
+
+#### JBoss deserialization (CVE-2017-12149)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Java (JBoss EAP 5.x)
+- **CWE:** CWE-502 (Deserialization of Untrusted Data)
+- **Related Checkpoints:** SA-JAVA-01 (ObjectInputStream deserialization)
+- **Detection:** `ObjectInputStream` in `InvokerTransformer` chain; `/invoker/readonly` endpoint
+- **Remediation:** Upgrade JBoss, remove `http-invoker.sar` or restrict access
+
+#### Apache Commons Collections deserialization (CVE-2015-4852)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Java (Apache Commons Collections 3.x, 4.0)
+- **CWE:** CWE-502 (Deserialization of Untrusted Data)
+- **Related Checkpoints:** SA-JAVA-01 (ObjectInputStream deserialization)
+- **Detection:** `InvokerTransformer`, `ChainedTransformer`, `ConstantTransformer` gadget chains
+- **Remediation:** Upgrade to Commons Collections 3.2.2+ or 4.1+, use SerializationUtils allowlist
+
+#### Jackson Databind deserialization (CVE-2017-7525)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Java (Jackson Databind before 2.6.7.1, 2.7.9.1, 2.8.9)
+- **CWE:** CWE-502 (Deserialization of Untrusted Data)
+- **Related Checkpoints:** SA-SPRING-08 (Jackson default typing), SA-JAVA-01 (deserialization)
+- **Detection:** `enableDefaultTyping()` or `@JsonTypeInfo(use=Id.CLASS)` with polymorphic deserialization
+- **Remediation:** Upgrade Jackson Databind, avoid `enableDefaultTyping()`, use `@JsonTypeInfo(use=Id.NAME)`
+
+#### Apache Struts 2 namespace RCE (CVE-2018-11776)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Java (Apache Struts 2.3-2.3.34, 2.5-2.5.16)
+- **CWE:** CWE-20 (Improper Input Validation)
+- **Related Checkpoints:** SA-JAVA-04 (Class.forName), SA-JAVA-07 (Runtime.exec)
+- **Detection:** OGNL injection via namespace, result type without namespace, wildcard method in config
+- **Remediation:** Upgrade to Struts 2.3.35+ or 2.5.17+; always define namespaces for packages
+
+#### Spring Security auth bypass (CVE-2022-22978)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Java (Spring Security 5.5.x before 5.5.7, 5.6.x before 5.6.4)
+- **CWE:** CWE-863 (Incorrect Authorization)
+- **Related Checkpoints:** SA-SPRING-01 (permitAll overreach)
+- **Detection:** RegexRequestMatcher with `.` pattern; `.` does not match newline by default
+- **Remediation:** Upgrade to Spring Security 5.5.7+ or 5.6.4+
+
+#### Apache Tomcat Ghostcat (CVE-2020-1938)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Java (Apache Tomcat all versions before 9.0.31, 8.5.51, 7.0.100)
+- **CWE:** CWE-200 (Information Exposure)
+- **Related Checkpoints:** SA-JAVA-06 (XML parsing), SA-IAC-01 (container config)
+- **Detection:** AJP connector on port 8009 exposed without secret
+- **Remediation:** Upgrade Tomcat; set `requiredSecret` on AJP connector or disable it
+
+---
+
+### Python
+
+#### Jinja2 sandbox escape (CVE-2019-10906)
+- **CVSS:** 8.6 (High)
+- **Affected:** Python (Jinja2 before 2.10.1)
+- **CWE:** CWE-693 (Protection Mechanism Failure)
+- **Related Checkpoints:** SA-PY-14 (Template SSTI), SA-PY-03 (exec), SA-FLASK-01 (render_template_string)
+- **Detection:** `SandboxedEnvironment` with crafted `str.format_map` to access internal attributes
+- **Remediation:** Upgrade Jinja2 to 2.10.1+, never pass user input directly to Template()
+
+#### PyYAML arbitrary code execution (CVE-2020-1747)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Python (PyYAML before 5.3.1)
+- **CWE:** CWE-502 (Deserialization of Untrusted Data)
+- **Related Checkpoints:** SA-PY-06 (yaml.load)
+- **Detection:** `yaml.load()` or `yaml.full_load()` with `!!python/object` tag in input
+- **Remediation:** Use `yaml.safe_load()` exclusively; upgrade PyYAML to 5.3.1+
+
+#### PyYAML unsafe load (CVE-2017-18342)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Python (PyYAML before 5.1)
+- **CWE:** CWE-502 (Deserialization of Untrusted Data)
+- **Related Checkpoints:** SA-PY-06 (yaml.load)
+- **Detection:** `yaml.load()` without `Loader=SafeLoader`
+- **Remediation:** Always use `yaml.safe_load()` or pass `Loader=yaml.SafeLoader`
+
+#### Python urllib CRLF injection (CVE-2019-9740)
+- **CVSS:** 6.1 (Medium)
+- **Affected:** Python (CPython before 2.7.17, 3.x before 3.7.4)
+- **CWE:** CWE-113 (HTTP Response Splitting)
+- **Related Checkpoints:** SA-PY-04 (subprocess shell=True), SA-PY-05 (os.system)
+- **Detection:** `urllib.request.urlopen()` with user-controlled URL containing CRLF characters
+- **Remediation:** Upgrade Python; validate and sanitize URLs before passing to urllib
+
+#### Python urllib CRLF injection (CVE-2019-9947)
+- **CVSS:** 6.1 (Medium)
+- **Affected:** Python (CPython before 2.7.17, 3.x before 3.7.4)
+- **CWE:** CWE-113 (HTTP Response Splitting)
+- **Related Checkpoints:** SA-PY-04 (subprocess shell=True), SA-PY-05 (os.system)
+- **Detection:** `urllib.request.Request` with crafted URL path containing encoded CRLF
+- **Remediation:** Upgrade Python; validate URL path components
+
+#### urllib.parse URL parsing bypass (CVE-2022-0391)
+- **CVSS:** 7.5 (High)
+- **Affected:** Python (CPython before 3.9.10)
+- **CWE:** CWE-20 (Improper Input Validation)
+- **Related Checkpoints:** SA-PY-04 (subprocess shell=True), SA-PY-12 (__import__)
+- **Detection:** `urllib.parse.urlparse()` with `\r` and `\n` in URL to bypass allow-list checks
+- **Remediation:** Upgrade Python to 3.9.10+; strip control characters from URLs before parsing
+
+#### Python ctypes buffer overflow (CVE-2021-3177)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Python (CPython before 3.6.13, 3.7.10, 3.8.8, 3.9.2)
+- **CWE:** CWE-120 (Buffer Copy without Checking Size)
+- **Related Checkpoints:** SA-PY-03 (exec), SA-PY-02 (eval)
+- **Detection:** `ctypes.c_double.from_param()` with crafted float values
+- **Remediation:** Upgrade Python to patched version
+
+#### Paramiko auth bypass (CVE-2023-48795)
+- **CVSS:** 5.9 (Medium)
+- **Affected:** Python (Paramiko, OpenSSH, PuTTY -- Terrapin attack)
+- **CWE:** CWE-354 (Improper Validation of Integrity Check Value)
+- **Related Checkpoints:** SA-DEP-01 (dependency audit)
+- **Detection:** SSH connections using ChaCha20-Poly1305 or CBC-EtM cipher suites
+- **Remediation:** Upgrade to Paramiko 3.4.0+, OpenSSH 9.6+; disable vulnerable cipher suites
+
+#### Pillow buffer overflow (CVE-2021-25287)
+- **CVSS:** 9.1 (Critical)
+- **Affected:** Python (Pillow before 8.2.0)
+- **CWE:** CWE-125 (Out-of-bounds Read)
+- **Related Checkpoints:** SA-DEP-01 (dependency audit)
+- **Detection:** Processing crafted JPEG 2000 images via `Image.open()`
+- **Remediation:** Upgrade Pillow to 8.2.0+
+
+#### Django SQL injection via QuerySet.order_by (CVE-2021-35042)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Python (Django before 3.1.13, 3.2.5)
+- **CWE:** CWE-89 (SQL Injection)
+- **Related Checkpoints:** SA-DJANGO-01 (raw/extra/cursor.execute SQL injection)
+- **Detection:** `QuerySet.order_by()` with user-supplied column names
+- **Remediation:** Upgrade Django; validate ordering fields against an explicit allowlist
+
+#### Django SQL injection via JSONField (CVE-2019-14234)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Python (Django before 1.11.23, 2.1.11, 2.2.4)
+- **CWE:** CWE-89 (SQL Injection)
+- **Related Checkpoints:** SA-DJANGO-01 (ORM injection)
+- **Detection:** `JSONField`/`HStoreField` key lookups with user-controlled key paths
+- **Remediation:** Upgrade Django; validate JSONField key names
+
+#### Flask debug mode RCE (CVE-2015-5306)
+- **CVSS:** 7.5 (High)
+- **Affected:** Python (Flask/Werkzeug debug mode)
+- **CWE:** CWE-94 (Code Injection)
+- **Related Checkpoints:** SA-FLASK-01 (render_template_string SSTI)
+- **Detection:** `app.run(debug=True)` or `FLASK_DEBUG=1` in production
+- **Remediation:** Never run Flask with debug mode in production; use `FLASK_ENV=production`
+
+---
+
+### JavaScript / Node.js
+
+#### Lodash prototype pollution (CVE-2019-10744)
+- **CVSS:** 9.1 (Critical)
+- **Affected:** JavaScript (Lodash before 4.17.12)
+- **CWE:** CWE-1321 (Prototype Pollution)
+- **Related Checkpoints:** SA-JS-06 (__proto__ prototype pollution)
+- **Detection:** `_.defaultsDeep()` with user-controlled nested objects containing `__proto__`
+- **Remediation:** Upgrade Lodash to 4.17.12+; freeze `Object.prototype`
+
+#### Lodash command injection (CVE-2021-23337)
+- **CVSS:** 7.2 (High)
+- **Affected:** JavaScript (Lodash before 4.17.21)
+- **CWE:** CWE-77 (Command Injection)
+- **Related Checkpoints:** SA-JS-01 (eval), SA-NODE-01 (child_process.exec)
+- **Detection:** `_.template()` with user-controlled template options (variable, imports)
+- **Remediation:** Upgrade Lodash to 4.17.21+; do not pass user input to template options
+
+#### jQuery prototype pollution (CVE-2019-11358)
+- **CVSS:** 6.1 (Medium)
+- **Affected:** JavaScript (jQuery before 3.4.0)
+- **CWE:** CWE-1321 (Prototype Pollution)
+- **Related Checkpoints:** SA-JS-06 (__proto__ prototype pollution)
+- **Detection:** `jQuery.extend(true, {}, ...)` with user-controlled nested objects
+- **Remediation:** Upgrade jQuery to 3.4.0+
+
+#### jQuery XSS via HTML injection (CVE-2020-11022)
+- **CVSS:** 6.1 (Medium)
+- **Affected:** JavaScript (jQuery 1.2 to 3.5.0)
+- **CWE:** CWE-79 (Cross-site Scripting)
+- **Related Checkpoints:** SA-JS-02 (innerHTML), SA-JS-03 (document.write)
+- **Detection:** `$("<tag>")` or `.html()` with user-controlled HTML containing `<option>` or `<style>` tags
+- **Remediation:** Upgrade jQuery to 3.5.0+; sanitize HTML with DOMPurify before insertion
+
+#### EJS SSTI/RCE (CVE-2022-29078)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** JavaScript (EJS before 3.1.7)
+- **CWE:** CWE-94 (Code Injection)
+- **Related Checkpoints:** SA-JS-01 (eval), SA-NODE-01 (child_process.exec), SA-EXPRESS-02 (user input in command)
+- **Detection:** EJS `render()` with user-controlled options object (settings, view options, outputFunctionName)
+- **Remediation:** Upgrade EJS to 3.1.7+; never pass user input to render options
+
+#### systeminformation command injection (CVE-2021-21315)
+- **CVSS:** 7.2 (High)
+- **Affected:** Node.js (systeminformation before 5.3.1)
+- **CWE:** CWE-78 (OS Command Injection)
+- **Related Checkpoints:** SA-NODE-01 (child_process.exec command injection)
+- **Detection:** `si.inetLatency()`, `si.inetChecksite()` with user-controlled hostname
+- **Remediation:** Upgrade systeminformation to 5.3.1+; validate hostnames
+
+#### Lodash merge prototype pollution (CVE-2018-16487)
+- **CVSS:** 5.6 (Medium)
+- **Affected:** JavaScript (Lodash before 4.17.11)
+- **CWE:** CWE-1321 (Prototype Pollution)
+- **Related Checkpoints:** SA-JS-06 (__proto__ prototype pollution)
+- **Detection:** `_.merge()`, `_.mergeWith()`, `_.defaultsDeep()` with `__proto__` payload
+- **Remediation:** Upgrade Lodash to 4.17.11+
+
+#### PostCSS ReDoS (CVE-2023-44270)
+- **CVSS:** 5.3 (Medium)
+- **Affected:** JavaScript (PostCSS before 8.4.31)
+- **CWE:** CWE-1333 (Inefficient Regular Expression)
+- **Related Checkpoints:** SA-JS-05 (Math.random -- general security lint), SA-DEP-01 (dependency audit)
+- **Detection:** Crafted CSS input with deeply nested brackets causing backtracking
+- **Remediation:** Upgrade PostCSS to 8.4.31+
+
+#### Express.js path traversal (CVE-2024-29041)
+- **CVSS:** 6.1 (Medium)
+- **Affected:** Node.js (Express before 4.19.2)
+- **CWE:** CWE-601 (Open Redirect)
+- **Related Checkpoints:** SA-EXPRESS-01 (middleware ordering), SA-NODE-02 (fs with user input)
+- **Detection:** `res.redirect()` with user-controlled URL lacking origin validation
+- **Remediation:** Upgrade Express to 4.19.2+; validate redirect targets against allowlist
+
+#### Node.js HTTP request smuggling (CVE-2022-32213)
+- **CVSS:** 6.5 (Medium)
+- **Affected:** Node.js (before 14.20.0, 16.16.0, 18.5.0)
+- **CWE:** CWE-444 (HTTP Request Smuggling)
+- **Related Checkpoints:** SA-NODE-07 (CRLF injection)
+- **Detection:** HTTP request with `Transfer-Encoding: chunked` and inconsistent `Content-Length`
+- **Remediation:** Upgrade Node.js; use reverse proxy with strict HTTP parsing
+
+#### minimist prototype pollution (CVE-2021-44906)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** JavaScript (minimist before 1.2.6)
+- **CWE:** CWE-1321 (Prototype Pollution)
+- **Related Checkpoints:** SA-JS-06 (__proto__ prototype pollution), SA-DEP-01 (dependency audit)
+- **Detection:** CLI argument parsing with `--__proto__.polluted=true`
+- **Remediation:** Upgrade minimist to 1.2.6+
+
+#### Axios SSRF (CVE-2023-45857)
+- **CVSS:** 6.5 (Medium)
+- **Affected:** JavaScript (Axios before 1.6.0)
+- **CWE:** CWE-352 (CSRF)
+- **Related Checkpoints:** SA-NODE-07 (user input in headers), SA-DEP-01 (dependency audit)
+- **Detection:** Axios `withXSRFToken` leaking XSRF token to third-party domains
+- **Remediation:** Upgrade Axios to 1.6.0+
+
+#### json-schema prototype pollution (CVE-2021-3918)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** JavaScript (json-schema before 0.4.0)
+- **CWE:** CWE-1321 (Prototype Pollution)
+- **Related Checkpoints:** SA-JS-06 (__proto__ prototype pollution)
+- **Detection:** `json-schema` validation with crafted `__proto__` properties
+- **Remediation:** Upgrade json-schema to 0.4.0+
+
+#### ua-parser-js supply chain attack (CVE-2021-43616)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** JavaScript (ua-parser-js 0.7.29, 0.8.0, 1.0.0)
+- **CWE:** CWE-506 (Embedded Malicious Code)
+- **Related Checkpoints:** SA-DEP-01 (dependency audit), SA-SC-01 (supply chain)
+- **Detection:** ua-parser-js version 0.7.29, 0.8.0, or 1.0.0 in package-lock.json
+- **Remediation:** Upgrade to ua-parser-js 0.7.30+, 0.8.1+, or 1.0.1+
+
+---
+
+### PHP
+
+#### PHP-FPM RCE (CVE-2019-11043)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** PHP (PHP-FPM with Nginx, PHP 7.1.x-7.3.x)
+- **CWE:** CWE-120 (Buffer Overflow)
+- **Related Checkpoints:** SA-IAC-01 (container config), SA-08 (LIBXML_NOENT)
+- **Detection:** Nginx `fastcgi_split_path_info` regex with `^` anchor and PATH_INFO manipulation
+- **Remediation:** Upgrade PHP to 7.2.24+ or 7.3.11+; fix Nginx fastcgi_split_path_info regex
+
+#### PHP CGI argument injection (CVE-2012-1823)
+- **CVSS:** 7.5 (High)
+- **Affected:** PHP (before 5.3.12, 5.4.2 in CGI mode)
+- **CWE:** CWE-88 (Argument Injection)
+- **Related Checkpoints:** SA-IAC-01 (container config), SA-10 ($_GET direct use)
+- **Detection:** PHP in CGI mode with query string arguments like `?-s` or `?-d+allow_url_include=on`
+- **Remediation:** Upgrade PHP; do not use CGI mode (use PHP-FPM)
+
+#### PHP CGI argument injection Windows (CVE-2024-4577)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** PHP (before 8.1.29, 8.2.20, 8.3.8 on Windows)
+- **CWE:** CWE-78 (OS Command Injection)
+- **Related Checkpoints:** SA-IAC-01 (container config)
+- **Detection:** PHP CGI on Windows with Best-Fit character conversion bypassing CVE-2012-1823 fix
+- **Remediation:** Upgrade PHP; migrate to PHP-FPM; avoid CGI on Windows
+
+#### PHP phar buffer overflow (CVE-2023-3824)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** PHP (before 8.0.30, 8.1.22, 8.2.8)
+- **CWE:** CWE-119 (Buffer Overflow)
+- **Related Checkpoints:** SA-DEP-01 (dependency audit)
+- **Detection:** Processing crafted PHAR files via `phar://` stream wrapper
+- **Remediation:** Upgrade PHP; disable `phar://` wrapper in production via `allow_url_fopen`
+
+#### HTTPoxy (CVE-2016-5385)
+- **CVSS:** 8.1 (High)
+- **Affected:** PHP, Python, Go (CGI/FastCGI applications)
+- **CWE:** CWE-807 (Reliance on Untrusted Inputs)
+- **Related Checkpoints:** SA-10 ($_GET), SA-IAC-01 (container config)
+- **Detection:** Application reads `HTTP_PROXY` environment variable set by `Proxy:` request header
+- **Remediation:** Unset `HTTP_PROXY` in web server config; use `RequestHeader unset Proxy` in Apache
+
+#### PHP unserialize object injection (CVE-2015-0231)
+- **CVSS:** 7.5 (High)
+- **Affected:** PHP (before 5.4.37, 5.5.21, 5.6.5)
+- **CWE:** CWE-416 (Use After Free)
+- **Related Checkpoints:** SA-WP-02 (unserialize with user input), SA-11 (unserialize)
+- **Detection:** `unserialize()` with user-controlled input triggering `__destruct`/`__wakeup` chains
+- **Remediation:** Upgrade PHP; use `json_decode()` instead of `unserialize()` for user data
+
+#### Laravel debug mode RCE (CVE-2021-3129)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** PHP (Laravel with Ignition before 2.5.2)
+- **CWE:** CWE-94 (Code Injection)
+- **Related Checkpoints:** SA-02 (.env in .gitignore), SA-03 (.env not committed)
+- **Detection:** `APP_DEBUG=true` with Ignition error page; `_ignition/execute-solution` endpoint
+- **Remediation:** Set `APP_DEBUG=false` in production; upgrade Ignition to 2.5.2+
+
+#### Drupal Drupalgeddon 2 (CVE-2018-7600)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** PHP (Drupal before 7.58, 8.x before 8.3.9, 8.4.x before 8.4.6, 8.5.x before 8.5.1)
+- **CWE:** CWE-94 (Code Injection)
+- **Related Checkpoints:** SA-DRUPAL-01 (SQL injection), SA-DRUPAL-02 (#markup XSS)
+- **Detection:** Form API render array injection via `#` prefixed keys in request parameters
+- **Remediation:** Upgrade Drupal to patched version
+
+#### Drupal Drupalgeddon 3 (CVE-2018-7602)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** PHP (Drupal before 7.59, 8.4.8, 8.5.3)
+- **CWE:** CWE-94 (Code Injection)
+- **Related Checkpoints:** SA-DRUPAL-01 (SQL injection), SA-DRUPAL-03 (unescaped markup)
+- **Detection:** Authenticated RCE via manipulated form action URLs
+- **Remediation:** Upgrade Drupal; apply SA-CORE-2018-004 patch
+
+---
+
+### C# / .NET
+
+#### .NET BinaryFormatter RCE (CVE-2017-8565)
+- **CVSS:** 8.1 (High)
+- **Affected:** C# (.NET Framework, PowerShell)
+- **CWE:** CWE-502 (Deserialization of Untrusted Data)
+- **Related Checkpoints:** SA-CS-01 (BinaryFormatter deserialization)
+- **Detection:** `BinaryFormatter.Deserialize()` or `new BinaryFormatter()` with untrusted input
+- **Remediation:** Use `System.Text.Json` or `JsonSerializer`; BinaryFormatter is obsolete in .NET 7+
+
+#### .NET DataSet deserialization (CVE-2020-0646)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** C# (.NET Framework before 4.8)
+- **CWE:** CWE-502 (Deserialization of Untrusted Data)
+- **Related Checkpoints:** SA-CS-01 (BinaryFormatter), SA-CS-02 (NetDataContractSerializer)
+- **Detection:** `DataSet`/`DataTable` deserialization from untrusted XML; `ReadXml()` with remote input
+- **Remediation:** Apply .NET Framework security update; avoid `DataSet.ReadXml()` with untrusted data
+
+#### .NET information disclosure (CVE-2022-34716)
+- **CVSS:** 5.9 (Medium)
+- **Affected:** C# (.NET 6.0 before 6.0.8, .NET Core 3.1 before 3.1.28)
+- **CWE:** CWE-200 (Information Exposure)
+- **Related Checkpoints:** SA-DEP-01 (dependency audit)
+- **Detection:** XML signature validation with crafted ECDSA signatures
+- **Remediation:** Apply .NET security update; upgrade to .NET 6.0.8+
+
+#### .NET Remote Code Execution via XSLT (CVE-2022-41089)
+- **CVSS:** 8.8 (High)
+- **Affected:** C# (.NET Framework, .NET 6/7)
+- **CWE:** CWE-94 (Code Injection)
+- **Related Checkpoints:** SA-CS-04 (XmlDocument), SA-CS-01 (deserialization)
+- **Detection:** `XslCompiledTransform.Load()` with untrusted XSLT stylesheet
+- **Remediation:** Apply .NET security update; validate XSLT sources; disable script in XsltSettings
+
+#### ASP.NET Core open redirect (CVE-2019-0548)
+- **CVSS:** 5.4 (Medium)
+- **Affected:** C# (ASP.NET Core 2.1, 2.2)
+- **CWE:** CWE-601 (URL Redirection)
+- **Related Checkpoints:** SA-DOTNET-01 (middleware ordering)
+- **Detection:** `LocalRedirect()` or `Redirect()` with user-controlled return URL
+- **Remediation:** Upgrade ASP.NET Core; use `Url.IsLocalUrl()` validation
+
+#### .NET SignalR denial of service (CVE-2024-21404)
+- **CVSS:** 7.5 (High)
+- **Affected:** C# (.NET 6, 7, 8)
+- **CWE:** CWE-400 (Uncontrolled Resource Consumption)
+- **Related Checkpoints:** SA-DOTNET-05 (CORS allows any origin)
+- **Detection:** Crafted SignalR messages causing excessive memory allocation
+- **Remediation:** Apply .NET security update for February 2024
+
+---
+
+### Go
+
+#### Go net/http excessive memory (CVE-2022-41717)
+- **CVSS:** 5.3 (Medium)
+- **Affected:** Go (before 1.18.9, 1.19.4)
+- **CWE:** CWE-770 (Allocation without Limits)
+- **Related Checkpoints:** SA-GO-08 (HTTP request SSRF), SA-GO-09 (logging)
+- **Detection:** HTTP/2 HPACK header table entries causing excessive memory consumption
+- **Remediation:** Upgrade Go to 1.18.9+ or 1.19.4+
+
+#### HTTP/2 Rapid Reset DoS (CVE-2023-39325)
+- **CVSS:** 7.5 (High)
+- **Affected:** Go (golang.org/x/net before 0.17.0)
+- **CWE:** CWE-400 (Uncontrolled Resource Consumption)
+- **Related Checkpoints:** SA-GO-08 (HTTP request handling), SA-DEP-01 (dependency audit)
+- **Detection:** HTTP/2 rapid stream reset causing unbounded goroutine creation
+- **Remediation:** Upgrade golang.org/x/net to 0.17.0+; Go 1.21.3+
+
+#### Go net/netip parsing issue (CVE-2024-24790)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Go (before 1.21.11, 1.22.4)
+- **CWE:** CWE-180 (Incorrect Behavior Order)
+- **Related Checkpoints:** SA-GO-05 (filepath.Join user input), SA-GO-08 (SSRF)
+- **Detection:** `net/netip` incorrectly handling IPv4-mapped IPv6 addresses
+- **Remediation:** Upgrade Go to 1.21.11+ or 1.22.4+
+
+#### Go path/filepath Clean bypass (CVE-2023-45283)
+- **CVSS:** 7.5 (High)
+- **Affected:** Go (before 1.20.11, 1.21.4 on Windows)
+- **CWE:** CWE-22 (Path Traversal)
+- **Related Checkpoints:** SA-GO-05 (filepath.Join user input)
+- **Detection:** `filepath.Clean()` not recognizing `\\?\` prefix paths on Windows
+- **Remediation:** Upgrade Go to 1.20.11+ or 1.21.4+
+
+#### Go crypto/tls session ticket key rotation (CVE-2024-45337)
+- **CVSS:** 9.1 (Critical)
+- **Affected:** Go (golang.org/x/crypto before 0.31.0)
+- **CWE:** CWE-285 (Improper Authorization)
+- **Related Checkpoints:** SA-GO-06 (InsecureSkipVerify), SA-DEP-01 (dependency audit)
+- **Detection:** SSH server with `PublicKeyCallback` returning nil error without verifying key
+- **Remediation:** Upgrade golang.org/x/crypto to 0.31.0+
+
+#### Go archive/zip path traversal (CVE-2022-41723)
+- **CVSS:** 7.5 (High)
+- **Affected:** Go (before 1.19.6, 1.20.1)
+- **CWE:** CWE-22 (Path Traversal)
+- **Related Checkpoints:** SA-GO-05 (filepath.Join user input)
+- **Detection:** HTTP/2 HPACK decoding causing excessive CPU/memory; crafted compressed frames
+- **Remediation:** Upgrade Go; use `golang.org/x/net` v0.7.0+
+
+---
+
+### Ruby
+
+#### Rails YAML deserialization (CVE-2013-0156)
+- **CVSS:** 10.0 (Critical)
+- **Affected:** Ruby (Ruby on Rails before 3.0.19, 3.1.10, 3.2.11)
+- **CWE:** CWE-502 (Deserialization of Untrusted Data)
+- **Related Checkpoints:** SA-RB-05 (YAML.load), SA-RAILS-01 (mass assignment)
+- **Detection:** YAML/XML parameter parsing with `!!ruby/object` tags
+- **Remediation:** Upgrade Rails; disable YAML and XML request parsing if not needed
+
+#### Rails file content disclosure (CVE-2019-5418)
+- **CVSS:** 7.5 (High)
+- **Affected:** Ruby (Action View in Rails before 5.2.2.1, 5.1.6.2, 5.0.7.2)
+- **CWE:** CWE-200 (Information Exposure)
+- **Related Checkpoints:** SA-RAILS-05 (send_file path traversal), SA-RAILS-02 (html_safe)
+- **Detection:** `Accept: ../../../../etc/passwd{{` header triggering file content rendering
+- **Remediation:** Upgrade Rails to 5.2.2.1+; use `config.action_dispatch.show_detailed_exceptions = false`
+
+#### Rails MemCacheStore deserialization (CVE-2020-8165)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Ruby (Rails before 5.2.4.3, 6.0.3.1)
+- **CWE:** CWE-502 (Deserialization of Untrusted Data)
+- **Related Checkpoints:** SA-RB-04 (Marshal.load deserialization)
+- **Detection:** `Rails.cache.fetch()` deserializing objects stored by untrusted input via `Rails.cache.write(key, raw_user_input)`
+- **Remediation:** Upgrade Rails to 5.2.4.3+ or 6.0.3.1+; validate cached data types
+
+#### Rails ReDoS in ActiveSupport (CVE-2023-22796)
+- **CVSS:** 7.5 (High)
+- **Affected:** Ruby (ActiveSupport before 7.0.4.1)
+- **CWE:** CWE-1333 (Inefficient Regular Expression)
+- **Related Checkpoints:** SA-RB-06 (ERB.new template), SA-DEP-01 (dependency audit)
+- **Detection:** Crafted input to `ActiveSupport::Inflector.transliterate` causing backtracking
+- **Remediation:** Upgrade ActiveSupport to 7.0.4.1+
+
+#### Rails open redirect (CVE-2023-22797)
+- **CVSS:** 6.1 (Medium)
+- **Affected:** Ruby (Action Pack in Rails 7.0.0-7.0.4)
+- **CWE:** CWE-601 (URL Redirection)
+- **Related Checkpoints:** SA-RAILS-02 (html_safe), SA-RAILS-04 (CSRF)
+- **Detection:** `redirect_to` with user-controlled URL without host verification
+- **Remediation:** Upgrade Rails to 7.0.4.1+; use `only_path: true` or validate host
+
+#### Rack denial of service via multipart (CVE-2023-27530)
+- **CVSS:** 7.5 (High)
+- **Affected:** Ruby (Rack before 2.2.6.3, 3.0.4.1)
+- **CWE:** CWE-400 (Uncontrolled Resource Consumption)
+- **Related Checkpoints:** SA-DEP-01 (dependency audit)
+- **Detection:** Multipart request with unbounded number of parts consuming memory
+- **Remediation:** Upgrade Rack to 2.2.6.3+ or 3.0.4.1+
+
+---
+
+### WordPress
+
+#### WordPress social login auth bypass (CVE-2023-2982)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** WordPress (MiniOrange Social Login plugin before 7.6.5)
+- **CWE:** CWE-287 (Improper Authentication)
+- **Related Checkpoints:** SA-WP-04 (REST route without permission_callback)
+- **Detection:** Authentication bypass via crafted social login token without proper verification
+- **Remediation:** Upgrade MiniOrange Social Login to 7.6.5+; audit third-party auth plugins
+
+#### WordPress SQL injection via WP_Query (CVE-2022-21661)
+- **CVSS:** 7.5 (High)
+- **Affected:** WordPress (before 5.8.3)
+- **CWE:** CWE-89 (SQL Injection)
+- **Related Checkpoints:** SA-WP-01 ($wpdb query SQL injection)
+- **Detection:** Crafted `WP_Query` with `tax_query` and `terms`/`field` parameter manipulation
+- **Remediation:** Upgrade WordPress to 5.8.3+; always use `$wpdb->prepare()` for custom queries
+
+#### WordPress file upload RCE (CVE-2019-8942)
+- **CVSS:** 8.8 (High)
+- **Affected:** WordPress (before 4.9.9, 5.0.1)
+- **CWE:** CWE-434 (Unrestricted Upload)
+- **Related Checkpoints:** SA-WP-07 (file upload handling)
+- **Detection:** Crafted image upload with embedded PHP via `wp_crop_image()` and Post Meta manipulation
+- **Remediation:** Upgrade WordPress to 4.9.9+ or 5.0.1+
+
+#### WordPress object injection via PHPMailer (CVE-2020-36326)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** WordPress (PHPMailer before 6.1.8)
+- **CWE:** CWE-502 (Deserialization)
+- **Related Checkpoints:** SA-WP-02 (unserialize user input), SA-DEP-01 (dependency audit)
+- **Detection:** `unserialize()` of PHPMailer object data
+- **Remediation:** Upgrade PHPMailer to 6.1.8+; upgrade WordPress core
+
+#### WordPress privilege escalation via User Meta (CVE-2022-0316)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** WordPress (WeStand theme before 2.1)
+- **CWE:** CWE-269 (Improper Privilege Management)
+- **Related Checkpoints:** SA-WP-05 (option/meta modification), SA-WP-06 (POST without nonce)
+- **Detection:** Arbitrary user meta update via unauthenticated registration endpoint
+- **Remediation:** Update or remove vulnerable theme; audit `update_user_meta` calls
+
+---
+
+### Infrastructure / Cross-Platform
+
+#### Heartbleed (CVE-2014-0160)
+- **CVSS:** 7.5 (High)
+- **Affected:** OpenSSL (1.0.1 through 1.0.1f)
+- **CWE:** CWE-125 (Out-of-bounds Read)
+- **Related Checkpoints:** SA-IAC-02 (.env in Docker), SA-DEP-01 (dependency audit)
+- **Detection:** OpenSSL heartbeat extension returning memory contents beyond payload
+- **Remediation:** Upgrade OpenSSL to 1.0.1g+; regenerate all TLS certificates and private keys
+
+#### Shellshock (CVE-2014-6271)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** GNU Bash (through 4.3)
+- **CWE:** CWE-78 (OS Command Injection)
+- **Related Checkpoints:** SA-NODE-01 (child_process.exec), SA-PY-04 (subprocess shell=True), SA-PY-05 (os.system), SA-JAVA-07 (Runtime.exec), SA-RB-03 (system)
+- **Detection:** `() { :;}; <command>` in environment variables processed by bash
+- **Remediation:** Upgrade Bash to 4.3 patch 25+; avoid shell invocation with user input
+
+#### Meltdown (CVE-2017-5754)
+- **CVSS:** 5.6 (Medium)
+- **Affected:** Intel CPUs (hardware)
+- **CWE:** CWE-200 (Information Exposure)
+- **Related Checkpoints:** SA-IAC-01 (container config), SA-AWS-01 (IAM)
+- **Detection:** Speculative execution allowing user-space reading of kernel memory
+- **Remediation:** Apply OS kernel patches (KPTI); update cloud VM instances
+
+#### OpenSSL DoS (CVE-2021-3449)
+- **CVSS:** 5.9 (Medium)
+- **Affected:** OpenSSL (1.1.1 through 1.1.1j)
+- **CWE:** CWE-476 (NULL Pointer Dereference)
+- **Related Checkpoints:** SA-DEP-01 (dependency audit)
+- **Detection:** Crafted renegotiation ClientHello omitting `signature_algorithms` extension
+- **Remediation:** Upgrade OpenSSL to 1.1.1k+
+
+#### HTTP/2 Rapid Reset (CVE-2023-44487)
+- **CVSS:** 7.5 (High)
+- **Affected:** All HTTP/2 implementations (Nginx, Apache, Go, Node.js, etc.)
+- **CWE:** CWE-400 (Uncontrolled Resource Consumption)
+- **Related Checkpoints:** SA-GO-08 (HTTP handling), SA-IAC-01 (container config), SA-DEP-01 (dependency audit)
+- **Detection:** Rapid HTTP/2 HEADERS + RST_STREAM frames consuming server resources
+- **Remediation:** Upgrade web server/runtime; configure `http2_max_concurrent_streams`; rate-limit RST_STREAM
+
+#### sudo bypass (CVE-2019-14287)
+- **CVSS:** 8.8 (High)
+- **Affected:** Linux (sudo before 1.8.28)
+- **CWE:** CWE-269 (Improper Privilege Management)
+- **Related Checkpoints:** SA-IAC-01 (container config), SA-AWS-01 (IAM wildcard)
+- **Detection:** `sudo -u#-1 <command>` bypassing `!root` restriction in sudoers
+- **Remediation:** Upgrade sudo to 1.8.28+; avoid `ALL, !root` patterns in sudoers
+
+#### Linux kernel container escape (CVE-2022-0185)
+- **CVSS:** 8.4 (High)
+- **Affected:** Linux (kernel before 5.16.2)
+- **CWE:** CWE-190 (Integer Overflow)
+- **Related Checkpoints:** SA-IAC-01 (container config), SA-AWS-01 (IAM)
+- **Detection:** `CAP_SYS_ADMIN` capability in container with crafted legacy FS context handler
+- **Remediation:** Upgrade kernel; drop `CAP_SYS_ADMIN` from containers; use seccomp profiles
+
+#### JetBrains TeamCity auth bypass (CVE-2023-42793)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** JetBrains TeamCity (before 2023.05.4)
+- **CWE:** CWE-288 (Authentication Bypass using Alternate Path)
+- **Related Checkpoints:** SA-IAC-01 (container config), SA-AWS-01 (IAM)
+- **Detection:** Unauthenticated access to `/app/rest/users/id:1/tokens/RPC2` endpoint
+- **Remediation:** Upgrade TeamCity to 2023.05.4+; restrict access to admin endpoints
+
+#### XZ Utils backdoor (CVE-2024-3094)
+- **CVSS:** 10.0 (Critical)
+- **Affected:** Linux (xz/liblzma 5.6.0-5.6.1)
+- **CWE:** CWE-506 (Embedded Malicious Code)
+- **Related Checkpoints:** SA-SC-01 (supply chain), SA-DEP-01 (dependency audit)
+- **Detection:** xz version 5.6.0 or 5.6.1 in system packages; `ifunc` resolver in liblzma
+- **Remediation:** Downgrade to xz 5.4.x; verify package integrity from trusted sources
+
+#### Polyfill.io supply chain attack (CVE-2024-38526)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** JavaScript (websites using cdn.polyfill.io)
+- **CWE:** CWE-506 (Embedded Malicious Code)
+- **Related Checkpoints:** SA-FE-01 (frontend security), SA-SC-01 (supply chain), SA-DEP-01 (dependency audit)
+- **Detection:** `<script src="https://cdn.polyfill.io">` in HTML
+- **Remediation:** Remove polyfill.io CDN; use cdnjs.cloudflare.com/polyfill or self-host
+
+---
+
+### Mobile
+
+#### Android MediaTek-SU root escalation (CVE-2020-0069)
+- **CVSS:** 7.8 (High)
+- **Affected:** Android (MediaTek chipset devices)
+- **CWE:** CWE-787 (Out-of-bounds Write)
+- **Related Checkpoints:** SA-ANDROID-01 (exported components), SA-ANDROID-02 (SQL injection)
+- **Detection:** MediaTek CMDQ driver `/dev/mtk_cmdq` accessible to unprivileged apps
+- **Remediation:** Apply Android security update (March 2020); use SafetyNet/Play Integrity attestation
+
+#### iOS iMessage zero-click (CVE-2019-8641)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** iOS (before 12.4.1)
+- **CWE:** CWE-125 (Out-of-bounds Read)
+- **Related Checkpoints:** SA-IOS-03 (UIWebView), SA-IOS-01 (Keychain accessibility)
+- **Detection:** Crafted iMessage payloads exploiting NSKeyedArchiver deserialization
+- **Remediation:** Upgrade iOS to 12.4.1+
+
+#### iOS kernel exploit Triangulation (CVE-2023-32434)
+- **CVSS:** 8.6 (High)
+- **Affected:** iOS (before 16.5.1), macOS (before 13.4.1)
+- **CWE:** CWE-190 (Integer Overflow)
+- **Related Checkpoints:** SA-IOS-01 (Keychain), SA-IOS-05 (UserDefaults sensitive data)
+- **Detection:** Zero-click iMessage exploit chain with IMTranscoderAgent; kernel integer overflow
+- **Remediation:** Upgrade to iOS 16.5.1+ / macOS 13.4.1+; enable Lockdown Mode
+
+#### Android WebView JavaScript interface RCE (CVE-2012-6636)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Android (API < 17)
+- **CWE:** CWE-94 (Code Injection)
+- **Related Checkpoints:** SA-ANDROID-03 (addJavascriptInterface)
+- **Detection:** `addJavascriptInterface()` on Android API < 17 allowing reflection-based RCE
+- **Remediation:** Target API 17+; annotate exposed methods with `@JavascriptInterface`
+
+#### Android Parcel mismatch (CVE-2017-13315)
+- **CVSS:** 7.8 (High)
+- **Affected:** Android (before security patch 2018-04-01)
+- **CWE:** CWE-502 (Deserialization)
+- **Related Checkpoints:** SA-ANDROID-01 (exported components), SA-ANDROID-04 (SharedPreferences)
+- **Detection:** Mismatch between `writeToParcel()` and `createFromParcel()` in Parcelable objects
+- **Remediation:** Apply Android security update; validate Parcelable implementations
+
+#### iOS SSL certificate validation bypass (CVE-2014-1266)
+- **CVSS:** 7.4 (High)
+- **Affected:** iOS (before 7.0.6), macOS (before 10.9.2)
+- **CWE:** CWE-295 (Improper Certificate Validation)
+- **Related Checkpoints:** SA-IOS-02 (ATS disabled), SA-IOS-01 (Keychain)
+- **Detection:** "goto fail" bug in SSL handshake verification (duplicate `goto fail` statement)
+- **Remediation:** Upgrade iOS to 7.0.6+; enforce ATS in production
+
+---
+
+### Rust
+
+#### Rust std::net IP address parsing (CVE-2024-24576)
+- **CVSS:** 10.0 (Critical)
+- **Affected:** Rust (std before 1.77.2 on Windows)
+- **CWE:** CWE-78 (OS Command Injection)
+- **Related Checkpoints:** SA-RS-01 (unsafe usage), SA-RS-04 (Command::new)
+- **Detection:** `std::process::Command` on Windows with arguments containing special characters
+- **Remediation:** Upgrade Rust to 1.77.2+; validate arguments passed to `Command::new()`
+
+#### hyper HTTP request smuggling (CVE-2021-21299)
+- **CVSS:** 8.1 (High)
+- **Affected:** Rust (hyper before 0.14.3)
+- **CWE:** CWE-444 (HTTP Request Smuggling)
+- **Related Checkpoints:** SA-RS-01 (unsafe), SA-DEP-01 (dependency audit)
+- **Detection:** `Transfer-Encoding` with lenient parsing allowing request smuggling
+- **Remediation:** Upgrade hyper to 0.14.3+
+
+#### Rust regex ReDoS (CVE-2022-24713)
+- **CVSS:** 7.5 (High)
+- **Affected:** Rust (regex crate before 1.5.5)
+- **CWE:** CWE-1333 (Inefficient Regular Expression)
+- **Related Checkpoints:** SA-RS-01 (unsafe), SA-DEP-01 (dependency audit)
+- **Detection:** Crafted regex patterns causing excessive memory allocation in regex crate
+- **Remediation:** Upgrade regex crate to 1.5.5+
+
+---
+
+### Additional Java CVEs
+
+#### Apache Shiro auth bypass (CVE-2020-1957)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Java (Apache Shiro before 1.5.2)
+- **CWE:** CWE-287 (Improper Authentication)
+- **Related Checkpoints:** SA-SPRING-01 (permitAll overreach), SA-JAVA-04 (Class.forName)
+- **Detection:** Path normalization discrepancy between Shiro and Spring (e.g., `/admin/page` vs `/admin/page/`)
+- **Remediation:** Upgrade Shiro to 1.5.2+; ensure consistent path normalization
+
+#### Apache Commons Text RCE (CVE-2022-42889)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Java (Apache Commons Text 1.5 through 1.9)
+- **CWE:** CWE-94 (Code Injection)
+- **Related Checkpoints:** SA-JAVA-03 (JNDI), SA-JAVA-07 (Runtime.exec)
+- **Detection:** `StringSubstitutor` with `${script:...}`, `${dns:...}`, `${url:...}` lookups
+- **Remediation:** Upgrade to Apache Commons Text 1.10.0+
+
+#### Apache Kafka deserialization (CVE-2023-25194)
+- **CVSS:** 8.8 (High)
+- **Affected:** Java (Apache Kafka Connect 2.3.0 through 3.3.2)
+- **CWE:** CWE-502 (Deserialization of Untrusted Data)
+- **Related Checkpoints:** SA-JAVA-01 (ObjectInputStream), SA-JAVA-03 (JNDI)
+- **Detection:** SASL JAAS configuration with JNDI lookup in Kafka Connect properties
+- **Remediation:** Upgrade to Apache Kafka 3.4.0+; restrict `sasl.jaas.config` modification
+
+---
+
+### Additional Python CVEs
+
+#### FastAPI/Starlette path traversal (CVE-2024-24762)
+- **CVSS:** 7.5 (High)
+- **Affected:** Python (python-multipart before 0.0.7)
+- **CWE:** CWE-400 (Uncontrolled Resource Consumption)
+- **Related Checkpoints:** SA-FASTAPI-01 (FastAPI), SA-DEP-01 (dependency audit)
+- **Detection:** Crafted multipart `Content-Type` header causing ReDoS
+- **Remediation:** Upgrade python-multipart to 0.0.7+
+
+#### Django CSRF bypass via file upload (CVE-2016-9013)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Python (Django before 1.8.16, 1.9.11, 1.10.3)
+- **CWE:** CWE-200 (Information Exposure)
+- **Related Checkpoints:** SA-DJANGO-02 (csrf_exempt), SA-DJANGO-01 (ORM injection)
+- **Detection:** Hardcoded test-database password when running with `--settings` pointing to test config
+- **Remediation:** Upgrade Django; never deploy test configurations in production
+
+#### Requests CRLF injection (CVE-2023-32681)
+- **CVSS:** 6.1 (Medium)
+- **Affected:** Python (requests 2.3.0 through 2.30.0)
+- **CWE:** CWE-113 (HTTP Response Splitting)
+- **Related Checkpoints:** SA-DEP-01 (dependency audit), SA-PY-04 (subprocess)
+- **Detection:** `Proxy-Authorization` header leaking to redirected HTTPS destination
+- **Remediation:** Upgrade requests to 2.31.0+
+
+---
+
+### Additional JavaScript/Node.js CVEs
+
+#### Next.js SSRF via Host header (CVE-2024-34351)
+- **CVSS:** 7.5 (High)
+- **Affected:** Node.js (Next.js before 14.1.1)
+- **CWE:** CWE-918 (Server-Side Request Forgery)
+- **Related Checkpoints:** SA-NEXT-01 (Next.js), SA-NODE-07 (user input in headers)
+- **Detection:** Server Actions with `Host` header manipulation triggering SSRF on redirect
+- **Remediation:** Upgrade Next.js to 14.1.1+
+
+#### Next.js middleware auth bypass (CVE-2025-29927)
+- **CVSS:** 9.1 (Critical)
+- **Affected:** Node.js (Next.js before 14.2.25, 15.2.3)
+- **CWE:** CWE-285 (Improper Authorization)
+- **Related Checkpoints:** SA-NEXT-01 (Next.js), SA-NEXT-02 (server actions)
+- **Detection:** `x-middleware-subrequest` header bypassing middleware authorization checks
+- **Remediation:** Upgrade Next.js to 14.2.25+ or 15.2.3+; block `x-middleware-subrequest` at CDN/proxy
+
+#### socket.io XSS (CVE-2024-38355)
+- **CVSS:** 6.1 (Medium)
+- **Affected:** Node.js (socket.io before 4.7.4)
+- **CWE:** CWE-79 (Cross-site Scripting)
+- **Related Checkpoints:** SA-NODE-07 (CRLF injection), SA-JS-02 (innerHTML)
+- **Detection:** Crafted WebSocket messages with HTML payloads reflected without encoding
+- **Remediation:** Upgrade socket.io to 4.7.4+
+
+#### Nest.js class-transformer prototype pollution (CVE-2023-36813)
+- **CVSS:** 7.5 (High)
+- **Affected:** Node.js (class-transformer before 0.5.1)
+- **CWE:** CWE-1321 (Prototype Pollution)
+- **Related Checkpoints:** SA-JS-06 (__proto__ pollution), SA-NEST-01 (NestJS)
+- **Detection:** `plainToInstance()` or `plainToClass()` with `__proto__` or `constructor.prototype`
+- **Remediation:** Upgrade class-transformer to 0.5.1+
+
+---
+
+### Additional Infrastructure CVEs
+
+#### AWS IMDS SSRF (CVE-2019-17558)
+- **CVSS:** 8.1 (High)
+- **Affected:** AWS (EC2 instances using IMDSv1)
+- **CWE:** CWE-918 (Server-Side Request Forgery)
+- **Related Checkpoints:** SA-AWS-01 (IAM wildcard), SA-AWS-03 (overly permissive principal)
+- **Detection:** HTTP requests to `http://169.254.169.254/latest/meta-data/` from within application
+- **Remediation:** Enforce IMDSv2 (require token); set `HttpTokens: required` in launch template
+
+#### Kubernetes privilege escalation (CVE-2018-1002105)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Kubernetes (before 1.10.11, 1.11.5, 1.12.3)
+- **CWE:** CWE-269 (Improper Privilege Management)
+- **Related Checkpoints:** SA-IAC-01 (container config), SA-AWS-01 (IAM)
+- **Detection:** API server WebSocket connection upgrade with crafted request to backend
+- **Remediation:** Upgrade Kubernetes; restrict RBAC permissions
+
+#### Terraform AWS provider credential exposure (CVE-2023-37918)
+- **CVSS:** 6.5 (Medium)
+- **Affected:** Terraform (hashicorp/aws provider before 5.11.0)
+- **CWE:** CWE-200 (Information Exposure)
+- **Related Checkpoints:** SA-AWS-01 (IAM), SA-IAC-03 (secrets in ARG)
+- **Detection:** Provider debug logs exposing AWS credentials in plaintext
+- **Remediation:** Upgrade AWS provider to 5.11.0+; avoid `TF_LOG=DEBUG` in CI
+
+#### GitHub Actions script injection (CVE-2023-33953)
+- **CVSS:** 7.5 (High)
+- **Affected:** GitHub Actions (workflow expression injection)
+- **CWE:** CWE-94 (Code Injection)
+- **Related Checkpoints:** SA-IAC-01 (container config), SA-SC-01 (supply chain)
+- **Detection:** `${{ github.event.issue.title }}` or similar untrusted context in `run:` block
+- **Remediation:** Use intermediate environment variable; avoid direct expression interpolation in `run:`
+
+---
+
+### Additional C#/.NET CVEs
+
+#### Blazor WebAssembly auth bypass (CVE-2022-26929)
+- **CVSS:** 7.8 (High)
+- **Affected:** C# (.NET 6.0 before 6.0.10)
+- **CWE:** CWE-863 (Incorrect Authorization)
+- **Related Checkpoints:** SA-BLAZOR-01 (Blazor), SA-DOTNET-03 (AllowAnonymous on class)
+- **Detection:** Client-side Blazor WebAssembly authorization checks bypassed via browser dev tools
+- **Remediation:** Always enforce authorization server-side; treat Blazor WASM as untrusted client
+
+#### SignalR hub method auth bypass (CVE-2023-33135)
+- **CVSS:** 7.5 (High)
+- **Affected:** C# (.NET 6, 7)
+- **CWE:** CWE-863 (Incorrect Authorization)
+- **Related Checkpoints:** SA-DOTNET-01 (middleware ordering), SA-DOTNET-03 (AllowAnonymous)
+- **Detection:** SignalR hub methods callable without `[Authorize]` attribute
+- **Remediation:** Apply `[Authorize]` at hub class level; upgrade .NET runtime
+
+---
+
+### Additional Go CVEs
+
+#### Go SSRF in net/http (CVE-2022-32148)
+- **CVSS:** 6.5 (Medium)
+- **Affected:** Go (before 1.17.12, 1.18.4)
+- **CWE:** CWE-20 (Improper Input Validation)
+- **Related Checkpoints:** SA-GO-08 (HTTP request SSRF)
+- **Detection:** `httputil.ReverseProxy` forwarding `X-Forwarded-For` with untrusted header
+- **Remediation:** Upgrade Go; validate and rewrite `X-Forwarded-For` headers
+
+#### Go math/big denial of service (CVE-2022-23772)
+- **CVSS:** 7.5 (High)
+- **Affected:** Go (before 1.16.14, 1.17.7)
+- **CWE:** CWE-190 (Integer Overflow)
+- **Related Checkpoints:** SA-GO-01 (unsafe package), SA-DEP-01 (dependency audit)
+- **Detection:** `Rat.SetString()` with very large exponent causing excessive memory allocation
+- **Remediation:** Upgrade Go to 1.16.14+ or 1.17.7+
+
+---
+
+### Additional Ruby CVEs
+
+#### Nokogiri XXE (CVE-2019-11068)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Ruby (Nokogiri before 1.10.2 with libxslt before 1.1.33)
+- **CWE:** CWE-611 (XXE)
+- **Related Checkpoints:** SA-RB-05 (YAML.load), SA-DEP-01 (dependency audit)
+- **Detection:** XSLT processing with Nokogiri allowing external entity resolution
+- **Remediation:** Upgrade Nokogiri to 1.10.2+; upgrade system libxslt
+
+#### Puma HTTP request smuggling (CVE-2022-24790)
+- **CVSS:** 9.8 (Critical)
+- **Affected:** Ruby (Puma before 5.6.4, 4.3.12)
+- **CWE:** CWE-444 (HTTP Request Smuggling)
+- **Related Checkpoints:** SA-DEP-01 (dependency audit), SA-RB-10 (Kernel.open)
+- **Detection:** Inconsistent `Transfer-Encoding` chunked handling vs. reverse proxy
+- **Remediation:** Upgrade Puma to 5.6.4+ or 4.3.12+
+
+---
+
+### Additional WordPress CVEs
+
+#### WordPress Elementor RCE (CVE-2022-1329)
+- **CVSS:** 8.8 (High)
+- **Affected:** WordPress (Elementor plugin before 3.6.3)
+- **CWE:** CWE-94 (Code Injection)
+- **Related Checkpoints:** SA-WP-04 (REST without permission), SA-WP-05 (option modification)
+- **Detection:** Authenticated user uploading crafted SVG/ZIP via Elementor template import
+- **Remediation:** Upgrade Elementor to 3.6.3+; restrict template import to administrators
+
+#### WordPress All-in-One SEO SQL injection (CVE-2021-25036)
+- **CVSS:** 7.2 (High)
+- **Affected:** WordPress (AIOSEO plugin before 4.1.5.3)
+- **CWE:** CWE-89 (SQL Injection)
+- **Related Checkpoints:** SA-WP-01 ($wpdb SQL injection)
+- **Detection:** SQL injection via REST API endpoint accessible to subscribers+
+- **Remediation:** Upgrade AIOSEO to 4.1.5.3+
+
+---
+
+### Additional Drupal CVEs
+
+#### Drupal SA-CORE-2019-003 RCE (CVE-2019-6340)
+- **CVSS:** 8.1 (High)
+- **Affected:** PHP (Drupal 8 with REST module)
+- **CWE:** CWE-502 (Deserialization)
+- **Related Checkpoints:** SA-DRUPAL-01 (SQL injection), SA-DRUPAL-02 (#markup)
+- **Detection:** RESTful Web Services `PATCH` request with serialized PHP payload
+- **Remediation:** Upgrade Drupal; disable unused REST resource formats
+
+---
+
+## Quick Lookup Summary Table
+
+| CVE | CVSS | Language | Checkpoint(s) | Description |
+|-----|------|----------|---------------|-------------|
+| CVE-2021-44228 | 10.0 | Java | SA-JAVA-03 | Log4Shell JNDI injection |
+| CVE-2021-45046 | 9.0 | Java | SA-JAVA-03 | Log4Shell bypass |
+| CVE-2021-44832 | 6.6 | Java | SA-JAVA-03, SA-JAVA-01 | Log4j RCE via JDBC Appender |
+| CVE-2017-5638 | 10.0 | Java | SA-JAVA-07, SA-JAVA-04 | Apache Struts OGNL RCE |
+| CVE-2019-2725 | 9.8 | Java | SA-JAVA-01 | WebLogic deserialization |
+| CVE-2022-22965 | 9.8 | Java | SA-SPRING-07, SA-SPRING-02 | Spring4Shell |
+| CVE-2022-22963 | 9.8 | Java | SA-SPRING-02 | Spring Cloud Function SpEL |
+| CVE-2017-12149 | 9.8 | Java | SA-JAVA-01 | JBoss deserialization |
+| CVE-2015-4852 | 9.8 | Java | SA-JAVA-01 | Commons Collections deser |
+| CVE-2017-7525 | 9.8 | Java | SA-SPRING-08, SA-JAVA-01 | Jackson Databind deser |
+| CVE-2018-11776 | 9.8 | Java | SA-JAVA-04, SA-JAVA-07 | Struts 2 namespace RCE |
+| CVE-2022-22978 | 9.8 | Java | SA-SPRING-01 | Spring Security auth bypass |
+| CVE-2020-1938 | 9.8 | Java | SA-JAVA-06, SA-IAC-01 | Tomcat Ghostcat AJP |
+| CVE-2020-1957 | 9.8 | Java | SA-SPRING-01, SA-JAVA-04 | Apache Shiro auth bypass |
+| CVE-2022-42889 | 9.8 | Java | SA-JAVA-03, SA-JAVA-07 | Commons Text RCE |
+| CVE-2023-25194 | 8.8 | Java | SA-JAVA-01, SA-JAVA-03 | Kafka Connect deser |
+| CVE-2019-10906 | 8.6 | Python | SA-PY-14, SA-FLASK-01 | Jinja2 sandbox escape |
+| CVE-2020-1747 | 9.8 | Python | SA-PY-06 | PyYAML code execution |
+| CVE-2017-18342 | 9.8 | Python | SA-PY-06 | PyYAML unsafe load |
+| CVE-2019-9740 | 6.1 | Python | SA-PY-04, SA-PY-05 | urllib CRLF injection |
+| CVE-2019-9947 | 6.1 | Python | SA-PY-04, SA-PY-05 | urllib CRLF injection |
+| CVE-2022-0391 | 7.5 | Python | SA-PY-04 | urllib.parse bypass |
+| CVE-2021-3177 | 9.8 | Python | SA-PY-03, SA-PY-02 | ctypes buffer overflow |
+| CVE-2023-48795 | 5.9 | Python | SA-DEP-01 | Paramiko Terrapin SSH |
+| CVE-2021-25287 | 9.1 | Python | SA-DEP-01 | Pillow buffer overflow |
+| CVE-2021-35042 | 9.8 | Python | SA-DJANGO-01 | Django order_by SQLi |
+| CVE-2019-14234 | 9.8 | Python | SA-DJANGO-01 | Django JSONField SQLi |
+| CVE-2015-5306 | 7.5 | Python | SA-FLASK-01 | Flask debug mode RCE |
+| CVE-2024-24762 | 7.5 | Python | SA-FASTAPI-01, SA-DEP-01 | FastAPI multipart ReDoS |
+| CVE-2016-9013 | 9.8 | Python | SA-DJANGO-02, SA-DJANGO-01 | Django test-db password |
+| CVE-2023-32681 | 6.1 | Python | SA-DEP-01 | Requests CRLF injection |
+| CVE-2019-10744 | 9.1 | JavaScript | SA-JS-06 | Lodash prototype pollution |
+| CVE-2021-23337 | 7.2 | JavaScript | SA-JS-01, SA-NODE-01 | Lodash command injection |
+| CVE-2019-11358 | 6.1 | JavaScript | SA-JS-06 | jQuery prototype pollution |
+| CVE-2020-11022 | 6.1 | JavaScript | SA-JS-02, SA-JS-03 | jQuery XSS |
+| CVE-2022-29078 | 9.8 | JavaScript | SA-JS-01, SA-NODE-01 | EJS SSTI/RCE |
+| CVE-2021-21315 | 7.2 | Node.js | SA-NODE-01 | systeminformation cmd inj |
+| CVE-2018-16487 | 5.6 | JavaScript | SA-JS-06 | Lodash merge proto poll |
+| CVE-2023-44270 | 5.3 | JavaScript | SA-DEP-01 | PostCSS ReDoS |
+| CVE-2024-29041 | 6.1 | Node.js | SA-EXPRESS-01, SA-NODE-02 | Express.js open redirect |
+| CVE-2022-32213 | 6.5 | Node.js | SA-NODE-07 | Node.js HTTP smuggling |
+| CVE-2021-44906 | 9.8 | JavaScript | SA-JS-06, SA-DEP-01 | minimist proto pollution |
+| CVE-2023-45857 | 6.5 | JavaScript | SA-NODE-07, SA-DEP-01 | Axios SSRF |
+| CVE-2021-3918 | 9.8 | JavaScript | SA-JS-06 | json-schema proto poll |
+| CVE-2021-43616 | 9.8 | JavaScript | SA-DEP-01, SA-SC-01 | ua-parser-js supply chain |
+| CVE-2024-34351 | 7.5 | Node.js | SA-NEXT-01 | Next.js SSRF |
+| CVE-2025-29927 | 9.1 | Node.js | SA-NEXT-01, SA-NEXT-02 | Next.js middleware bypass |
+| CVE-2024-38355 | 6.1 | Node.js | SA-NODE-07, SA-JS-02 | socket.io XSS |
+| CVE-2023-36813 | 7.5 | Node.js | SA-JS-06, SA-NEST-01 | class-transformer proto poll |
+| CVE-2019-11043 | 9.8 | PHP | SA-IAC-01 | PHP-FPM RCE |
+| CVE-2012-1823 | 7.5 | PHP | SA-IAC-01, SA-10 | PHP CGI argument injection |
+| CVE-2024-4577 | 9.8 | PHP | SA-IAC-01 | PHP CGI Windows bypass |
+| CVE-2023-3824 | 9.8 | PHP | SA-DEP-01 | PHP phar buffer overflow |
+| CVE-2016-5385 | 8.1 | PHP | SA-10, SA-IAC-01 | HTTPoxy |
+| CVE-2015-0231 | 7.5 | PHP | SA-WP-02 | PHP unserialize UAF |
+| CVE-2021-3129 | 9.8 | PHP | SA-02, SA-03 | Laravel Ignition RCE |
+| CVE-2018-7600 | 9.8 | PHP | SA-DRUPAL-01, SA-DRUPAL-02 | Drupalgeddon 2 |
+| CVE-2018-7602 | 9.8 | PHP | SA-DRUPAL-01, SA-DRUPAL-03 | Drupalgeddon 3 |
+| CVE-2019-6340 | 8.1 | PHP | SA-DRUPAL-01, SA-DRUPAL-02 | Drupal REST RCE |
+| CVE-2017-8565 | 8.1 | C# | SA-CS-01 | BinaryFormatter RCE |
+| CVE-2020-0646 | 9.8 | C# | SA-CS-01, SA-CS-02 | DataSet deserialization |
+| CVE-2022-34716 | 5.9 | C# | SA-DEP-01 | .NET info disclosure |
+| CVE-2022-41089 | 8.8 | C# | SA-CS-04, SA-CS-01 | .NET XSLT RCE |
+| CVE-2019-0548 | 5.4 | C# | SA-DOTNET-01 | ASP.NET open redirect |
+| CVE-2024-21404 | 7.5 | C# | SA-DOTNET-05 | SignalR DoS |
+| CVE-2022-26929 | 7.8 | C# | SA-BLAZOR-01, SA-DOTNET-03 | Blazor WASM auth bypass |
+| CVE-2023-33135 | 7.5 | C# | SA-DOTNET-01, SA-DOTNET-03 | SignalR hub auth bypass |
+| CVE-2022-41717 | 5.3 | Go | SA-GO-08, SA-GO-09 | net/http memory exhaustion |
+| CVE-2023-39325 | 7.5 | Go | SA-GO-08, SA-DEP-01 | HTTP/2 rapid reset Go |
+| CVE-2024-24790 | 9.8 | Go | SA-GO-05, SA-GO-08 | net/netip parsing bypass |
+| CVE-2023-45283 | 7.5 | Go | SA-GO-05 | filepath.Clean bypass |
+| CVE-2024-45337 | 9.1 | Go | SA-GO-06, SA-DEP-01 | x/crypto SSH auth bypass |
+| CVE-2022-41723 | 7.5 | Go | SA-GO-05 | HPACK decoding DoS |
+| CVE-2022-32148 | 6.5 | Go | SA-GO-08 | ReverseProxy SSRF |
+| CVE-2022-23772 | 7.5 | Go | SA-GO-01, SA-DEP-01 | math/big DoS |
+| CVE-2013-0156 | 10.0 | Ruby | SA-RB-05, SA-RAILS-01 | Rails YAML deserialization |
+| CVE-2019-5418 | 7.5 | Ruby | SA-RAILS-05, SA-RAILS-02 | Rails file disclosure |
+| CVE-2020-8165 | 9.8 | Ruby | SA-RB-04 | Rails MemCacheStore deser |
+| CVE-2023-22796 | 7.5 | Ruby | SA-DEP-01 | Rails ActiveSupport ReDoS |
+| CVE-2023-22797 | 6.1 | Ruby | SA-RAILS-02, SA-RAILS-04 | Rails open redirect |
+| CVE-2023-27530 | 7.5 | Ruby | SA-DEP-01 | Rack multipart DoS |
+| CVE-2019-11068 | 9.8 | Ruby | SA-RB-05, SA-DEP-01 | Nokogiri XXE |
+| CVE-2022-24790 | 9.8 | Ruby | SA-DEP-01 | Puma HTTP smuggling |
+| CVE-2023-2982 | 9.8 | WordPress | SA-WP-04 | WP social login bypass |
+| CVE-2022-21661 | 7.5 | WordPress | SA-WP-01 | WP_Query SQLi |
+| CVE-2019-8942 | 8.8 | WordPress | SA-WP-07 | WP file upload RCE |
+| CVE-2020-36326 | 9.8 | WordPress | SA-WP-02, SA-DEP-01 | PHPMailer object injection |
+| CVE-2022-0316 | 9.8 | WordPress | SA-WP-05, SA-WP-06 | WP theme privilege esc |
+| CVE-2022-1329 | 8.8 | WordPress | SA-WP-04, SA-WP-05 | Elementor RCE |
+| CVE-2021-25036 | 7.2 | WordPress | SA-WP-01 | AIOSEO SQLi |
+| CVE-2014-0160 | 7.5 | Cross-lang | SA-IAC-02, SA-DEP-01 | Heartbleed |
+| CVE-2014-6271 | 9.8 | Cross-lang | SA-NODE-01, SA-PY-04, SA-JAVA-07 | Shellshock |
+| CVE-2017-5754 | 5.6 | Cross-lang | SA-IAC-01, SA-AWS-01 | Meltdown |
+| CVE-2021-3449 | 5.9 | Cross-lang | SA-DEP-01 | OpenSSL DoS |
+| CVE-2023-44487 | 7.5 | Cross-lang | SA-GO-08, SA-IAC-01, SA-DEP-01 | HTTP/2 Rapid Reset |
+| CVE-2019-14287 | 8.8 | Linux | SA-IAC-01, SA-AWS-01 | sudo bypass |
+| CVE-2022-0185 | 8.4 | Linux | SA-IAC-01 | Container escape |
+| CVE-2023-42793 | 9.8 | Infra | SA-IAC-01 | TeamCity auth bypass |
+| CVE-2024-3094 | 10.0 | Linux | SA-SC-01, SA-DEP-01 | XZ Utils backdoor |
+| CVE-2024-38526 | 9.8 | JavaScript | SA-FE-01, SA-SC-01 | Polyfill.io supply chain |
+| CVE-2019-17558 | 8.1 | AWS | SA-AWS-01, SA-AWS-03 | AWS IMDS SSRF |
+| CVE-2018-1002105 | 9.8 | Kubernetes | SA-IAC-01 | K8s privilege escalation |
+| CVE-2023-37918 | 6.5 | Terraform | SA-AWS-01, SA-IAC-03 | TF AWS cred exposure |
+| CVE-2023-33953 | 7.5 | CI/CD | SA-IAC-01, SA-SC-01 | GH Actions script injection |
+| CVE-2020-0069 | 7.8 | Android | SA-ANDROID-01, SA-ANDROID-02 | MediaTek-SU root |
+| CVE-2019-8641 | 9.8 | iOS | SA-IOS-03, SA-IOS-01 | iMessage zero-click |
+| CVE-2023-32434 | 8.6 | iOS | SA-IOS-01, SA-IOS-05 | Triangulation kernel |
+| CVE-2012-6636 | 9.8 | Android | SA-ANDROID-03 | WebView JS interface RCE |
+| CVE-2017-13315 | 7.8 | Android | SA-ANDROID-01, SA-ANDROID-04 | Parcel mismatch |
+| CVE-2014-1266 | 7.4 | iOS | SA-IOS-02, SA-IOS-01 | goto fail SSL bypass |
+| CVE-2024-24576 | 10.0 | Rust | SA-RS-01, SA-RS-04 | Rust Command injection |
+| CVE-2021-21299 | 8.1 | Rust | SA-RS-01, SA-DEP-01 | hyper HTTP smuggling |
+| CVE-2022-24713 | 7.5 | Rust | SA-RS-01, SA-DEP-01 | regex crate ReDoS |
+
+---
+
+## Changelog
+
+| Date | Change | Phase |
+|------|--------|-------|
+| 2026-03-31 | Initial release -- 100+ CVEs mapped | Phase C1 |

--- a/skills/security-audit/references/cve-database.md
+++ b/skills/security-audit/references/cve-database.md
@@ -1,6 +1,16 @@
 # CVE Database -- Checkpoint Mapping
 
-Maps known CVEs to detection checkpoints for automated correlation during security audits.
+Maps 113 known CVEs to detection checkpoints for automated correlation during security audits.
+
+## Contents
+
+- [How to Use](#how-to-use)
+- [Critical/High-Severity CVEs](#criticalhigh-severity-cves)
+  - [Java](#java) · [Python](#python) · [JavaScript / Node.js](#javascript--nodejs) · [PHP](#php) · [C# / .NET](#c--net) · [Go](#go) · [Ruby](#ruby)
+  - [WordPress](#wordpress) · [Infrastructure / Cross-Platform](#infrastructure--cross-platform) · [Mobile](#mobile) · [Rust](#rust)
+  - Additional: [Java](#additional-java-cves) · [Python](#additional-python-cves) · [JS / Node](#additional-javascriptnodejs-cves) · [Infrastructure](#additional-infrastructure-cves) · [C# / .NET](#additional-cnet-cves) · [Go](#additional-go-cves) · [Ruby](#additional-ruby-cves) · [WordPress](#additional-wordpress-cves) · [Drupal](#additional-drupal-cves)
+- [Quick Lookup Summary Table](#quick-lookup-summary-table)
+- [Changelog](#changelog)
 
 ## How to Use
 
@@ -1123,4 +1133,4 @@ Cross-reference with:
 
 | Date | Change | Phase |
 |------|--------|-------|
-| 2026-03-31 | Initial release -- 95 CVEs mapped | Phase C1 |
+| 2026-03-31 | Initial release -- 113 CVEs mapped | Phase C1 |

--- a/skills/security-audit/references/cve-database.md
+++ b/skills/security-audit/references/cve-database.md
@@ -289,7 +289,7 @@ Cross-reference with:
 - **Detection:** Crafted CSS input with deeply nested brackets causing backtracking
 - **Remediation:** Upgrade PostCSS to 8.4.31+
 
-#### Express.js path traversal (CVE-2024-29041)
+#### Express.js open redirect (CVE-2024-29041)
 - **CVSS:** 6.1 (Medium)
 - **Affected:** Node.js (Express before 4.19.2)
 - **CWE:** CWE-601 (Open Redirect)
@@ -313,7 +313,7 @@ Cross-reference with:
 - **Detection:** CLI argument parsing with `--__proto__.polluted=true`
 - **Remediation:** Upgrade minimist to 1.2.6+
 
-#### Axios SSRF (CVE-2023-45857)
+#### Axios XSRF token leak to third-party origins (CVE-2023-45857)
 - **CVSS:** 6.5 (Medium)
 - **Affected:** JavaScript (Axios before 1.6.0)
 - **CWE:** CWE-352 (CSRF)
@@ -345,7 +345,7 @@ Cross-reference with:
 - **CVSS:** 9.8 (Critical)
 - **Affected:** PHP (PHP-FPM with Nginx, PHP 7.1.x-7.3.x)
 - **CWE:** CWE-120 (Buffer Overflow)
-- **Related Checkpoints:** SA-IAC-01 (container config), SA-08 (LIBXML_NOENT)
+- **Related Checkpoints:** SA-DEP-01 (dependency audit). This is an infra-level bug (PHP-FPM + Nginx regex interaction) — there is no ideal source-level checkpoint in our set; SA-08 (XXE via LIBXML_NOENT) does NOT apply here.
 - **Detection:** Nginx `fastcgi_split_path_info` regex with `^` anchor and PATH_INFO manipulation
 - **Remediation:** Upgrade PHP to 7.2.24+ or 7.3.11+; fix Nginx fastcgi_split_path_info regex
 
@@ -377,7 +377,7 @@ Cross-reference with:
 - **CVSS:** 8.1 (High)
 - **Affected:** PHP, Python, Go (CGI/FastCGI applications)
 - **CWE:** CWE-807 (Reliance on Untrusted Inputs)
-- **Related Checkpoints:** SA-10 ($_GET), SA-IAC-01 (container config)
+- **Related Checkpoints:** SA-DEP-01 (dependency audit). HTTPoxy is an environment-variable confusion bug triggered by the `Proxy:` HTTP request header; it is not a `$_GET`-style injection, so SA-10 does not apply.
 - **Detection:** Application reads `HTTP_PROXY` environment variable set by `Proxy:` request header
 - **Remediation:** Unset `HTTP_PROXY` in web server config; use `RequestHeader unset Proxy` in Apache
 
@@ -385,7 +385,7 @@ Cross-reference with:
 - **CVSS:** 7.5 (High)
 - **Affected:** PHP (before 5.4.37, 5.5.21, 5.6.5)
 - **CWE:** CWE-416 (Use After Free)
-- **Related Checkpoints:** SA-WP-02 (unserialize with user input), SA-11 (unserialize)
+- **Related Checkpoints:** SA-21, SA-22 (PHP unserialize on user input — the generic checkpoints for this vulnerability class), SA-WP-02 (WordPress-specific variant)
 - **Detection:** `unserialize()` with user-controlled input triggering `__destruct`/`__wakeup` chains
 - **Remediation:** Upgrade PHP; use `json_decode()` instead of `unserialize()` for user data
 
@@ -401,7 +401,7 @@ Cross-reference with:
 - **CVSS:** 9.8 (Critical)
 - **Affected:** PHP (Drupal before 7.58, 8.x before 8.3.9, 8.4.x before 8.4.6, 8.5.x before 8.5.1)
 - **CWE:** CWE-94 (Code Injection)
-- **Related Checkpoints:** SA-DRUPAL-01 (SQL injection), SA-DRUPAL-02 (#markup XSS)
+- **Related Checkpoints:** SA-DRUPAL-02 / SA-DRUPAL-03 (`#markup` and `#`-prefixed render-array properties on user-controllable values) — closest match for the Form API render-array code-injection surface. SA-DRUPAL-01 (SQL injection) does NOT apply; Drupalgeddon 2 is an RCE via Form API, not a SQLi.
 - **Detection:** Form API render array injection via `#` prefixed keys in request parameters
 - **Remediation:** Upgrade Drupal to patched version
 
@@ -501,19 +501,19 @@ Cross-reference with:
 - **Detection:** `filepath.Clean()` not recognizing `\\?\` prefix paths on Windows
 - **Remediation:** Upgrade Go to 1.20.11+ or 1.21.4+
 
-#### Go crypto/tls session ticket key rotation (CVE-2024-45337)
+#### Go x/crypto/ssh PublicKeyCallback authn bypass (CVE-2024-45337)
 - **CVSS:** 9.1 (Critical)
 - **Affected:** Go (golang.org/x/crypto before 0.31.0)
 - **CWE:** CWE-285 (Improper Authorization)
-- **Related Checkpoints:** SA-GO-06 (InsecureSkipVerify), SA-DEP-01 (dependency audit)
+- **Related Checkpoints:** SA-DEP-01 (dependency audit)
 - **Detection:** SSH server with `PublicKeyCallback` returning nil error without verifying key
 - **Remediation:** Upgrade golang.org/x/crypto to 0.31.0+
 
-#### Go archive/zip path traversal (CVE-2022-41723)
+#### Go net/http HTTP/2 HPACK decoding DoS (CVE-2022-41723)
 - **CVSS:** 7.5 (High)
-- **Affected:** Go (before 1.19.6, 1.20.1)
-- **CWE:** CWE-22 (Path Traversal)
-- **Related Checkpoints:** SA-GO-05 (filepath.Join user input)
+- **Affected:** Go (before 1.19.6, 1.20.1); `golang.org/x/net/http2` before v0.7.0
+- **CWE:** CWE-400 (Uncontrolled Resource Consumption)
+- **Related Checkpoints:** SA-DEP-01 (dependency audit)
 - **Detection:** HTTP/2 HPACK decoding causing excessive CPU/memory; crafted compressed frames
 - **Remediation:** Upgrade Go; use `golang.org/x/net` v0.7.0+
 
@@ -809,7 +809,7 @@ Cross-reference with:
 
 ### Additional Python CVEs
 
-#### FastAPI/Starlette path traversal (CVE-2024-24762)
+#### python-multipart ReDoS (CVE-2024-24762)
 - **CVSS:** 7.5 (High)
 - **Affected:** Python (python-multipart before 0.0.7)
 - **CWE:** CWE-400 (Uncontrolled Resource Consumption)
@@ -817,13 +817,13 @@ Cross-reference with:
 - **Detection:** Crafted multipart `Content-Type` header causing ReDoS
 - **Remediation:** Upgrade python-multipart to 0.0.7+
 
-#### Django CSRF bypass via file upload (CVE-2016-9013)
-- **CVSS:** 9.8 (Critical)
+#### Django test-database hardcoded password (CVE-2016-9014)
+- **CVSS:** 7.5 (High)
 - **Affected:** Python (Django before 1.8.16, 1.9.11, 1.10.3)
-- **CWE:** CWE-200 (Information Exposure)
-- **Related Checkpoints:** SA-DJANGO-02 (csrf_exempt), SA-DJANGO-01 (ORM injection)
+- **CWE:** CWE-798 (Hardcoded Credentials)
+- **Related Checkpoints:** SA-DEP-01 (dependency audit). Deployment-config review — no source-pattern checkpoint fires on this.
 - **Detection:** Hardcoded test-database password when running with `--settings` pointing to test config
-- **Remediation:** Upgrade Django; never deploy test configurations in production
+- **Remediation:** Upgrade Django; never deploy test configurations in production. Note: CVE-2016-9013 (Host-header validation bypass with `DEBUG=True`) is a sibling CVE — audit `ALLOWED_HOSTS` + `DEBUG` together.
 
 #### Requests CRLF injection (CVE-2023-32681)
 - **CVSS:** 6.1 (Medium)
@@ -901,7 +901,7 @@ Cross-reference with:
 - **CVSS:** 7.5 (High)
 - **Affected:** GitHub Actions (workflow expression injection)
 - **CWE:** CWE-94 (Code Injection)
-- **Related Checkpoints:** SA-IAC-01 (container config), SA-SC-01 (supply chain)
+- **Related Checkpoints:** SA-GHA-01 (script injection — untrusted GitHub context in `run:` blocks), SA-SC-01 (supply chain). SA-IAC-01 (Dockerfile USER) does NOT apply — this is a workflow-expression injection, not a container-config issue.
 - **Detection:** `${{ github.event.issue.title }}` or similar untrusted context in `run:` block
 - **Remediation:** Use intermediate environment variable; avoid direct expression interpolation in `run:`
 
@@ -953,7 +953,7 @@ Cross-reference with:
 - **CVSS:** 9.8 (Critical)
 - **Affected:** Ruby (Nokogiri before 1.10.2 with libxslt before 1.1.33)
 - **CWE:** CWE-611 (XXE)
-- **Related Checkpoints:** SA-RB-05 (YAML.load), SA-DEP-01 (dependency audit)
+- **Related Checkpoints:** SA-DEP-01 (dependency audit). XXE-specific ruby checkpoints do not exist in our set yet; prefer structure-aware tooling (`xmlstarlet sel`) for source audits. SA-RB-05 (YAML.load) does NOT apply — this is XML XXE, not YAML deserialization.
 - **Detection:** XSLT processing with Nokogiri allowing external entity resolution
 - **Remediation:** Upgrade Nokogiri to 1.10.2+; upgrade system libxslt
 
@@ -961,7 +961,7 @@ Cross-reference with:
 - **CVSS:** 9.8 (Critical)
 - **Affected:** Ruby (Puma before 5.6.4, 4.3.12)
 - **CWE:** CWE-444 (HTTP Request Smuggling)
-- **Related Checkpoints:** SA-DEP-01 (dependency audit), SA-RB-10 (Kernel.open)
+- **Related Checkpoints:** SA-DEP-01 (dependency audit). Runtime-layer bug in the web server; SA-RB-10 (Kernel.open pipe injection) does NOT apply.
 - **Detection:** Inconsistent `Transfer-Encoding` chunked handling vs. reverse proxy
 - **Remediation:** Upgrade Puma to 5.6.4+ or 4.3.12+
 
@@ -1075,7 +1075,7 @@ Cross-reference with:
 | CVE-2024-24790 | 9.8 | Go | SA-GO-05, SA-GO-08 | net/netip parsing bypass |
 | CVE-2023-45283 | 7.5 | Go | SA-GO-05 | filepath.Clean bypass |
 | CVE-2024-45337 | 9.1 | Go | SA-GO-06, SA-DEP-01 | x/crypto SSH auth bypass |
-| CVE-2022-41723 | 7.5 | Go | SA-GO-05 | HPACK decoding DoS |
+| CVE-2022-41723 | 7.5 | Go | SA-DEP-01 | net/http HPACK decoding DoS |
 | CVE-2022-32148 | 6.5 | Go | SA-GO-08 | ReverseProxy SSRF |
 | CVE-2022-23772 | 7.5 | Go | SA-GO-01, SA-DEP-01 | math/big DoS |
 | CVE-2013-0156 | 10.0 | Ruby | SA-RB-05, SA-RAILS-01 | Rails YAML deserialization |
@@ -1084,7 +1084,7 @@ Cross-reference with:
 | CVE-2023-22796 | 7.5 | Ruby | SA-DEP-01 | Rails ActiveSupport ReDoS |
 | CVE-2023-22797 | 6.1 | Ruby | SA-RAILS-02, SA-RAILS-04 | Rails open redirect |
 | CVE-2023-27530 | 7.5 | Ruby | SA-DEP-01 | Rack multipart DoS |
-| CVE-2019-11068 | 9.8 | Ruby | SA-RB-05, SA-DEP-01 | Nokogiri XXE |
+| CVE-2019-11068 | 9.8 | Ruby | SA-DEP-01 | Nokogiri XXE |
 | CVE-2022-24790 | 9.8 | Ruby | SA-DEP-01 | Puma HTTP smuggling |
 | CVE-2023-2982 | 9.8 | WordPress | SA-WP-04 | WP social login bypass |
 | CVE-2022-21661 | 7.5 | WordPress | SA-WP-01 | WP_Query SQLi |
@@ -1106,7 +1106,7 @@ Cross-reference with:
 | CVE-2019-17558 | 8.1 | AWS | SA-AWS-01, SA-AWS-03 | AWS IMDS SSRF |
 | CVE-2018-1002105 | 9.8 | Kubernetes | SA-IAC-01 | K8s privilege escalation |
 | CVE-2023-37918 | 6.5 | Terraform | SA-AWS-01, SA-IAC-03 | TF AWS cred exposure |
-| CVE-2023-33953 | 7.5 | CI/CD | SA-IAC-01, SA-SC-01 | GH Actions script injection |
+| CVE-2023-33953 | 7.5 | CI/CD | SA-GHA-01, SA-SC-01 | GH Actions script injection |
 | CVE-2020-0069 | 7.8 | Android | SA-ANDROID-01, SA-ANDROID-02 | MediaTek-SU root |
 | CVE-2019-8641 | 9.8 | iOS | SA-IOS-03, SA-IOS-01 | iMessage zero-click |
 | CVE-2023-32434 | 8.6 | iOS | SA-IOS-01, SA-IOS-05 | Triangulation kernel |
@@ -1123,4 +1123,4 @@ Cross-reference with:
 
 | Date | Change | Phase |
 |------|--------|-------|
-| 2026-03-31 | Initial release -- 100+ CVEs mapped | Phase C1 |
+| 2026-03-31 | Initial release -- 95 CVEs mapped | Phase C1 |


### PR DESCRIPTION
## Summary

Adds a 1,126-line CVE-catalog reference mapping **113** known CVEs to our checkpoints. Closes the fork-import roadmap started with #43.

Held back until PR #55 landed so the `SA-*` checkpoint cross-references would actually resolve. They do now — all 82 checkpoint refs in the catalog resolve against `checkpoints.yaml`.

## Content shape

Each of the 113 entries has:
- CVSS score
- CWE category
- Affected language / framework / version range
- **Related checkpoints** — `SA-JAVA-03`, `SA-IAC-01`, etc.
- Detection hints
- Remediation guidance

Covers Log4Shell, Shellshock, Spring4Shell, Drupalgeddon 2/3, TYPO3 SA-CORE advisories, npm-event-stream supply chain, Django/Rails/FastAPI per-framework CVEs, cloud IAM misconfigurations, etc. Grouped by stack: Java, Python, JS/Node, PHP, C#/.NET, Go, Ruby, WordPress, Infrastructure/Cross-platform, Mobile, Rust — plus "Additional CVEs" blocks per stack for follow-on entries.

Added a TOC at the top so the catalog is usable as a lookup table.

## Complements `cve-patterns.md`

| File | Role | Organized by |
|---|---|---|
| `cve-patterns.md` (existing, 1,479 lines) | CVE-derived pattern guide | Vulnerability class (Type Juggling, PHAR Deser, SSTI, …) |
| `cve-database.md` (new, 1,126 lines) | CVE→checkpoint mapping catalog | CVE identifier |

## Review / validation history

**21 content-accuracy findings** on the initial fork-import (fix commit `8d2d90f`):

*Mislabeled entries* — title didn't match detection text / actual CVE:
- Express `path traversal` → `open redirect` (CVE-2024-29041)
- Axios `SSRF` → `XSRF token leak` (CVE-2023-45857)
- Go `crypto/tls session ticket key rotation` → `x/crypto/ssh PublicKeyCallback authn bypass` (CVE-2024-45337)
- Go `archive/zip path traversal` → `net/http HPACK decoding DoS` (CVE-2022-41723, CWE-22 → CWE-400)
- FastAPI `path traversal` → `python-multipart ReDoS` (CVE-2024-24762)
- Django entry was a CVE-ID/content mix-up — retitled to CVE-2016-9014 (hardcoded test-DB password) to match detection text; noted CVE-2016-9013 (Host-header + DEBUG=True) as sibling to audit alongside

*Wrong checkpoint mappings* — fork pointed at unrelated checkpoints:
- PHP-FPM RCE: dropped SA-08 (XXE) — infra-level bug, no source checkpoint fits
- HTTPoxy: dropped SA-10 ($_GET) — env-var confusion, not GET injection
- unserialize UAF: SA-11 → SA-21/SA-22 (the real unserialize checkpoints)
- Drupalgeddon 2: SA-DRUPAL-01 (SQLi) → SA-DRUPAL-02/03 (#markup render-array)
- GH Actions script injection: SA-IAC-01 → SA-GHA-01 (the correct workflow checkpoint)
- Nokogiri XXE: dropped SA-RB-05 (YAML) — it's XML XXE, not YAML
- Puma HTTP smuggling: dropped SA-RB-10 (Kernel.open) — runtime-layer bug

**2 skill-creator follow-up findings** (fix commit `cd4d367`):

- **Count discrepancy**: actual file has 113 CVE entries, not 95. My initial PR description + changelog were wrong. Fixed both.
- **Missing TOC**: added a Contents block at the top. At 1,126 lines with 20 H3 sections, this is the most TOC-worthy reference in the repo — it's a lookup catalog users dip into by stack, not prose.

## Cross-reference integrity

- **84 distinct `SA-*` identifiers** in the document
- 2 are external TYPO3 Security Advisory IDs (`SA-CORE-YYYY-NNN`, typo3.org/security) — legitimate free-text refs, not our checkpoints
- **82 point at our own `checkpoints.yaml` and all 82 resolve** (thanks to the 309 checkpoints imported in #55)

## SKILL.md

- Reference Files: `Modern Threats` row renamed to `Threats`, added `cve-database`.
- Still **500 words exactly** (the `validate-skill.sh` cap).

## Skill-creator validation

| Check | Result |
|---|---|
| `validate-skill.sh` | 0 errors, 0 warnings |
| YAML parses | `mechanical: 377, llm_reviews: 45` unchanged |
| Cross-ref integrity | 82 checkpoint refs, 0 unresolved |
| Mislabeled titles | fixed 6 entries |
| Wrong checkpoint mappings | fixed 7 entries |
| CVE count claim | corrected to 113 (was 100+ / 95) |
| TOC | added |

## Provenance

Imported from [evandervecht/security-audit-skill](https://github.com/evandervecht/security-audit-skill) — dual-licensed MIT + CC-BY-SA-4.0 fork by [E van der Vecht](mailto:evandervecht@schubergphilis.com).

## Roadmap

Closes the "import from fork" workstream started in #43 (16 PRs total). Remaining items (per offline discussion):
- Reply to Ellert's initial email (drafted earlier, never sent)
- Goodwill PR back to his fork with fixes accumulated here