### PR TITLE
feat: TYPO3 v14.3 LTS security audit checklist

### DIFF
--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-audit
-description: "Use when conducting security assessments — OWASP Top 10, OWASP API Top 10, OWASP LLM Top 10, CWE Top 25, or CVSS scoring — auditing PHP/TYPO3, REST/GraphQL APIs, frontend, Terraform/Kubernetes/Docker IaC, AWS/Azure/GCP cloud, or AI agent configs (SKILL.md/AGENTS.md/CLAUDE.md/mcp.json/hooks.json) for vulnerabilities, or scanning dependencies."
+description: "Use when conducting security assessments — OWASP Top 10 / API / LLM, CWE Top 25, CVSS scoring — auditing PHP/TYPO3 (v14.3 LTS: #109585, HashService removal, Authorize/RateLimit), APIs, frontend, Terraform/K8s/Docker IaC, AWS/Azure/GCP cloud, AI agent configs, or scanning dependencies."
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires grep, jq, gh CLI."
 metadata:
@@ -12,7 +12,7 @@ allowed-tools: Bash(grep:*) Bash(jq:*) Bash(gh:*) Read Glob Grep
 
 # Security Audit Skill
 
-Security audit patterns (OWASP Top 10, LLM Top 10 2025, CWE Top 25 2025, CVSS v4.0), cloud/IaC checks, GitHub project security. 80+ PHP/TYPO3 checkpoints.
+Security audit patterns (OWASP Top 10, LLM Top 10 2025, CWE Top 25 2025, CVSS v4.0), cloud/IaC checks, GitHub security. 80+ PHP/TYPO3 checkpoints (v14.3 LTS in `typo3-security.md`).
 
 ## Expertise Areas
 

