### PR TITLE
docs(ci-pipeline): composer audit fails on abandoned packages

### DIFF
--- a/skills/security-audit/references/ci-security-pipeline.md
+++ b/skills/security-audit/references/ci-security-pipeline.md
@@ -63,7 +63,39 @@ jobs:
 - `composer audit` - Check for known vulnerabilities
 - `composer audit --format=json` - Machine-readable output
 - `composer audit --locked` - Check against lock file (faster, no install needed)
-- `composer audit --abandoned` - Also report abandoned packages
+- `composer audit --abandoned=ignore|report|fail` - How abandoned packages affect the exit code
+
+#### Abandoned packages fail the audit too
+
+`composer audit` exits non-zero for an **abandoned** package even when no
+advisory matches — verified on Composer 2.10.2, where a lock containing one
+abandoned package produced `Found 1 abandoned package` and exit 1 with zero
+vulnerabilities. Set the repo-level default in `composer.json` when the
+abandoned dependency is unavoidable (a transitive dependency of the last
+release supporting your minimum PHP version, for example):
+
+```json
+{
+    "config": {
+        "audit": {
+            "abandoned": "report"
+        }
+    }
+}
+```
+
+`report` lists them without failing; `ignore` hides them; `fail` is the
+per-run `--abandoned=fail` behavior.
+
+The abandonment marker is written **into `composer.lock`** at `composer
+update` time, not looked up live at audit time. Two consequences:
+
+- A stale lock hides an abandonment that Packagist already records — the audit
+  stays green until someone refreshes the lock.
+- Refreshing the lock can therefore turn a green audit red with no new CVE.
+  When updating a lock to clear an advisory, re-run `composer audit --locked`
+  against the **new** lock before pushing, or CI trades one red audit for
+  another.
 
 ### Trivy (Multi-Purpose Scanner)
 

--- a/skills/security-audit/references/ci-security-pipeline.md
+++ b/skills/security-audit/references/ci-security-pipeline.md
@@ -84,8 +84,9 @@ release supporting your minimum PHP version, for example):
 }
 ```
 
-`report` lists them without failing; `ignore` hides them; `fail` is the
-per-run `--abandoned=fail` behavior.
+`report` lists them without failing; `ignore` hides them; `fail` — the
+behavior observed with no config set on Composer 2.10.2 — makes an abandoned
+package fail the audit.
 
 The abandonment marker is written **into `composer.lock`** at `composer
 update` time, not looked up live at audit time. Two consequences:


### PR DESCRIPTION
## Summary

`composer audit` exits non-zero for an abandoned package with zero advisories present. The reference listed `--abandoned` as if it only added reporting, and said nothing about the repo-level config knob or about where the abandonment marker actually lives.

## Came from

`/retro` session on 2026-07-25.
Finding: B16 (hard-won technique) + B14 (doc drift).

- **Symptom:** A lock refresh that cleared three `symfony/yaml` CVEs would have failed the same `composer audit` job again — this time on an abandoned transitive dependency, with no vulnerability.
- **Cause:** Composer 2.10.2 defaults to failing on abandoned packages, and records the abandonment marker in `composer.lock` at `composer update` time. A stale lock hides it; refreshing surfaces it.
- **Required behavior:** After refreshing a lock to clear an advisory, re-run `composer audit --locked` against the new lock before pushing; set `config.audit.abandoned` when the abandoned dependency is unavoidable.
- **Verification:** Empirical, on `composer:2` (2.10.2): unset → `Found 1 abandoned package`, exit 1; `config.audit.abandoned: report` → same listing, exit 0.

## Change

`references/ci-security-pipeline.md`: corrected the `--abandoned` option line to its real values, added an "Abandoned packages fail the audit too" subsection with the `composer.json` snippet and the stale-lock consequence.

## Test plan

- [x] `scripts/verify-harness.sh` — Level 3 COMPLETE, 0 errors
- [x] SKILL.md untouched (no word-cap risk)
- [x] Behavior verified against Composer 2.10.2 rather than inferred from docs
