### PR TITLE
chore(release): v2.9.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-audit",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "Security audit patterns (OWASP Top 10, CWE Top 25 2025, CVSS v4.0) and GitHub project security checks for any project. Deep automated PHP/TYPO3 scanning with 80+ checkpoints, 19 reference guides, PreToolUse warnings. By Netresearch.",
   "repository": "https://github.com/netresearch/security-audit-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires grep, jq, gh CLI."
 metadata:
   author: Netresearch DTT GmbH
-  version: "2.8.1"
+  version: "2.9.0"
   repository: https://github.com/netresearch/security-audit-skill
 allowed-tools: Bash(grep:*) Bash(jq:*) Bash(gh:*) Read Glob Grep
 ---


### PR DESCRIPTION
## Release v2.9.0

Minor release. Bumps `.claude-plugin/plugin.json` and `skills/security-audit/SKILL.md` frontmatter `metadata.version` from `2.8.1` to `2.9.0`. Picks up nine commits since `v2.8.1`.

### Highlights since v2.8.1

- `feat`: ship as an npm package via `@netresearch/agent-skill-coordinator` so consumers on JS/TS toolchains can install the skill alongside the existing composer route. Tarball assembly is corrected to ship `hooks/` and `scripts/`.
- `feat(checkpoints)`: use `org_provides` for SECURITY.md so org-level baselines suppress per-repo file-presence checks. Companion fix honors org-provided SECURITY.md and intra-org wildcard dependencies; further follow-up addresses review feedback on SA-01 and SA-SC-02.
- `fix(deps)`: pin `netresearch/composer-agent-skill-plugin` to v2 (Renovate-driven).
- `ci(release)`: grant SLSA provenance permissions, trailing-newline yamllint fix, and drop the deprecated `with:` block + `workflow_dispatch.bump` input.

### Release plan

After merge: tag main with a signed annotated tag, push, the `skill-repo-skill` reusable workflow publishes archives + SHA256SUMS with cosign + SLSA attestation, then narrative notes get applied via `gh release edit ... --notes-file`.
