### PR TITLE
docs(security-audit): confirm real exposure in the deployed artifact

### DIFF
--- a/skills/security-audit/references/supply-chain-security.md
+++ b/skills/security-audit/references/supply-chain-security.md
@@ -739,6 +739,16 @@ permissions:[\s\S]*?contents:\s+write(?!.*security-events)
 | Low | No SLSA Level 3 provenance | 1 month |
 | Low | No reproducible build verification | 1 month |
 
+## Confirm real exposure in the deployed artifact
+
+An advisory version range is a *candidate*, not a verdict. Before reporting a component as affected, confirm the vulnerable code is **actually present at a vulnerable version in the artifact that ships** — inventory the real container image, JARs, or lockfile, not just the spec:
+
+- **False positives:** a bundled library may already be a patched version, a transitive dependency may be absent, or the named component (e.g. Struts) may not be in the build at all. A per-component version check removes these.
+- **False negatives:** vendor advisories often list only *currently-supported* version ranges, so an older, frozen build below the listed floor can still ship the same vulnerable component (a scan-window artifact). Check the actual bundled version, not the advisory's lower bound.
+- **Reachability:** confirm the vulnerable code path is reachable in *this* deployment (entrypoint/feature enabled, pre-auth vs authenticated) before ranking severity.
+
+This routinely shrinks a long advisory-range list to a much smaller, accurate exposure set — and can reverse wrong conclusions.
+
 ## Related References
 
 - `ci-security-pipeline.md` - CI tools that implement these practices


### PR DESCRIPTION
Adds a principle: an advisory version range is a candidate, not a verdict. Verify the vulnerable component is actually present at a vulnerable version in the shipped artifact (removes false positives), that an older frozen build below the advisory floor isn't still shipping it (scan-window false negatives), and that the path is reachable. From a retro after an image-verified Jira CVE assessment collapsed a 51-CVE advisory list to a much smaller real-exposure set.