### PR TITLE
chore(release): v2.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-audit",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "Security audit patterns (OWASP Top 10, CWE Top 25 2025, CVSS v4.0) and GitHub project security checks for any project. Deep automated PHP/TYPO3 scanning with 80+ checkpoints, 19 reference guides, PreToolUse warnings. By Netresearch.",
   "repository": "https://github.com/netresearch/security-audit-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires grep, jq, gh CLI."
 metadata:
   author: Netresearch DTT GmbH
-  version: "2.9.0"
+  version: "2.10.0"
   repository: https://github.com/netresearch/security-audit-skill
 allowed-tools: Bash(grep:*) Bash(jq:*) Bash(gh:*) Read Glob Grep
 ---


### PR DESCRIPTION
Release **v2.10.0** (minor bump, conventional commits since v2.9.0).

Bumps `.claude-plugin/plugin.json` + `SKILL.md` version to 2.10.0.

Changes since v2.9.0:
- feat(references): add security-invariants
- 
- Encodes authorization boundaries, tenant isolation, principal
- binding, and redaction guarantees as runtime assertions in the
- code path — complementing (not replacing) input validation and
- test coverage. Examples in PHP, Go, TypeScript, Python.
- 
- Explicit anti-patterns include asserting on attacker-controlled
- fields and wrapping assertions in catch-all handlers (fail-open).
- Pairs with input-validation, authentication-patterns, and
- security-logging; primary OWASP fits are A01, A04, A09.
- 
- Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>
- docs(security-invariants): address review feedback
- 
- - Qualify intro: 'proves in production' only when checks are
-   always-on (strippable assert/assert are not enough for security)
- - PHP example: use thrown InvariantViolation instead of \assert(),
-   because \assert() is stripped under zend.assertions=-1
- - Python example: use 'if not cond: raise' instead of assert,

After merge: a signed tag `v2.10.0` on `main` triggers the release workflow.