### PR TITLE
feat: ship as npm package via @netresearch/agent-skill-coordinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,25 @@ composer require netresearch/security-audit-skill
 ```
 
 Requires [netresearch/composer-agent-skill-plugin](https://github.com/netresearch/composer-agent-skill-plugin).
+
+### npm (Node Projects)
+
+```bash
+npm install --save-dev \
+  @netresearch/agent-skill-coordinator \
+  github:netresearch/security-audit-skill
+```
+
+Requires [@netresearch/agent-skill-coordinator](https://github.com/netresearch/node-agent-skill-coordinator), which discovers the skill in `node_modules` and registers it in `AGENTS.md` via a `postinstall` hook. For pnpm, also allowlist the coordinator's postinstall:
+
+```json
+{
+  "pnpm": {
+    "onlyBuiltDependencies": ["@netresearch/agent-skill-coordinator"]
+  }
+}
+```
+
 ## Usage
 
 This skill is automatically triggered when:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@netresearch/security-audit-skill",
+  "version": "0.0.0-source",
+  "description": "Netresearch AI skill for security audits (OWASP, CWE, CVSS). Universal patterns + deep PHP/TYPO3 scanning with 80+ checkpoints.",
+  "license": "(MIT AND CC-BY-SA-4.0)",
+  "author": "Netresearch DTT GmbH (https://www.netresearch.de/)",
+  "homepage": "https://github.com/netresearch/security-audit-skill",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/netresearch/security-audit-skill.git"
+  },
+  "bugs": {
+    "url": "https://github.com/netresearch/security-audit-skill/issues"
+  },
+  "keywords": [
+    "ai-agent-skill",
+    "security",
+    "owasp",
+    "cwe",
+    "cvss",
+    "audit",
+    "anthropic",
+    "claude-code"
+  ],
+  "aiAgentSkill": "skills/security-audit/SKILL.md",
+  "files": [
+    "skills/security-audit/",
+    "LICENSE-MIT",
+    "LICENSE-CC-BY-SA-4.0",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "@netresearch/agent-skill-coordinator": "^0.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   "aiAgentSkill": "skills/security-audit/SKILL.md",
   "files": [
     "skills/security-audit/",
+    "hooks/",
+    "scripts/",
     "LICENSE-MIT",
     "LICENSE-CC-BY-SA-4.0",
     "README.md"


### PR DESCRIPTION
## Summary
- Adds `package.json` so the skill is npm-installable straight from this GitHub repo (no npm-registry publication required to start).
- README gains a parallel **npm (Node Projects)** section under Installation, mirroring the existing **Composer (PHP Projects)** section.

## How discovery works (consumer side)

After installing the coordinator + this package, the coordinator's `postinstall` walks `node_modules`, finds this package via the `aiAgentSkill` field, validates the frontmatter, and writes a `<skills_system>` block into the projects `AGENTS.md`. Same shape as the Composer plugin output, so any agent that reads either works here unchanged.

## Why version stays at `0.0.0-source`

Versioning still lives in git tags and the existing release workflow. A real npm version would be set at publish time; until then, `0.0.0-source` is the placeholder that signals "manifest exists for tooling, not as a release marker."

## Sibling PRs
- Coordinator: https://github.com/netresearch/node-agent-skill-coordinator (released as `@netresearch/agent-skill-coordinator@0.1.1`)
- git-workflow-skill: https://github.com/netresearch/git-workflow-skill/pull/39