### PR TITLE
chore(renovate): enable the pre-commit manager, pin validator at v1.36.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         args: [--allow-multiple-documents]
 
   - repo: https://github.com/netresearch/skill-repo-skill
-    rev: v1.22.0
+    rev: v1.36.0
     hooks:
       - id: validate-skill
       - id: check-version-parity

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "pre-commit": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
Part of [skill-repo-skill#252](https://github.com/netresearch/skill-repo-skill/issues/252) — fleet sweep.

The `.pre-commit-config.yaml` header promises that Renovate bumps the pinned hook revs automatically, but Renovate's `pre-commit` manager is opt-in and was never enabled — a fleet survey found 27 of 29 consumer repos on stale pins (mostly v1.22.0, whose validator still enforces the withdrawn 500-word SKILL.md cap that CI, validating against `main`, dropped long ago; two repos were bitten by exactly that on 2026-08-26). This enables the manager so the promise becomes true, and pins the skill-repo-skill hooks at v1.36.0 to match what CI enforces today. Repos without a `renovate.json` get the fleet-standard one with the manager enabled.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_01C7S9rbgu5giqCwnzwafrHA)_