--- a/skills/security-audit/references/typo3-security.md
+++ b/skills/security-audit/references/typo3-security.md
@@ -501,7 +501,7 @@ v14.0 strengthened the HMAC algorithm family from SHA1 to SHA256 (Breaking [#106
 **Detection (grep):**
 ```bash
 grep -rn 'GeneralUtility::hmac(\|HashService' Classes/ --include='*.php'
-grep -rn 'Extbase\\\\Security\\\\Cryptography\\\\HashService' Classes/ --include='*.php'
+grep -rn 'Extbase\\Security\\Cryptography\\HashService' Classes/ --include='*.php'
 ```
 
 **Remediation:** migrate callers to `TYPO3\CMS\Core\Crypto\HashService`; force regeneration of any persisted HMACs.
@@ -527,7 +527,7 @@ v14.2+ ships [`#[Authorize]`](https://docs.typo3.org/c/typo3/cms-core/main/en-us
 grep -rn '#\[Authorize\|#\[RateLimit' Classes/Controller --include='*.php'
 ```
 
-Missing attributes on sensitive endpoints → **recommended finding**. For v13+v14 dual compatibility, guard with `class_exists()` — v13 safely ignores unknown attributes.
+Missing attributes on sensitive endpoints → **recommended finding** (not a vulnerability). For v13+v14 dual compatibility, runtime `class_exists()` guards don't work on attributes (attributes are declarative syntax). Ship polyfill stub classes for v13 so the `use` + `#[…]` constructs parse cleanly on both versions; see `typo3-conformance-skill` `references/v13-v14-dual-compatibility.md` for the concrete pattern.
 
 ### AUDIT-005: TypoScript `userFunc` allow-list (#108054)
 

--- a/skills/security-audit/references/typo3-security.md
+++ b/skills/security-audit/references/typo3-security.md
@@ -470,3 +470,80 @@ $typo3Patterns = [
 
 ---
 
+## TYPO3 v14.3 LTS security audit checklist
+
+v14.3 LTS (released 2026-04-21) brings several security-relevant changes that should appear on any v13→v14 audit:
+
+### AUDIT-001: Important #109585 — Serialized credential data in `be_users`
+
+**Severity:** HIGH (plaintext credentials persisted in DB)
+**Applies to:** any TYPO3 site that ran v14.2 at any point.
+
+During v14.2 runtime, backend-user password changes could persist serialized plaintext password fields into `be_users.uc` / `user_settings` columns.
+
+**Detection (SQL):**
+```sql
+SELECT uid, username FROM be_users
+WHERE uc LIKE '%password%' OR user_settings LIKE '%password%';
+```
+
+**Remediation:** Install Tool → Upgrade → Upgrade Wizards → run the v14.3-provided wizard that unserializes, strips password fields, and re-serializes. Wizard appears automatically when applicable.
+
+**Citation:** [Important #109585](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.3/Important-109585-SerializedCredentialDataInBeUsersDatabaseTable.html)
+
+### AUDIT-002: HMAC algorithm strengthened (SHA1 → SHA256)
+
+**Severity:** MEDIUM (cryptographic hygiene)
+**Applies to:** all extensions calling `GeneralUtility::hmac()` or `HashService`.
+
+v14.0 strengthened the HMAC algorithm family from SHA1 to SHA256 (Breaking [#106307](https://forge.typo3.org/issues/106307)). Persisted HMACs minted under v13 will no longer validate.
+
+**Detection (grep):**
+```bash
+grep -rn 'GeneralUtility::hmac(\|HashService' Classes/ --include='*.php'
+grep -rn 'Extbase\\\\Security\\\\Cryptography\\\\HashService' Classes/ --include='*.php'
+```
+
+**Remediation:** migrate callers to `TYPO3\CMS\Core\Crypto\HashService`; force regeneration of any persisted HMACs.
+
+### AUDIT-003: Extbase `HashService` removed (for v14 targets)
+
+**Severity:** HIGH (broken code in v14)
+**Applies to:** extensions declaring `typo3/cms-core: ^14`.
+
+`TYPO3\CMS\Extbase\Security\Cryptography\HashService` is **removed in v14** (part of #105377 umbrella). Any extension claiming v14 support that still references it will crash.
+
+**Remediation:** replace with `TYPO3\CMS\Core\Crypto\HashService`. For symmetric-encryption use cases, use the new cipher service (Feature [#108002](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.0/Feature-108002-SymmetricEncryptionAndDecryptionOfData.html)).
+
+### AUDIT-004: Recommended controls — `#[Authorize]` and `#[RateLimit]`
+
+**Severity:** MEDIUM (defense-in-depth)
+**Applies to:** Extbase controllers handling login, password reset, import/export, registration.
+
+v14.2+ ships [`#[Authorize]`](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.2/Feature-107826-IntroduceExtbaseActionAuthorizationLogic.html) (`requireLogin`, `requireGroups`) and [`#[RateLimit]`](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.2/Feature-108982-NewExtbaseAttributeForRateLimitingControllerActions.html) attributes, integrated with TYPO3's unified rate-limiter factory (Feature [#109080](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.2/Feature-109080-UnifiedRateLimiterFactoryWithAdminOverrides.html)).
+
+**Audit:**
+```bash
+grep -rn '#\[Authorize\|#\[RateLimit' Classes/Controller --include='*.php'
+```
+
+Missing attributes on sensitive endpoints → **recommended finding**. For v13+v14 dual compatibility, guard with `class_exists()` — v13 safely ignores unknown attributes.
+
+### AUDIT-005: TypoScript `userFunc` allow-list (#108054)
+
+**Severity:** LOW (hardening)
+**Applies to:** sites using TypoScript or TSconfig callables.
+
+Breaking #108054 requires explicit allow-listing via `$GLOBALS['TYPO3_CONF_VARS']['SYS']['allowedFunctions']['typoscript']`. Unlisted callables are silently ignored.
+
+**Detection:** cross-reference TypoScript `userFunc`/`preUserFunc`/`postUserFunc` references against `ext_localconf.php` allow-lists.
+
+### AUDIT-006: SRI + CSP preferences (v14.2+)
+
+- v14.2 adds automatic SRI hash resolution (Feature [#109187](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.2/Feature-109187-IntegrityPropertyAndAutomaticSRIResolving.html)) and `integrity` for CSS includes.
+- `useNonce` in `f:asset:css`/`script` deprecated (Deprecation [#100887](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.2/Deprecation-100887-DeprecateUseNonceArgumentOfAssetViewHelpers.html)) — prefer CSP hashes.
+
+**Audit:** if the project has an active CSP policy, verify migration from nonce-based allow-lists to hash-based.
+
+---
+


### PR DESCRIPTION
## Summary

TYPO3 v14.3 LTS (2026-04-21) brings several security-relevant changes that every v13→v14 audit should cover. This PR adds six audit items to the TYPO3-specific security reference and updates SKILL.md triggers so the skill activates on the new keywords.

Landing page for the full v14 reference: <https://netresearch.github.io/typo3-conformance-skill/>

## Changes

- **SKILL.md**: description + body trigger on v14.3 LTS security items (#109585, HashService removal, `#[Authorize]`/`#[RateLimit]`); body cross-links to `typo3-security.md`.
- **`references/typo3-security.md`** adds the "TYPO3 v14.3 LTS security audit checklist":
  - **AUDIT-001** Important [#109585](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.3/Important-109585-SerializedCredentialDataInBeUsersDatabaseTable.html) — serialized credential data in `be_users` (SQL detection + upgrade-wizard remediation; HIGH severity)
  - **AUDIT-002** HMAC SHA1→SHA256 strengthening (#106307) with grep detection + rotation strategy
  - **AUDIT-003** Extbase `HashService` removal → broken code in v14, migrate to `Core\Crypto\HashService`
  - **AUDIT-004** Recommended `#[Authorize]` + `#[RateLimit]` (#107826, #108982, #109080), dual-v13 guarded via `class_exists()`
  - **AUDIT-005** TypoScript `userFunc` allow-list hardening (#108054)
  - **AUDIT-006** SRI auto-resolution (#109187) + CSP hash-over-nonce preference (#100887 deprecation)

## Test plan

- [ ] SKILL.md under 500-word limit (currently 499)
- [ ] All Forge issue links resolve
- [ ] SQL detection query in AUDIT-001 runs without syntax errors
- [ ] Grep patterns in AUDIT-002/003/004 are valid POSIX regex
- [ ] Markdown lint passes