### PR TITLE
chore(release): v2.10.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-audit",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "description": "Security audit patterns (OWASP Top 10, CWE Top 25 2025, CVSS v4.0) and GitHub project security checks for any project. Deep automated PHP/TYPO3 scanning with 80+ checkpoints, 19 reference guides, PreToolUse warnings. By Netresearch.",
   "repository": "https://github.com/netresearch/security-audit-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires grep, jq, gh CLI."
 metadata:
   author: Netresearch DTT GmbH
-  version: "2.10.4"
+  version: "2.10.5"
   repository: https://github.com/netresearch/security-audit-skill
 allowed-tools: Bash(grep:*) Bash(jq:*) Bash(gh:*) Read Glob Grep
 ---


### PR DESCRIPTION
- Retire off-stack cloud/language/framework references (tranche 1 https://github.com/netresearch/security-audit-skill/pull/84, tranche 2 https://github.com/netresearch/security-audit-skill/pull/85)
- Keep the nextjs-security.md gitleaks fingerprint after the reference cut
- Remove stale cve-database.md CVE snapshot
- Drop TYPO3-version specifics from the skill description
- Cut the SKILL.md Quick Patterns block
- Document SonarCloud quality-gate false-positive handling (S8705 array-form subprocess FPs, API FP marking, https://github.com/netresearch/security-audit-skill/pull/82)