### PR TITLE
docs(scanning): document two gitleaks allowlist pitfalls

### DIFF
--- a/skills/security-audit/references/automated-scanning.md
+++ b/skills/security-audit/references/automated-scanning.md
@@ -281,13 +281,20 @@ useDefault = true
 
 ### Two traps when writing an allowlist
 
-**1. `[[allowlists]]` (plural) replaces the built-in allowlists.** The singular
-`[allowlist]` table above merges with the defaults that `[extend] useDefault`
-pulls in. The plural array-of-tables form overrides them, so every false
-positive the default config used to suppress comes back. Observed on a real
-repo: a config that added two path entries took the finding count from **2 to
-110**, because the default allowlists disappeared. Use the singular `[allowlist]`
-unless you deliberately want to replace the defaults.
+**1. The repo may already ship a tuned config — do not measure against your
+own.** Before concluding anything about an allowlist's effect, check for an
+existing `.gitleaks.toml` / `.betterleaks.toml` at the repo root. Overwriting a
+config that already names the exact fixture files with a generic one makes the
+finding count jump, and the jump looks like the new config *caused* findings
+rather than that it *stopped suppressing* known ones. Measured on a real repo:
+119 findings with no config, 2 with the repo's own tuned config, 110 with a
+generic two-path config dropped on top — the 2 → 110 move was the tuned config
+being replaced, not a syntax effect.
+
+For the same reason, test config changes on a copy of the tree **outside any
+repo**: gitleaks auto-discovers `(target)/.gitleaks.toml` (betterleaks also
+`.betterleaks.toml`) and walks up the tree, so a "with vs without" comparison
+run inside a clone silently picks up a config you did not intend to include.
 
 **2. The scan covers git history, so deleting the file does not clear the
 finding.** `gitleaks git` / `betterleaks git` walk every commit. A secret
@@ -309,14 +316,12 @@ and confirming it is still reported:
 ```bash
 # Control probe — must still report a finding.
 printf 'const T = "ghp_%s";\n' "$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 36)" \
-  > src/probe.tmp
-gitleaks dir --redact . ; rm src/probe.tmp
+  > ./probe.tmp
+gitleaks dir --redact .
+status=$?
+rm -f ./probe.tmp
+exit $status   # preserve the scan's exit code; rm must not mask it
 ```
-
-Test config changes in a copy of the tree **outside any repo**: gitleaks
-auto-discovers `(target)/.gitleaks.toml` (betterleaks also `.betterleaks.toml`),
-so a "with vs without" comparison run inside the clone silently picks up the
-repo's own committed config and measures the wrong pair.
 
 ### Pre-commit Hook Setup
 

--- a/skills/security-audit/references/automated-scanning.md
+++ b/skills/security-audit/references/automated-scanning.md
@@ -279,6 +279,45 @@ useDefault = true
   keywords = ["NR-"]
 ```
 
+### Two traps when writing an allowlist
+
+**1. `[[allowlists]]` (plural) replaces the built-in allowlists.** The singular
+`[allowlist]` table above merges with the defaults that `[extend] useDefault`
+pulls in. The plural array-of-tables form overrides them, so every false
+positive the default config used to suppress comes back. Observed on a real
+repo: a config that added two path entries took the finding count from **2 to
+110**, because the default allowlists disappeared. Use the singular `[allowlist]`
+unless you deliberately want to replace the defaults.
+
+**2. The scan covers git history, so deleting the file does not clear the
+finding.** `gitleaks git` / `betterleaks git` walk every commit. A secret
+committed once stays reported after it is deleted or the file is moved, and the
+alert cites the **historical** path at the **old** commit. Consequences:
+
+- A path allowlist must match where the file *was*, not only where it is now —
+  e.g. `'''^Tests/(Unit|Functional)/Service/Tool/AgentStateCodecTest\.php'''`
+  for a fixture that moved between the two directories.
+- "Just delete the file" is not a fix. The real choices are an allowlist entry
+  or history rewriting; for synthetic fixtures and local dev material, rewriting
+  public history is disproportionate.
+
+**Prefer concrete paths over value regexes.** A repo-wide regex on the secret
+shape masks a genuine leak of the same shape elsewhere. Verify the allowlist is
+still sharp by planting a fresh synthetic secret outside the allowlisted paths
+and confirming it is still reported:
+
+```bash
+# Control probe — must still report a finding.
+printf 'const T = "ghp_%s";\n' "$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 36)" \
+  > src/probe.tmp
+gitleaks dir --redact . ; rm src/probe.tmp
+```
+
+Test config changes in a copy of the tree **outside any repo**: gitleaks
+auto-discovers `(target)/.gitleaks.toml` (betterleaks also `.betterleaks.toml`),
+so a "with vs without" comparison run inside the clone silently picks up the
+repo's own committed config and measures the wrong pair.
+
 ### Pre-commit Hook Setup
 
 ```bash


### PR DESCRIPTION
## Friction

Two behaviours cost real time during an org-wide secret-scanning rollout, and
neither was documented.

**A repo may already ship a tuned config.** Measuring an allowlist's effect
without checking for an existing `.gitleaks.toml` produces a number that looks
like the new config caused findings, when it actually stopped suppressing known
ones. Measured on a real repo: 119 findings with no config, **2** with the
repo's own tuned config naming the exact fixture files, **110** with a generic
two-path config dropped on top. Related: gitleaks auto-discovers
`(target)/.gitleaks.toml` and walks up the tree, so a "with vs without"
comparison run inside a clone silently includes a config you did not intend.

**The scan walks git history.** A finding survives deleting or moving the file
and cites the *historical* path at the *old* commit. Two of three findings in
that rollout pointed at files no longer present in the tree, so "delete the
file" would have changed nothing. A path allowlist has to match the old
location too.

## Change

Adds a "Two traps when writing an allowlist" subsection covering both, plus a
control probe (plant a fresh synthetic secret outside the allowlisted paths,
confirm it is still reported) so an allowlist can be shown to be still sharp.

Documentation only; no rule or workflow changes.

## Review correction

The first version of this PR claimed that a top-level `[[allowlists]]` replaces
the built-in allowlists while singular `[allowlist]` merges with them. Copilot
challenged it and was right — I tested betterleaks 1.1.2 against a fixture with
one secret inside and one outside the allowlisted path:

| config | findings |
|---|---|
| none | 2 |
| `[extend] useDefault` only | 2 |
| `[allowlist]` (singular) | 1 |
| `[[allowlists]]` (plural) | 1 |

Identical, so no such mechanism exists. The false trap was removed in 50c2fdb
and replaced with the tuned-config lesson above, which is what the 2 → 110
measurement actually showed.

Came from /retro: yes
