### PR TITLE
chore(release): v2.10.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-audit",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "Security audit patterns (OWASP Top 10, CWE Top 25 2025, CVSS v4.0) and GitHub project security checks for any project. Deep automated PHP/TYPO3 scanning with 80+ checkpoints, 19 reference guides, PreToolUse warnings. By Netresearch.",
   "repository": "https://github.com/netresearch/security-audit-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires grep, jq, gh CLI."
 metadata:
   author: Netresearch DTT GmbH
-  version: "2.10.1"
+  version: "2.10.2"
   repository: https://github.com/netresearch/security-audit-skill
 allowed-tools: Bash(grep:*) Bash(jq:*) Bash(gh:*) Read Glob Grep
 ---


### PR DESCRIPTION
Release v2.10.2.

Bumps plugin.json + skill metadata version 2.10.1 → 2.10.2.

Content since v2.10.1:
- docs(security-audit): confirm real exposure in the deployed artifact (#76)
- ci: adopt canonical skill template; allowlist pedagogical VULNERABLE examples (#75)