### PR TITLE
docs: indistinguishability defences + verifying scanner coverage claims

### DIFF
--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -26,7 +26,7 @@ Security audit patterns (OWASP Top 10, LLM Top 10 2025, CWE Top 25 2025, CVSS v4
 
 - **Core**: owasp-top10, cwe-top25, xxe-prevention, cvss-scoring, api-key-encryption
 - **Prevention**: deserialization-prevention, path-traversal-prevention, file-upload-security, input-validation, error-message-sanitization
-- **Architecture**: authentication-patterns, security-headers, security-logging, cryptography-guide, security-invariants
+- **Architecture**: authentication-patterns, security-headers, security-logging, cryptography-guide, security-invariants, indistinguishability-defences
 - **Language features** (`*-security-features`): php, python, javascript-typescript, nodejs, go
 - **Frameworks** (`*-security`): typo3, typo3-fluid, typo3-typoscript, symfony, react, vue
 - **Cloud & IaC**: aws-security, iac-security

--- a/skills/security-audit/references/automated-scanning.md
+++ b/skills/security-audit/references/automated-scanning.md
@@ -515,3 +515,43 @@ echo "PASS: No security findings"
 echo ""
 echo "All security checks passed."
 ```
+
+---
+
+## Read the Scanner's Coverage Claim Before Reading Its Findings
+
+Every scoped scanner reports two things: what it *found*, and what it *looked
+at*. The second one is the load-bearing half of a clean result, and it is the
+one nobody reads. "No findings" means "clean" only if the scanner examined what
+you think it examined.
+
+Scoping goes wrong quietly:
+
+- **A tool resolving paths against the wrong working tree.** In a bare-repo /
+  worktree layout (`.bare/`, `main/`, several short-lived feature worktrees), a
+  scan of a 22-file range reported its target as "adds only the `.gitattributes`
+  file" — a file that was not in the range at all, but *was* the entire diff of a
+  sibling worktree. Its component list named one file; the range had 22.
+- **A path filter that silently matches nothing** — a renamed directory, a typo
+  in an `include:` glob, an `--exclude` that swallows the target.
+- **A cap that truncates** — max files, max findings, per-rule limits — dropping
+  the tail of the target without failing.
+- **An expired or missing upload** in the reporting backend, so the *metric* is
+  computed from a subset while the run itself was complete.
+
+Before acting on a low count, diff the claim against the target:
+
+```bash
+# What the scan says it covered vs. what the range actually contains
+git diff --numstat <base>..<head> | wc -l      # real file count
+# then compare against the tool's own coverage/inventory output
+```
+
+**A non-empty result does not prove the scoping was right.** In the case above
+the researchers did read real code and did report a genuine defect — while the
+inventory was still wrong, so nothing could be concluded about the other 21
+files. Findings validate themselves; they never validate coverage.
+
+When the coverage claim and the target disagree, say so in the report rather
+than passing the finding count on unqualified. "Partial review of the range" and
+"clean" are different results, and only one of them is safe to act on.

--- a/skills/security-audit/references/indistinguishability-defences.md
+++ b/skills/security-audit/references/indistinguishability-defences.md
@@ -1,0 +1,95 @@
+# Indistinguishability Defences (Decoys, Dummy Responses, Constant-Time Paths)
+
+When an endpoint must not reveal whether a subject exists — a username, an
+account, a tenant, a licence key — the usual defence is to answer the unknown
+case with something that *looks like* the known case: dummy credentials, a decoy
+record, a synthetic delay. The defence only works if an observer cannot
+distinguish the two. Getting that wrong is subtle, and the failure is silent:
+the code looks defensive, the tests pass, and the oracle is still open.
+
+Three rules, each of which has been violated in a shipped fix.
+
+## 1. Never derive a published value from material that also selected its shape
+
+If the response's observable properties (length, count, flags, transports) are
+chosen from bytes that are *themselves published*, the observer can recompute the
+selection and check it.
+
+```php
+// VULNERABLE: $material[0] picks the length, and $material's head IS the id
+$material    = hash_hmac('sha256', $subject . '|' . $i, $key, true);
+$length      = LENGTHS[ord($material[0]) % count(LENGTHS)];
+$transports  = SETS[ord($material[1]) % count(SETS)];
+$id          = substr($material, 0, $length);   // publishes bytes 0 and 1
+```
+
+An unauthenticated caller now tests `strlen($id) === LENGTHS[ord($id[0]) % n]`
+and `$transports === SETS[ord($id[1]) % m]`. Both hold for **every** decoy and
+for a genuine record only by coincidence — and never when the real value's shape
+falls outside the hardcoded sets. The test is one-sided, so **any response that
+fails it is certainly real**. One request classifies the subject.
+
+```php
+// FIXED: independent derivations under distinct labels
+$selectors = hash_hmac('sha256', $subject . '|' . $i . '|selectors', $key, true);
+$id        = deriveId($key, $subject . '|' . $i . '|id', $length);
+```
+
+Note the constants being private buys nothing: in open-source or any shipped
+client they are readable, and the attacker only needs the relation.
+
+## 2. Never stretch a published value by hashing its own published prefix
+
+The same defect one level down, and it appears precisely when fixing rule 1 —
+the output must be longer than one hash block, so the obvious stretch is to
+append a hash of what you already have:
+
+```php
+// VULNERABLE: the head is published, so the tail is computable from it
+$id = $material;
+while (strlen($id) < $length) {
+    $id .= hash('sha256', $material . '|' . ++$block, true);
+}
+// attacker: substr($id, 32) === hash('sha256', substr($id, 0, 32) . '|1', true)
+```
+
+Every long decoy satisfies that; no real value does. Derive **every block** from
+the key instead, so no published byte predicts another:
+
+```php
+while (strlen($id) < $length) {
+    $id .= hash_hmac('sha256', $label . '|' . $block++, $key, true);
+}
+```
+
+## 3. Verify from the response alone, against the unfixed code first
+
+A test for this class must compute **only from what the endpoint returns** — that
+is the attacker's position. Two failure modes to avoid:
+
+- **Restating the constants in the test.** A hardcoded copy stops matching the
+  implementation the moment either changes, and the test then passes vacuously.
+  Read them from the implementation (reflection, an exported test hook), which is
+  also the faithful attacker model since they are public.
+- **Trusting a green result.** Run the test against the **unfixed** code and
+  watch it fail before you keep it. A test written after the fix, never run
+  against the defect, proves nothing about the defect.
+
+Report the measurement, not the intent: *"47 of 47 decoys satisfied the
+attacker's relation before, none beyond chance after"* is a result;
+*"decoys are now indistinguishable"* is a claim.
+
+## Related shapes
+
+The same reasoning applies beyond decoy records:
+
+| Defence | The tell to check |
+|---|---|
+| Dummy password verification for unknown users | Is the fake hash the same cost/algorithm as a real one? |
+| Constant-time comparison | Does an early length check leak before the comparison runs? |
+| Padded response timing | Is the pad applied to **both** branches, to a fixed budget — not added to one? |
+| Generic error messages | Do status code, body length, and headers match across branches? |
+| Decoy record counts | Can the count be zero for one branch only? An empty list no unknown subject can produce is itself the oracle. |
+
+The unifying question: *enumerate everything the observer receives — bytes,
+count, timing, status, headers — and ask which of them the branch decided.*


### PR DESCRIPTION
Two learnings from a `/retro` over a TYPO3 WebAuthn session, both earned by getting them wrong first.

## 1. `references/indistinguishability-defences.md` (new)

Decoy records, dummy responses and padded timing only work if an observer cannot tell the branches apart. Nothing in the skill covered how that breaks — and it broke twice in a row in a shipped fix, the second time *inside the fix for the first*.

**Rule 1 — never derive a published value from material that also selected its shape.** Choosing an id length from `$material[0]` and then publishing `substr($material, 0, $length)` lets any caller recompute `strlen($id) === LENGTHS[ord($id[0]) % n]`. It holds for every decoy and for a real record only by chance, so the test is one-sided: **a response that fails it is certainly real**. Measured: 47 of 47 decoys self-identifying.

**Rule 2 — never stretch a published value by hashing its own published prefix.** This surfaces precisely while fixing rule 1, because the output must exceed one hash block. `$material . sha256($material . '|1')` leaves the tail computable from the head the caller already holds. Measured: 15 of 15 long ids.

**Rule 3 — verify from the response alone, against the unfixed code first.** Two ways the test lies: restating the constants (the copy stops matching the implementation and the test passes vacuously — this happened), and never running it against the defect at all.

Closes with a table applying the same reasoning to dummy password verification, constant-time comparison, padded timing, generic errors and decoy counts, and the unifying question: enumerate everything the observer receives, and ask which of it the branch decided.

Indexed under **Architecture** in `SKILL.md`.

## 2. `references/automated-scanning.md` — read the coverage claim

A scoped scanner reports what it found *and* what it looked at; only the second makes "no findings" mean "clean".

In a bare-repo/worktree layout, a scan of a 22-file range reported its target as "adds only the `.gitattributes` file" — absent from that range, but the whole diff of a sibling worktree. It still surfaced a genuine defect, which is the trap: **findings validate themselves, never coverage**. Nothing could be concluded about the other 21 files.

Adds the quiet scoping failures (wrong working tree, path filter matching nothing, truncating caps, expired uploads feeding the metric), the diff to run before trusting a low count, and the ask to report a mismatch as a partial review rather than pass it on as clean.

---

`scripts/verify-harness.sh`: Level 3 COMPLETE, 0 errors, 0 warnings. Both commits signed and DCO signed-off.
