### PR TITLE
docs(js-ts): inline-<script> JSON data-island XSS pattern

### DIFF
--- a/skills/security-audit/checkpoints.yaml
+++ b/skills/security-audit/checkpoints.yaml
@@ -833,6 +833,13 @@ mechanical:
     severity: error
     desc: "postMessage with wildcard origin - data exposed to any frame"
 
+  - id: SA-JS-21
+    type: regex_not
+    target: "**/*.{js,ts,jsx,tsx,mjs,cjs}"
+    pattern: "replace(All)?\\(\\s*['\"\\x60]</script"
+    severity: warning
+    desc: "naive </script> escaping of a JSON data island - use replaceAll('<','\\u003c') + function replacer"
+
   # === NODE.JS SERVER-SIDE SECURITY (Phase 3) ===
   - id: SA-NODE-01
     type: regex_not

--- a/skills/security-audit/references/javascript-typescript-security-features.md
+++ b/skills/security-audit/references/javascript-typescript-security-features.md
@@ -152,9 +152,10 @@ interpolates the JSON, not in a browser API. Three footguns compound:
 //  3. Escaping only lowercase `</script>` is bypassable: </ScRiPt>, </script >, <!--
 
 // GOOD:
-if (!template.includes('__DATA_JSON__')) throw new Error('placeholder missing');
+const n = template.split('__DATA_JSON__').length - 1;
+if (n !== 1) throw new Error(`template must contain exactly one __DATA_JSON__ placeholder (found ${n})`);
 const payload = JSON.stringify(data).replaceAll('<', '\\u003c'); // still valid JSON; neutralizes every </script> casing, <script, and <!--
