### PR TITLE
docs(references): SonarCloud S8705 array-form subprocess false positives + API FP marking

### DIFF
--- a/skills/security-audit/references/automated-scanning.md
+++ b/skills/security-audit/references/automated-scanning.md
@@ -1,6 +1,6 @@
 # Automated Scanning Tools Reference
 
-Configuration, custom rules, CI integration, and best practices for semgrep / opengrep, trivy, and gitleaks.
+Configuration, custom rules, CI integration, and best practices for semgrep / opengrep, trivy, and gitleaks, plus false-positive handling for SonarCloud / SonarQube quality gates (SonarCloud is hosted; SonarQube is self-hosted).
 
 ## Tool Comparison
 
@@ -315,6 +315,78 @@ repos:
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+---
+
+## SonarCloud / SonarQube Quality Gate
+
+SonarCloud runs its own SAST engine (including AI-authored taint rules) and gates a PR
+via a **quality gate**. Sonar's inline suppression is `# NOSONAR` (or
+`# NOSONAR(ruleKey)`), but it leaves a marker in the code and suppresses *every* issue on
+the line. For a genuine false positive, prefer clearing it through the SonarCloud **API**
+(or UI): it records an auditable review decision, keeps the source clean, and the gate
+then recomputes.
+
+### AI taint rules over-flag safe patterns
+
+Sonar's AI taint rules match a **call pattern**, not the actual exploitability, so they
+raise false positives on code that is already safe:
+
+| Rule | Flags | Why it is often a false positive |
+|------|-------|----------------------------------|
+| `pythonsecurity:S8705` | `subprocess.run([...])` reaching a variable argument (framed as "an LLM could pass faulty CLI arguments and escape a shell sandbox") | Fires even in **array form** (`[cmd, "-x", var]`), which is immune to shell injection because no shell parses the arguments. Adding inline **or** cross-function argument validation does not clear it — the rule matches the shape of the call. |
+| `python:S5443` | String literals under publicly writable directories (`/tmp/...`) | Fires on `/tmp/...` **string literals even inside test fixtures**, where no untrusted process shares the path. |
+
+Practical consequences:
+
+- For **S8705** on an array-form `subprocess` call, two source-side sanitization attempts
+  (inline validation and a cross-function validator) will typically **not** clear the
+  finding. If the call is genuinely safe, mark it a false positive via the API rather than
+  contorting the code.
+- For **S5443** in test data, prefer a non-writable placeholder such as `/opt/...` instead
+  of `/tmp/...` so the literal never trips the rule in the first place.
+
+### Marking a false positive via the API
+
+Requires a token with **Administer Issues** on the project. Use an `Authorization: Bearer`
+header rather than `curl -u` basic auth — the `-u user:pass` form trips secret scanners
+(and reviewers). Note that a token passed as *any* curl argument (header included) is
+still visible to other users via `ps`; to keep it off the process list entirely, load it
+from a file with `curl --config <file>` or a `~/.netrc`.
+
+```bash
+AUTH="Authorization: Bearer $SONAR_TOKEN"
+
+# 1. Find the open issue keys for this PR
+curl -H "$AUTH" \
+  "https://sonarcloud.io/api/issues/search?components=<projectKey>&pullRequest=<N>&types=VULNERABILITY&resolved=false"
+
+# 2. (Optional) attach context explaining why it is a false positive
+curl -H "$AUTH" -X POST \
+  "https://sonarcloud.io/api/issues/add_comment" \
+  --data-urlencode "issue=<issueKey>" \
+  --data-urlencode "text=Array-form subprocess call; args never reach a shell. FP."
+
+# 3. Transition the issue to false-positive
+curl -H "$AUTH" -X POST \
+  "https://sonarcloud.io/api/issues/do_transition" \
+  --data-urlencode "issue=<issueKey>" \
+  --data-urlencode "transition=falsepositive"
+
+# 4. Confirm the gate recomputed green (status: OK)
+curl -H "$AUTH" \
+  "https://sonarcloud.io/api/qualitygates/project_status?projectKey=<projectKey>&pullRequest=<N>"
+```
+
+> **Always document the rationale** (step 2) before resolving — a bare `falsepositive`
+> transition with no comment is indistinguishable from suppressing a real finding.
+
+### Confirm the gate actually blocks merge
+
+SonarCloud's check is frequently **not a required status check**. Before treating a red
+SonarCloud gate as a merge blocker, verify the branch ruleset / protection rules actually
+require it. If it is advisory, fix genuine findings but do not let an over-flagging AI
+taint rule stall the PR.
 
 ---
 


### PR DESCRIPTION
## What

Adds a **SonarCloud / SonarQube** section to `references/automated-scanning.md` covering
false-positive handling for hosted quality gates — a gap next to the existing per-tool
FP guidance for semgrep, trivy, and gitleaks.

The section documents:

- **AI taint rules over-flag safe patterns.** `pythonsecurity:S8705` flags
  `subprocess.run([...])` even in **array form** (immune to shell injection) and even
  after inline *or* cross-function argument validation — it matches the call shape, not
  real exploitability. `python:S5443` flags `/tmp/...` string literals even in test
  fixtures.
- **How to mark a genuine false positive via the API** (token with *Administer Issues*):
  find open issue keys via `api/issues/search`, optionally `api/issues/add_comment`,
  then `api/issues/do_transition` with `transition=falsepositive`, authenticated as
  `curl -u "$SONAR_TOKEN:"` (token as username, empty password); confirm the gate
  recomputed via `api/qualitygates/project_status` (status `OK`).
- **Source-side workaround** for S5443 in test data: use `/opt/...` placeholders.
- **Gate-blocking caveat:** SonarCloud is often *not* a required check — confirm the
  branch ruleset actually gates merge before treating a red gate as a blocker.

## Why

Came out of a real session where an array-form `subprocess` call kept the SonarCloud
gate red on a PR. Two source-side sanitization attempts (inline + cross-function
validation) did not clear S8705 because the rule matches the call pattern, not the
actual risk. The resolution was to mark the finding a false positive through the API and
confirm the gate recomputed green — knowledge worth capturing so the next audit does not
burn time contorting already-safe code.

## Notes

- Extends the existing `automated-scanning.md` reference (already linked from `SKILL.md`)
  rather than adding a new file — matches the per-tool FP-handling pattern already in that
  doc.
- `SKILL.md` untouched: it is already at the 500-word cap, so no References-table row was
  added.
- markdownlint-cli2 passes with 0 errors on the edited file.