-const html = template.replace('__DATA_JSON__', () => payload);   // function replacement disables $-pattern interpretation
+const html = template.replace('__DATA_JSON__', () => payload);   // exactly one match (asserted above); function replacement disables $-pattern interpretation
 ```
 
 - Escaping `<` to its unicode form yields valid JSON (`JSON.parse` restores it)
@@ -163,7 +164,9 @@ const html = template.replace('__DATA_JSON__', () => payload);   // function rep
 - Use a **function** replacement (`() => payload`) so `$`-sequences in the data are
   never interpreted.
 - Use a placeholder token **distinct** from the JS variable name (`__DATA_JSON__`,
-  not `__DATA__`) to avoid the first-match substitution trap.
+  not `__DATA__`), and **assert it occurs exactly once** — `String.replace`
+  substitutes only the first match, so a duplicated placeholder would silently
+  ship partially-substituted, broken output.
 
 When rendering those values back into the DOM as markup, escape at every sink
 through one centralized helper so no call site is missed:
@@ -809,7 +812,7 @@ class AuthService {
 | Nested regex quantifiers | `(\+\)\+|\*\)\*|\+\)\*)` | warning | SA-JS-18 |
 | strict mode disabled | `"strict"\s*:\s*false` | warning | SA-JS-19 |
 | Unvalidated JSON.parse reviver | `JSON\.parse\([^)]+,\s*\(` | warning | SA-JS-20 |
-| Naive `</script>` escaping of a JSON data island | `replaceAll\(\s*['"]<\/script` | warning | SA-JS-21 |
+| Naive `</script>` escaping of a JSON data island | `replace(All)?\(\s*['"\x60]</script` | warning | SA-JS-21 |
 
 ## Version Adoption Security Checklist
 

--- a/skills/security-audit/references/javascript-typescript-security-features.md
+++ b/skills/security-audit/references/javascript-typescript-security-features.md
@@ -134,6 +134,54 @@ element.innerHTML = DOMPurify.sanitize(userHtml);
 
 **Security implication:** DOM XSS (CWE-79) bypasses server-side sanitization because the payload never reaches the server. The `innerHTML`, `outerHTML`, and `document.write` sinks interpret HTML markup, while `location.href` can execute `javascript:` URIs. Always use `textContent` for text output.
 
+### 3a. Embedding Untrusted JSON into an Inline `<script>` (build-time / SSR data island)
+
+Serializing data (some of it third-party — API descriptions, user profiles) into
+an inline `<script>` data island is a stored-XSS sink distinct from the DOM sinks
+above: the injection happens at **build/render time**, in the string that
+interpolates the JSON, not in a browser API. Three footguns compound:
+
+```javascript
+// BAD: template.replace('__DATA__', JSON.stringify(data).replaceAll('</script>', '<\\/script>'))
+//  1. String.prototype.replace(str, replacement) treats $' $& $` $$ in the REPLACEMENT
+//     as substitution patterns -> a $' inside any data value splices the template's
+//     suffix (including a literal </script>) back into the emitted JSON -> breakout.
+//  2. replace(str, ...) replaces only the FIRST match. If the template holds two
+//     identical tokens (`window.__DATA__ = __DATA__;`) it substitutes the variable
+//     name, shipping a blank page -- a correctness bug that masks the security one.
+//  3. Escaping only lowercase `</script>` is bypassable: </ScRiPt>, </script >, <!--
+
+// GOOD:
+if (!template.includes('__DATA_JSON__')) throw new Error('placeholder missing');
+const payload = JSON.stringify(data).replaceAll('<', '\\u003c'); // still valid JSON; neutralizes every </script> casing, <script, and <!--
+const html = template.replace('__DATA_JSON__', () => payload);   // function replacement disables $-pattern interpretation
+```
+
+- Escaping `<` to its unicode form yields valid JSON (`JSON.parse` restores it)
+  while making it impossible to close the `<script>` element or open a new
+  tag/comment.
+- Use a **function** replacement (`() => payload`) so `$`-sequences in the data are
+  never interpreted.
+- Use a placeholder token **distinct** from the JS variable name (`__DATA_JSON__`,
+  not `__DATA__`) to avoid the first-match substitution trap.
+
+When rendering those values back into the DOM as markup, escape at every sink
+through one centralized helper so no call site is missed:
+
+```javascript
+const esc = s => String(s ?? '').replace(/[&<>"']/g,
+  c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+```
+
+**Verify with a poison test:** inject `</script>`, `$'`, and `onerror=` payloads
+into the data, render headless, and assert the page is inert and non-blank —
+escaping bugs and the blank-page substitution trap both surface only at render.
+
+**Security implication:** Stored XSS (CWE-79). Naive `String.replace` templating
+of a JSON data island is exploitable even when no dynamic-HTML DOM sink is used,
+and the safe form costs one `replaceAll('<', '\\u003c')` plus a function
+replacement.
+
 ### 4. `postMessage` Origin Validation
 
 The `postMessage` API enables cross-origin communication. Without origin validation, any page can send messages to your application.
@@ -761,6 +809,7 @@ class AuthService {
 | Nested regex quantifiers | `(\+\)\+|\*\)\*|\+\)\*)` | warning | SA-JS-18 |
 | strict mode disabled | `"strict"\s*:\s*false` | warning | SA-JS-19 |
 | Unvalidated JSON.parse reviver | `JSON\.parse\([^)]+,\s*\(` | warning | SA-JS-20 |
+| Naive `</script>` escaping of a JSON data island | `replaceAll\(\s*['"]<\/script` | warning | SA-JS-21 |
 
 ## Version Adoption Security Checklist
 
@@ -790,3 +839,4 @@ class AuthService {
 | Date | Change | Reason |
 |------|--------|--------|
 | 2026-03-31 | Initial release | Phase 3 |
+| 2026-07-05 | Add §3a inline-`<script>` JSON data-island XSS + SA-JS-21 | Real stored-XSS class found building a data dashboard |

--- a/skills/security-audit/scripts/scanners/javascript.sh
+++ b/skills/security-audit/scripts/scanners/javascript.sh
@@ -202,6 +202,18 @@ else
     echo "OK: No wildcard postMessage targets detected"
 fi
 
+# === Check for naive </script> escaping of a JSON data island (SA-JS-21) ===
+echo ""
+echo "=== Checking for Naive </script> Escaping ==="
+SCRIPT_ESCAPE_HITS=$(scan_js "replace(All)?\(\s*['\"\\x60]</script" 10)
+if [[ -n "$SCRIPT_ESCAPE_HITS" ]]; then
+    echo "WARNING: naive </script> escaping of a data island (stored XSS via \$-patterns / case bypass); use replaceAll('<','\\u003c') + a function replacer:"
+    echo "$SCRIPT_ESCAPE_HITS" | head -5
+    WARNINGS=$((WARNINGS + 1))
+else
+    echo "OK: No naive </script> escaping detected"
+fi
+
 # === Check for npm audit vulnerabilities ===
 echo ""
 echo "=== Checking Dependencies ==="


### PR DESCRIPTION
## Summary

Add a JavaScript/TypeScript security pattern for safely embedding untrusted JSON into an inline `<script>` data island — a stored-XSS sink distinct from the DOM sinks already in section 3.

## Came from

`/retro` sweep on 2026-07-05 of session `44c102fc` (2026-07-04).
Finding: B8 (a reusable web-security technique had been captured only in cwd-scoped project-local memory) + B16 (hard-won technique). The class was found and fixed while building a data dashboard.

## Change

- New **§3a** with BAD/GOOD examples and a poison-test verification step, covering the three compounding footguns:
  - `String.replace` interpreting `$'`/`$&`/`` $` ``/`$$` in the *replacement* as substitution patterns (breakout via a `$'` in any value);
  - first-match-only replacement shipping a blank page when the template reuses the variable name;
  - case/whitespace bypass of naive `</script>` escaping. Safe form: `replaceAll('<', '<')` + a function replacement + a distinct placeholder token.
- Detection pattern **SA-JS-21** (`replaceAll('</script'…`).
- Changelog row.

## Test plan

- [ ] Skill Validation (markdown/link lint) passes
- [ ] Poison payloads (`</script>`, `$'`, `onerror=`) render inert with the GOOD form
- [ ] SA-JS-21 regex matches the BAD `replaceAll('</script>', …)` line
